### PR TITLE
Added check to test for intvalue in the port parameter

### DIFF
--- a/src/RateLimitStorage/DatabaseRateLimitStorage.php
+++ b/src/RateLimitStorage/DatabaseRateLimitStorage.php
@@ -29,8 +29,8 @@ class DatabaseRateLimitStorage extends AbstractRateLimitStorage
      */
     public function __construct(array $config = [])
     {
-        if (isset($config['connection']['port'])) {
-            $config['connection']['port'] = (int) $config['connection']['port'];
+        if (isset($config['connection']['port']) && is_numeric($config['connection']['port'])) {
+            $config['connection']['port'] = intval($config['connection']['port']);
         }
 
         parent::__construct($config);

--- a/src/RateLimitStorage/DatabaseRateLimitStorage.php
+++ b/src/RateLimitStorage/DatabaseRateLimitStorage.php
@@ -29,6 +29,10 @@ class DatabaseRateLimitStorage extends AbstractRateLimitStorage
      */
     public function __construct(array $config = [])
     {
+        if (isset($config['connection']['port'])) {
+            $config['connection']['port'] = (int) $config['connection']['port'];
+        }
+
         parent::__construct($config);
         $this->config['storage_table'] ??= 'firewall_rate_limit_storage';
 

--- a/src/RateLimitStorage/DatabaseRateLimitStorage.php
+++ b/src/RateLimitStorage/DatabaseRateLimitStorage.php
@@ -29,7 +29,7 @@ class DatabaseRateLimitStorage extends AbstractRateLimitStorage
      */
     public function __construct(array $config = [])
     {
-        if (isset($config['connection']['port']) && is_numeric($config['connection']['port'])) {
+        if (is_array($config['connection']) && isset($config['connection']['port']) && is_numeric($config['connection']['port'])) {
             $config['connection']['port'] = intval($config['connection']['port']);
         }
 

--- a/src/RateLimitStorage/RedisRateLimitStorage.php
+++ b/src/RateLimitStorage/RedisRateLimitStorage.php
@@ -33,6 +33,10 @@ class RedisRateLimitStorage extends AbstractRateLimitStorage
      */
     public function __construct(array $config = [])
     {
+        if (isset($config['redis']['port'])) {
+            $config['redis']['port'] = (int) $config['redis']['port'];
+        }
+
         parent::__construct($config);
 
         try {

--- a/src/RateLimitStorage/RedisRateLimitStorage.php
+++ b/src/RateLimitStorage/RedisRateLimitStorage.php
@@ -33,8 +33,8 @@ class RedisRateLimitStorage extends AbstractRateLimitStorage
      */
     public function __construct(array $config = [])
     {
-        if (isset($config['redis']['port'])) {
-            $config['redis']['port'] = (int) $config['redis']['port'];
+        if (isset($config['redis']['port']) && is_numeric($config['redis']['port'])) {
+            $config['redis']['port'] = intval($config['redis']['port']);
         }
 
         parent::__construct($config);

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -30,7 +30,7 @@ class DatabaseStorage extends AbstractStorageBase
      */
     public function __construct(array $config)
     {
-        if (isset($config['connection']['port']) && is_numeric($config['connection']['port'])) {
+        if (is_array($config['connection']) && isset($config['connection']['port']) && is_numeric($config['connection']['port'])) {
             $config['connection']['port'] = intval($config['connection']['port']);
         }
 

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -30,6 +30,10 @@ class DatabaseStorage extends AbstractStorageBase
      */
     public function __construct(array $config)
     {
+        if (isset($config['connection']['port'])) {
+            $config['connection']['port'] = (int) $config['connection']['port'];
+        }
+
         parent::__construct($config);
         $this->config['storage_table'] ??= 'firewall_storage';
         $this->config['offenses_table'] ??= 'firewall_offenses';

--- a/src/Storage/DatabaseStorage.php
+++ b/src/Storage/DatabaseStorage.php
@@ -30,8 +30,8 @@ class DatabaseStorage extends AbstractStorageBase
      */
     public function __construct(array $config)
     {
-        if (isset($config['connection']['port'])) {
-            $config['connection']['port'] = (int) $config['connection']['port'];
+        if (isset($config['connection']['port']) && is_numeric($config['connection']['port'])) {
+            $config['connection']['port'] = intval($config['connection']['port']);
         }
 
         parent::__construct($config);


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does -->
When Port is provided as a string (even if a number casted as a string) the remote connection throws and error as some require an integer. The application should cast the port as a string just to take any possible issues out of the equation.

## Related Issue

<!-- Link to the issue this PR addresses. Use "Fixes #123" to auto-close the issue when merged -->
Fixes #27 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Security fix

## Changes Made

<!-- List the specific changes made in this PR -->

- Added a conditional check where a port is potentially being used and casting it as an integer.

## Testing

### How to Test

<!-- Provide detailed steps to test your changes -->

1.  Follow the steps of a test drive found in the readme
2. When connecting to a databsae or a redis storage system use a string `"3606"` instead of an integer.
3. Confirm connection with no issues.

### Test Configuration

<!-- Provide example configuration for testing these changes -->

N/A

## Checklist

<!-- Mark completed items with an "x" -->

### Code Quality

- [x] My code follows the project's code style (`composer cs` passes)
- [x] Static analysis passes (`composer stan` passes)
- [ ] I have added appropriate code comments explaining complex logic
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have added integration tests if necessary
- [x] New and existing tests pass locally (`composer test` passes)
- [ ] I have achieved 100% test coverage for new code
- [x] I have tested edge cases and error conditions

### Security Considerations

- [ ] I have considered the security implications of my changes
- [ ] Input validation is properly implemented
- [ ] No sensitive information is logged or exposed
- [ ] Rate limiting is considered for new endpoints/features
- [ ] Changes don't introduce new attack vectors

### Documentation

- [ ] I have updated the README.md if needed
- [ ] I have added/updated configuration examples
- [ ] I have documented any new plugin variables or options
- [ ] I have updated inline documentation/comments

### Plugin Development (if applicable)

- [ ] Plugin follows the existing plugin pattern
- [ ] Plugin implements all required interface methods
- [ ] Plugin has appropriate metadata configuration
- [ ] Plugin properly uses logging
- [ ] Plugin returns appropriate status codes

## Breaking Changes

<!-- If this PR introduces breaking changes, describe them here -->

- [ ] This PR introduces breaking changes

<!-- If yes, describe:
- What breaks
- Why it's necessary
- Migration path for users
-->

## Performance Impact

<!-- Describe any performance implications -->

- [ ] This change has performance implications

<!-- If yes, describe:
- Nature of performance impact
- Benchmarking results (if applicable)
- Mitigation strategies
-->

## Screenshots/Examples

N/A

<!-- If applicable, add screenshots or examples to help explain your changes -->

## Additional Context

N/A

<!-- Add any other context, implementation notes, or design decisions -->

## Reviewer Notes

<!-- Any specific areas you'd like reviewers to focus on -->

N/A

---

<!-- 
Remember to:
- Keep PRs focused on a single issue/feature
- Update your branch with the latest from 2.x before submitting
- Be responsive to feedback
- Be patient - reviews may take time
-->