### PR TITLE
New Plugin Implementation

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,7 @@
 global: ~
 storage: ~
+plugins: []
+# Legacy format (deprecated, auto-converted to plugins:)
 bypass: ~
 block: ~
 logger: ~

--- a/example/README.md
+++ b/example/README.md
@@ -90,7 +90,23 @@ This tells the firewall to use the IP from `X-Forwarded-For` instead of the dire
 
 ### Testing IP-Based Blocking
 
-Create or modify `example/config.yml`:
+Create or modify `example/config.yml`.
+
+**New Format (Recommended):**
+
+```yaml
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: block
+    weight: 0
+    enable: true
+    config:
+      - '192.168.1.0/24'      # Block entire subnet
+      - '10.0.0.1'            # Block specific IP
+      - '8.8.8.0-8.8.8.255'   # Block IP range
+```
+
+**Legacy Format:**
 
 ```yaml
 block:
@@ -161,6 +177,37 @@ The GeoLocation and ASN plugins require MaxMind GeoIP2 databases. You have two o
 4. **Configure the firewall to use the databases**:
 
    In your `config.yml`:
+
+   **New Format (Recommended):**
+   ```yaml
+   plugins:
+     - plugin: "Kanopi\\Firewall\\Plugins\\GeoLocation"
+       response: block
+       weight: 0
+       enable: true
+       metadata:
+         reader:
+           type: reader
+           db: /usr/local/share/GeoIP/GeoLite2-City.mmdb
+       config:
+         - country:CN    # Block China
+         - country:RU    # Block Russia
+         - '!country:US' # Block everything except US
+
+     - plugin: "Kanopi\\Firewall\\Plugins\\Asn"
+       response: block
+       weight: 0
+       enable: true
+       metadata:
+         reader:
+           type: reader
+           db: /usr/local/share/GeoIP/GeoLite2-ASN.mmdb
+       config:
+         - asn:AS15169        # Block Google's ASN
+         - asn_org@contains:amazon  # Block Amazon ASNs
+   ```
+
+   **Legacy Format:**
    ```yaml
    block:
      Kanopi\Firewall\Plugins\GeoLocation:
@@ -319,6 +366,30 @@ done
 ```
 
 ### Example 4: Bypass Trusted IPs
+
+**New Format (Recommended):**
+
+```yaml
+plugins:
+  # Allow trusted IPs first (lower weight = runs first)
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: allow
+    weight: -100
+    enable: true
+    config:
+      - '127.0.0.1'
+      - '192.168.0.0/16'
+
+  # Then apply blocking rules
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: block
+    weight: 0
+    enable: true
+    config:
+      - '10.0.0.0/8'
+```
+
+**Legacy Format:**
 
 ```yaml
 bypass:

--- a/example/config.yml
+++ b/example/config.yml
@@ -13,6 +13,9 @@ configs:
   - "{presets_dir}/wordpress.yml"
   - "{presets_dir}/malicious-urls.yml"
 
+global:
+  mode: exception
+
 # =====================================================================
 # Storage Configuration
 # =====================================================================
@@ -23,12 +26,32 @@ storage:
       dsn: *DB_DSN
 
 # =====================================================================
-# Block Configuration with Plugin-Specific Config Includes
+# Plugin Configuration (Preferred Format)
+#
+# The plugins: array is the canonical format. Each plugin specifies:
+#   - plugin: The fully qualified class name
+#   - response: 'allow' (bypass) or 'block'
+#   - weight: Execution order (lower runs first)
+#   - enable: Whether the plugin is active
+#   - metadata: Plugin-specific configuration
+#   - config: Rules or conditions
+#
+# Evaluation order: All 'allow' plugins run first (sorted by weight),
+# then all 'block' plugins (sorted by weight).
 # =====================================================================
-block:
+plugins:
+  # Bypass trusted IPs (response: allow)
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: allow
+    weight: -200
+    enable: true
+    config:
+      - 203.0.113.100/32
+
   # IP Address blocking with external config file
-  Kanopi\Firewall\Plugins\IpAddress:
-    priority: -100
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: block
+    weight: -100
     enable: true
     metadata:
       # This plugin loads its config from an external file
@@ -37,11 +60,12 @@ block:
         - config.ip.yml
         # Remote URL example (uncomment if you have a remote config):
         # - https://example.com/firewall/blocked-ips.yml
-    config: ~ # Plugin config comes from the files above
+    config: [] # Plugin config comes from the files above
 
   # Vulnerability Score with external config
-  Kanopi\Firewall\Plugins\VulnerabilityScore:
-    priority: -75
+  - plugin: "Kanopi\\Firewall\\Plugins\\VulnerabilityScore"
+    response: block
+    weight: -75
     enable: true
     metadata:
       config:
@@ -54,43 +78,104 @@ block:
       asn_reader:
         type: reader
         db: GeoLite2-ASN.mmdb
-    config: ~
+    config: []
 
-  # URL plugin with inline config (merges with preset rules)
-  Kanopi\Firewall\Plugins\Url:
-    priority: -10
+  # URL plugin with inline config
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: block
+    weight: -10
     enable: true
     config:
-      # These rules will REPLACE the preset rules because config is a list
-      # If you want to ADD to preset rules, use bypass or separate plugin instance
       - path:/custom-blocked-path
       - query@contains:malicious-param
 
-  Kanopi\Firewall\Plugins\RateLimit:
-    priority: 0
+  # Rate limiting
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 0
     enable: true
     metadata:
       storage:
-        type: Kanopi\Firewall\RateLimitStorage\RedisRateLimitStorage
+        type: "Kanopi\\Firewall\\RateLimitStorage\\RedisRateLimitStorage"
         config:
           redis:
             host: "%env(safe:redis:string:CACHE_HOST)%"
             port: "%env(safe:6379:int:CACHE_PORT)%"
-#            auth: "%env(safe::string:CACHE_PASSWORD)%"
+            # auth: "%env(safe::string:CACHE_PASSWORD)%"
     config:
       - path: /login
         rate: 20      # 20 instead of default 10
         sample: 300
 
 # =====================================================================
-# Bypass Configuration
+# Block Configuration with Plugin-Specific Config Includes (Legacy Format)
 # =====================================================================
-bypass:
-  Kanopi\Firewall\Plugins\IpAddress:
-    priority: -200
-    enable: true
-    config:
-      - 203.0.113.100/32
+#block:
+#  # IP Address blocking with external config file
+#  Kanopi\Firewall\Plugins\IpAddress:
+#    priority: -100
+#    enable: true
+#    metadata:
+#      # This plugin loads its config from an external file
+#      # The file can be local or a remote URL
+#      config:
+#        - config.ip.yml
+#        # Remote URL example (uncomment if you have a remote config):
+#        # - https://example.com/firewall/blocked-ips.yml
+#    config: ~ # Plugin config comes from the files above
+#
+#  # Vulnerability Score with external config
+#  Kanopi\Firewall\Plugins\VulnerabilityScore:
+#    priority: -75
+#    enable: true
+#    metadata:
+#      config:
+#        - config.vulnerability-score.yml
+#      default_expiration_time: 3600
+#      status_code: 403
+#      country_reader:
+#        type: reader
+#        db: GeoLite2-Country.mmdb
+#      asn_reader:
+#        type: reader
+#        db: GeoLite2-ASN.mmdb
+#    config: ~
+#
+#  # URL plugin with inline config (merges with preset rules)
+#  Kanopi\Firewall\Plugins\Url:
+#    priority: -10
+#    enable: true
+#    config:
+#      # These rules will REPLACE the preset rules because config is a list
+#      # If you want to ADD to preset rules, use bypass or separate plugin instance
+#      - path:/custom-blocked-path
+#      - query@contains:malicious-param
+#
+#  Kanopi\Firewall\Plugins\RateLimit:
+#    priority: 0
+#    enable: true
+#    metadata:
+#      storage:
+#        type: Kanopi\Firewall\RateLimitStorage\RedisRateLimitStorage
+#        config:
+#          redis:
+#            host: "%env(safe:redis:string:CACHE_HOST)%"
+#            port: "%env(safe:6379:int:CACHE_PORT)%"
+#            #auth: "%env(safe::string:CACHE_PASSWORD)%"
+#    config:
+#      - path: /login
+#        rate: 20      # 20 instead of default 10
+#        sample: 300
+
+# =====================================================================
+# Bypass Configuration (Legacy Format)
+# =====================================================================
+#bypass:
+#  Kanopi\Firewall\Plugins\IpAddress:
+#    priority: -200
+#    enable: true
+#    config:
+#      - 203.0.113.100/32
 
 # =====================================================================
 # How Merging Works
@@ -100,21 +185,24 @@ bypass:
 #    - presets/wordpress.yml (contains Url plugin with block rules)
 #    - presets/malicious-urls.yml (contains Url plugin with more block rules)
 #
-# 2. Each preset's Url plugin config (a list) REPLACES the previous one
-#    (because lists are replaced, not merged)
+# 2. For the new plugins: array format:
+#    - Plugins arrays are APPENDED (not replaced) when merging configs
+#    - This allows multiple config files to each add plugins
 #
-# 3. This file's Url plugin config REPLACES all preset configs
+# 3. For legacy block:/bypass: format:
+#    - Plugin config lists are REPLACED by later files
+#    - Objects (associative arrays) are merged deeply
 #
 # 4. Plugin metadata.config files are loaded by the plugin itself
 #    (not by ConfigLoader), so they work differently
 #
-# To ADD rules instead of REPLACE:
-#   - Use bypass rules
-#   - Create separate plugin instances with different priorities
+# To ADD rules instead of REPLACE (legacy format):
+#   - Use multiple config files with plugins: array format (recommended)
+#   - Create separate plugin instances with different weights
 #   - Or combine all rules in a single config file
 
 logger:
   - class: "\\Monolog\\Handler\\StreamHandler"
     args:
       - "logs/firewall.log"
-      - "Monolog\\Level::INFO"
+      - "Monolog\\Level::Debug"

--- a/example/index.php
+++ b/example/index.php
@@ -1,10 +1,14 @@
 <?php
 
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+
 require_once __DIR__ . '/../vendor/autoload.php';
 
-// Put in test mode so throws an exception.
-putenv('FIREWALL_TEST=1');
-
+/**
+ * Print the headers to the screen.
+ */
 function print_headers()
 {
     global $start, $mem_start, $end, $mem_end;
@@ -12,10 +16,10 @@ function print_headers()
     $headers = [
         'start' => $start,
         'end' => $end,
-        'time' => $end - $start,
+        'time' => ($end - $start),
         'memory_start' => $mem_start,
         'memory_end' => $mem_end,
-        'memory' => $mem_end - $mem_start,
+        'memory' => ($mem_end - $mem_start),
     ];
 
     foreach ($headers as $header => $value) {
@@ -23,9 +27,14 @@ function print_headers()
     }
 }
 
-// Start
+// Start Recording.
 $start = microtime(true);
 $mem_start = memory_get_usage(true);
+
+// Test Handler used for getting log records.
+$testHandler = new TestHandler();
+$testHandler->setLevel(\Monolog\Level::Info);
+$formatter = new \Monolog\Formatter\LineFormatter();
 
 $status = 200;
 // Check to see if class loads.
@@ -39,11 +48,16 @@ if (class_exists('\Kanopi\Firewall\Firewall')) {
                 \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_FOR
             );
         }
-        \Kanopi\Firewall\Firewall::create(
+
+        // Evaluate the request.
+        \Kanopi\Firewall\Firewall::create([
+            __DIR__ . '/config.yml',
             [
-                __DIR__ . '/config.yml'
+                'logger' => [
+                    ['class' => $testHandler],
+                ],
             ]
-        )->evaluate();
+        ])->evaluate();
 
         ob_start();
         echo "<pre>";
@@ -59,6 +73,13 @@ if (class_exists('\Kanopi\Firewall\Firewall')) {
         $mem_end = memory_get_usage(true);
         http_response_code($status);
         print_headers();
+
+        $content .= "<br/><h2>Logs</h2>";
+        $content .= "<pre>";
+        foreach ($testHandler->getRecords() as $record) {
+            $content .= htmlspecialchars($formatter->format($record));
+        }
+        $content .= "</pre>";
     }
 
     echo $content;

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -19,6 +19,7 @@ use Kanopi\Firewall\Plugins\PluginManager;
 use Kanopi\Firewall\Storage\StorageFactory;
 use Kanopi\Firewall\Storage\StorageInterface;
 use Kanopi\Firewall\Utility\Config;
+use Kanopi\Firewall\Utility\PluginConfigNormalizer;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -91,24 +92,28 @@ final class Firewall
         // Set the default values.
         $config['logger'] = isset($config['logger']) && is_array($config['logger']) ? array_filter($config['logger']) : [];
         $config['storage'] = isset($config['storage']) && is_array($config['storage']) ? array_filter($config['storage']) : [];
-        $config['block'] = isset($config['block']) && is_array($config['block']) ? array_filter($config['block']) : [];
-        $config['bypass'] = isset($config['bypass']) && is_array($config['bypass']) ? array_filter($config['bypass']) : [];
         $config['global'] = isset($config['global']) && is_array($config['global']) ? array_filter($config['global']) : [];
 
         LoggingFactory::setLogger(LoggingFactory::create($config['logger']));
 
+        // Normalize configuration to the new plugins: array format.
+        $config = PluginConfigNormalizer::normalize($config);
+
+        // Partition plugins by response type and sort by weight.
+        $partitioned = PluginConfigNormalizer::partitionAndSort($config['plugins'] ?? []);
+
         $firewall = new self(
             StorageFactory::create($config['storage']),
-            PluginManager::create($config['block']),
-            PluginManager::create($config['bypass']),
+            PluginManager::createFromPluginsArray($partitioned['block']),
+            PluginManager::createFromPluginsArray($partitioned['allow']),
             $config['global']
         );
 
         $firewall->getLogger()->debug('Firewall initialized', [
             'logger_config_keys' => array_keys($config['logger']),
             'storage_config_keys' => array_keys($config['storage']),
-            'block_plugins' => array_keys($config['block']),
-            'bypass_plugins' => array_keys($config['bypass']),
+            'allow_plugins_count' => count($partitioned['allow']),
+            'block_plugins_count' => count($partitioned['block']),
             'global_config_keys' => array_keys($config['global']),
         ]);
 

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -102,6 +102,14 @@ final class Firewall
         // Partition plugins by response type and sort by weight.
         $partitioned = PluginConfigNormalizer::partitionAndSort($config['plugins'] ?? []);
 
+        LoggingFactory::logger()->debug('Starting Firewall', [
+            'logger_config_keys' => array_keys($config['logger']),
+            'storage_config_keys' => array_keys($config['storage']),
+            'allow_plugins_count' => count($partitioned['allow']),
+            'block_plugins_count' => count($partitioned['block']),
+            'global_config_keys' => array_keys($config['global']),
+        ]);
+
         $firewall = new self(
             StorageFactory::create($config['storage']),
             PluginManager::createFromPluginsArray($partitioned['block']),
@@ -109,7 +117,7 @@ final class Firewall
             $config['global']
         );
 
-        $firewall->getLogger()->debug('Firewall initialized', [
+        LoggingFactory::logger()->debug('Firewall initialized', [
             'logger_config_keys' => array_keys($config['logger']),
             'storage_config_keys' => array_keys($config['storage']),
             'allow_plugins_count' => count($partitioned['allow']),

--- a/src/Plugins/PluginManager.php
+++ b/src/Plugins/PluginManager.php
@@ -39,7 +39,7 @@ class PluginManager
      * Initialize the plugins and return the resulting array.
      *
      * @param array $config
-     *   Configuration for the plugins.
+     *   Configuration for the plugins (legacy format keyed by plugin class).
      *
      * @return self
      *   Return a new instance of self.
@@ -92,6 +92,83 @@ class PluginManager
 
         if ($skippedPlugins !== []) {
             $manager->getLogger()->debug('Plugins skipped', [
+                'skipped_plugins' => $skippedPlugins,
+                'skipped_count' => count($skippedPlugins),
+            ]);
+        }
+
+        return $manager;
+    }
+
+    /**
+     * Create a plugin manager from the new plugins array format.
+     *
+     * Each plugin entry should have:
+     *   - plugin: The fully qualified class name
+     *   - weight: Priority/weight for ordering (lower executes first)
+     *   - enable: Whether the plugin is enabled (defaults to true)
+     *   - metadata: Plugin-specific configuration
+     *   - config: Plugin rules/patterns
+     *
+     * @param array<int, array<string, mixed>> $plugins
+     *   Array of plugin definitions in the new format.
+     *
+     * @return self
+     *   A new PluginManager instance.
+     */
+    public static function createFromPluginsArray(array $plugins): self
+    {
+        $lazyObjectRegistry = new LazyObjectRegistry();
+        $enabledPlugins = [];
+        $skippedPlugins = [];
+
+        foreach ($plugins as $index => $pluginDef) {
+            $class = $pluginDef['plugin'] ?? '';
+
+            if ($class === '') {
+                $skippedPlugins[] = ['plugin' => 'index:' . $index, 'reason' => 'missing_plugin_class'];
+                continue;
+            }
+
+            if (!class_exists($class)) {
+                $skippedPlugins[] = ['plugin' => $class, 'reason' => 'class_not_found'];
+                continue;
+            }
+
+            if (!in_array(PluginInterface::class, class_implements($class), true)) {
+                $skippedPlugins[] = ['plugin' => $class, 'reason' => 'invalid_interface'];
+                continue;
+            }
+
+            $weight = $pluginDef['weight'] ?? 0;
+            $weight = is_int($weight) ? $weight : 0;
+
+            // Use class:index as unique ID to support multiple instances of the same plugin
+            $uniqueId = $class . ':' . $index;
+
+            $lazyObjectRegistry->add(
+                $uniqueId,
+                fn(): object => new $class($pluginDef['metadata'] ?? [], $pluginDef['config'] ?? []),
+                $weight
+            );
+
+            $enabledPlugins[] = [
+                'plugin' => $class,
+                'weight' => $weight,
+            ];
+        }
+
+        $manager = new self($lazyObjectRegistry);
+
+        if ($enabledPlugins !== []) {
+            $manager->getLogger()->debug('Plugins loaded from array', [
+                'enabled_plugins' => $enabledPlugins,
+                'enabled_count' => count($enabledPlugins),
+            ]);
+        }
+
+        if ($skippedPlugins !== []) {
+            $manager->getLogger()->debug('Plugins skipped from array', [
                 'skipped_plugins' => $skippedPlugins,
                 'skipped_count' => count($skippedPlugins),
             ]);

--- a/src/Plugins/RateLimit.php
+++ b/src/Plugins/RateLimit.php
@@ -30,6 +30,10 @@ class RateLimit extends AbstractPluginBase
      */
     public function __construct(array $metadata = [], array $config = [])
     {
+        // Set 10 requests as the default.
+        $metadata['default_rate'] = $metadata['default_rate'] ?? 10;
+        // Set 10 seconds as the default sample size.
+        $metadata['default_sample'] = $metadata['default_sample'] ?? 10;
         parent::__construct($metadata, $config);
 
         if (isset($this->metadata['storage'])) {

--- a/src/Plugins/RateLimit.php
+++ b/src/Plugins/RateLimit.php
@@ -31,9 +31,9 @@ class RateLimit extends AbstractPluginBase
     public function __construct(array $metadata = [], array $config = [])
     {
         // Set 10 requests as the default.
-        $metadata['default_rate'] = $metadata['default_rate'] ?? 10;
+        $metadata['default_rate'] ??= 10;
         // Set 10 seconds as the default sample size.
-        $metadata['default_sample'] = $metadata['default_sample'] ?? 10;
+        $metadata['default_sample'] ??= 10;
         parent::__construct($metadata, $config);
 
         if (isset($this->metadata['storage'])) {

--- a/src/Utility/Config.php
+++ b/src/Utility/Config.php
@@ -129,9 +129,14 @@ class Config
 
         $replacementPaths = [
             'storage.config.(storage_file|offense_file)',
+            // Legacy format paths
             '(allow|block).*.metadata.storage.config.file',
             '(allow|block).*.metadata.config.*',
             '(allow|block).*.metadata.(asn_reader|reader|country_reader).db',
+            // New plugins: array format paths
+            'plugins.*.metadata.storage.config.file',
+            'plugins.*.metadata.config.*',
+            'plugins.*.metadata.(asn_reader|reader|country_reader).db',
         ];
 
         if (Path::looksLikeUrl($file)) {

--- a/src/Utility/ConfigLoader.php
+++ b/src/Utility/ConfigLoader.php
@@ -245,6 +245,9 @@ final class ConfigLoader
      * - The 'priority' key is preserved from the base config (not overridden)
      * - The 'config' array is appended (not replaced)
      *
+     * Special handling for plugins: array (new format):
+     * - Entries are APPENDED (not replaced) to support multiple plugin files
+     *
      * @param array<string,mixed> $base
      *   Left-hand/base configuration.
      * @param array<string,mixed> $over
@@ -266,6 +269,17 @@ final class ConfigLoader
             }
 
             if (\is_array($v) && \is_array($base[$k])) {
+                // Special handling for 'plugins' array at root level: append entries
+                if ($k === 'plugins' && $path === []) {
+                    $baseIsList = $base[$k] === [] || \array_keys($base[$k]) === \range(0, \count($base[$k]) - 1);
+                    $overIsList = $v === [] || \array_keys($v) === \range(0, \count($v) - 1);
+
+                    if ($baseIsList && $overIsList) {
+                        $base[$k] = array_merge($base[$k], $v);
+                        continue;
+                    }
+                }
+
                 // Detect plugin configuration: path is [block|bypass][PluginClassName]
                 $isPluginConfig = count($currentPath) === 2
                     && in_array($currentPath[0], ['block', 'bypass'], true)

--- a/src/Utility/PluginConfigNormalizer.php
+++ b/src/Utility/PluginConfigNormalizer.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kanopi\Firewall\Utility;
+
+/**
+ * Normalizes plugin configuration from legacy (block:/bypass:) format to the new plugins: array format.
+ *
+ * The new canonical format is:
+ *
+ * plugins:
+ *   - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+ *     response: allow
+ *     weight: -200
+ *     enable: true
+ *     metadata: []
+ *     config: ["127.0.0.1"]
+ *
+ * The legacy format is:
+ *
+ * bypass:
+ *   Kanopi\Firewall\Plugins\IpAddress:
+ *     priority: -200
+ *     enable: true
+ *     config: ["127.0.0.1"]
+ *
+ * block:
+ *   Kanopi\Firewall\Plugins\IpAddress:
+ *     priority: -100
+ *     config: ["192.168.1.100"]
+ */
+final class PluginConfigNormalizer
+{
+    /**
+     * Normalize configuration to the canonical plugins: array format.
+     *
+     * Converts legacy block: and bypass: sections into the plugins: array format.
+     * If the config already uses plugins:, those entries are preserved.
+     *
+     * @param array<string, mixed> $config
+     *   The configuration array to normalize.
+     *
+     * @return array<string, mixed>
+     *   The normalized configuration with all plugins in the plugins: array.
+     */
+    public static function normalize(array $config): array
+    {
+        $plugins = $config['plugins'] ?? [];
+
+        // Convert legacy bypass: section → response: allow
+        if (isset($config['bypass']) && is_array($config['bypass'])) {
+            foreach ($config['bypass'] as $class => $pluginConfig) {
+                if (!is_array($pluginConfig)) {
+                    continue;
+                }
+
+                $plugins[] = self::convertLegacyPlugin($class, $pluginConfig, 'allow');
+            }
+
+            unset($config['bypass']);
+        }
+
+        // Convert legacy block: section → response: block
+        if (isset($config['block']) && is_array($config['block'])) {
+            foreach ($config['block'] as $class => $pluginConfig) {
+                if (!is_array($pluginConfig)) {
+                    continue;
+                }
+
+                $plugins[] = self::convertLegacyPlugin($class, $pluginConfig, 'block');
+            }
+
+            unset($config['block']);
+        }
+
+        $config['plugins'] = $plugins;
+
+        return $config;
+    }
+
+    /**
+     * Convert a legacy plugin configuration to the new format.
+     *
+     * @param string $class
+     *   The plugin class name.
+     * @param array<string, mixed> $config
+     *   The plugin configuration.
+     * @param string $response
+     *   The response type ('allow' or 'block').
+     *
+     * @return array<string, mixed>
+     *   The converted plugin configuration.
+     */
+    private static function convertLegacyPlugin(string $class, array $config, string $response): array
+    {
+        return [
+            'plugin' => $class,
+            'response' => $response,
+            'weight' => $config['priority'] ?? 0,
+            'enable' => $config['enable'] ?? true,
+            'metadata' => $config['metadata'] ?? [],
+            'config' => $config['config'] ?? [],
+        ];
+    }
+
+    /**
+     * Partition plugins array by response type and sort by weight.
+     *
+     * @param array<int, array<string, mixed>> $plugins
+     *   The plugins array to partition.
+     *
+     * @return array{allow: array<int, array<string, mixed>>, block: array<int, array<string, mixed>>}
+     *   Partitioned plugins: 'allow' plugins and 'block' plugins, each sorted by weight.
+     */
+    public static function partitionAndSort(array $plugins): array
+    {
+        $allowPlugins = [];
+        $blockPlugins = [];
+
+        foreach ($plugins as $plugin) {
+            // Skip disabled plugins
+            if (!($plugin['enable'] ?? true)) {
+                continue;
+            }
+
+            if (($plugin['response'] ?? 'block') === 'allow') {
+                $allowPlugins[] = $plugin;
+            } else {
+                $blockPlugins[] = $plugin;
+            }
+        }
+
+        // Sort each group by weight (lower weights execute first)
+        usort($allowPlugins, static fn(array $a, array $b): int => ($a['weight'] ?? 0) <=> ($b['weight'] ?? 0));
+        usort($blockPlugins, static fn(array $a, array $b): int => ($a['weight'] ?? 0) <=> ($b['weight'] ?? 0));
+
+        return [
+            'allow' => $allowPlugins,
+            'block' => $blockPlugins,
+        ];
+    }
+}

--- a/tests/Unit/FirewallTest.php
+++ b/tests/Unit/FirewallTest.php
@@ -370,4 +370,133 @@ class FirewallTest extends AbstractTestCase
         $result = $method->invoke($firewall, $request, $plugin);
         $this->assertTrue($result);
     }
+
+    /**
+     * Test Firewall::create with new plugins: array format.
+     */
+    public function testStaticCreateWithNewPluginsFormat(): void
+    {
+        $config = [
+            'plugins' => [
+                [
+                    'plugin' => IpAddress::class,
+                    'response' => 'allow',
+                    'weight' => -200,
+                    'enable' => true,
+                    'config' => ['127.0.0.1'],
+                ],
+            ],
+            'global' => [
+                'mode' => 'exception',
+            ],
+        ];
+
+        $firewall = Firewall::create([$config]);
+        $this->assertInstanceOf(Firewall::class, $firewall);
+    }
+
+    /**
+     * Test Firewall::create with mixed old and new format.
+     */
+    public function testStaticCreateWithMixedFormat(): void
+    {
+        $config = [
+            'plugins' => [
+                [
+                    'plugin' => IpAddress::class,
+                    'response' => 'allow',
+                    'weight' => -300,
+                    'enable' => true,
+                    'config' => ['10.0.0.1'],
+                ],
+            ],
+            'bypass' => [
+                IpAddress::class => [
+                    'priority' => -200,
+                    'enable' => true,
+                    'config' => ['127.0.0.1'],
+                ],
+            ],
+            'block' => [
+                IpAddress::class => [
+                    'priority' => -100,
+                    'enable' => true,
+                    'config' => ['192.168.1.100'],
+                ],
+            ],
+            'global' => [
+                'mode' => 'exception',
+            ],
+        ];
+
+        $firewall = Firewall::create([$config]);
+        $this->assertInstanceOf(Firewall::class, $firewall);
+    }
+
+    /**
+     * Test that bypass (allow) plugins are evaluated before block plugins.
+     */
+    public function testBypassEvaluatedBeforeBlock(): void
+    {
+        // Configure to allow localhost but block everything
+        $config = [
+            'plugins' => [
+                [
+                    'plugin' => IpAddress::class,
+                    'response' => 'allow',
+                    'weight' => 0,
+                    'enable' => true,
+                    'config' => ['127.0.0.1'],
+                ],
+                [
+                    'plugin' => IpAddress::class,
+                    'response' => 'block',
+                    'weight' => 0,
+                    'enable' => true,
+                    'config' => ['127.0.0.1'], // Same IP would be blocked if allow wasn't first
+                ],
+            ],
+            'global' => [
+                'mode' => 'exception',
+            ],
+        ];
+
+        $firewall = Firewall::create([$config]);
+        $request = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '127.0.0.1']);
+
+        // Should pass because allow is evaluated first
+        $this->assertTrue($firewall->evaluate($request));
+    }
+
+    /**
+     * Test plugins are sorted by weight within their response group.
+     */
+    public function testPluginsSortedByWeightWithinGroup(): void
+    {
+        // Plugin with higher weight should be evaluated after plugin with lower weight
+        $config = [
+            'plugins' => [
+                [
+                    'plugin' => IpAddress::class,
+                    'response' => 'block',
+                    'weight' => 100,
+                    'enable' => true,
+                    'config' => ['1.2.3.4'],
+                ],
+                [
+                    'plugin' => IpAddress::class,
+                    'response' => 'block',
+                    'weight' => -100,
+                    'enable' => true,
+                    'config' => ['5.6.7.8'],
+                ],
+            ],
+            'global' => [
+                'mode' => 'exception',
+            ],
+        ];
+
+        $firewall = Firewall::create([$config]);
+        $this->assertInstanceOf(Firewall::class, $firewall);
+    }
 }

--- a/tests/Unit/Plugins/PluginManagerTest.php
+++ b/tests/Unit/Plugins/PluginManagerTest.php
@@ -6,6 +6,7 @@ namespace Kanopi\Firewall\Tests\Unit\Plugins;
 
 use Kanopi\Firewall\Plugins\PluginInterface;
 use Kanopi\Firewall\Plugins\PluginManager;
+use Kanopi\Firewall\Tests\Plugins\TestFalsePlugin;
 use Kanopi\Firewall\Tests\Plugins\TestPriorityPluginHigh;
 use Kanopi\Firewall\Tests\Plugins\TestPriorityPluginLow;
 use Kanopi\Firewall\Tests\Plugins\TestTruePlugin;
@@ -109,6 +110,173 @@ class PluginManagerTest extends AbstractTestCase
         ]);
 
         $manager->evaluate(new Request());
+        $this->assertSame(
+            [TestPriorityPluginLow::class, TestPriorityPluginHigh::class],
+            $callOrder
+        );
+    }
+
+    /**
+     * Test: createFromPluginsArray with valid plugin returns false when plugin returns false.
+     */
+    public function testCreateFromPluginsArrayValidPluginReturnsFalse(): void
+    {
+        $manager = PluginManager::createFromPluginsArray([
+            [
+                'plugin' => TestFalsePlugin::class,
+                'weight' => 5,
+            ],
+        ]);
+
+        $this->assertFalse($manager->evaluate(new Request()));
+    }
+
+    /**
+     * Test: createFromPluginsArray with missing plugin class is skipped.
+     */
+    public function testCreateFromPluginsArrayMissingClassSkipped(): void
+    {
+        $manager = PluginManager::createFromPluginsArray([
+            [
+                'plugin' => 'Invalid\Missing\Plugin',
+                'weight' => 0,
+            ],
+        ]);
+
+        $this->assertFalse($manager->evaluate(new Request()));
+    }
+
+    /**
+     * Test: createFromPluginsArray with non-PluginInterface class is skipped.
+     */
+    public function testCreateFromPluginsArrayNonPluginInterfaceSkipped(): void
+    {
+        $manager = PluginManager::createFromPluginsArray([
+            [
+                'plugin' => \stdClass::class,
+                'weight' => 0,
+            ],
+        ]);
+
+        $this->assertFalse($manager->evaluate(new Request()));
+    }
+
+    /**
+     * Test: createFromPluginsArray with plugin returning true.
+     */
+    public function testCreateFromPluginsArrayPluginReturnsTrue(): void
+    {
+        $manager = PluginManager::createFromPluginsArray([
+            [
+                'plugin' => TestTruePlugin::class,
+                'weight' => 0,
+            ],
+        ]);
+
+        $result = $manager->evaluate(new Request());
+
+        $this->assertInstanceOf(TestTruePlugin::class, $result);
+    }
+
+    /**
+     * Test: createFromPluginsArray sorts by weight (lower first).
+     */
+    public function testCreateFromPluginsArraySortsByWeight(): void
+    {
+        $callOrder = [];
+
+        $manager = PluginManager::createFromPluginsArray([
+            [
+                'plugin' => TestPriorityPluginHigh::class,
+                'weight' => 10,
+                'metadata' => ['order' => &$callOrder],
+            ],
+            [
+                'plugin' => TestPriorityPluginLow::class,
+                'weight' => 1,
+                'metadata' => ['order' => &$callOrder],
+            ],
+        ]);
+
+        $manager->evaluate(new Request());
+        $this->assertSame(
+            [TestPriorityPluginLow::class, TestPriorityPluginHigh::class],
+            $callOrder
+        );
+    }
+
+    /**
+     * Test: createFromPluginsArray supports multiple instances of the same plugin.
+     */
+    public function testCreateFromPluginsArrayMultipleInstances(): void
+    {
+        $manager = PluginManager::createFromPluginsArray([
+            [
+                'plugin' => TestFalsePlugin::class,
+                'weight' => 0,
+            ],
+            [
+                'plugin' => TestFalsePlugin::class,
+                'weight' => 10,
+            ],
+        ]);
+
+        $plugins = $manager->getPlugins();
+        $this->assertCount(2, $plugins);
+    }
+
+    /**
+     * Test: createFromPluginsArray with missing plugin key is skipped.
+     */
+    public function testCreateFromPluginsArrayMissingPluginKeySkipped(): void
+    {
+        $manager = PluginManager::createFromPluginsArray([
+            [
+                'weight' => 0,
+                'config' => ['something'],
+            ],
+        ]);
+
+        $this->assertFalse($manager->evaluate(new Request()));
+    }
+
+    /**
+     * Test: createFromPluginsArray with empty plugin key is skipped.
+     */
+    public function testCreateFromPluginsArrayEmptyPluginKeySkipped(): void
+    {
+        $manager = PluginManager::createFromPluginsArray([
+            [
+                'plugin' => '',
+                'weight' => 0,
+            ],
+        ]);
+
+        $this->assertFalse($manager->evaluate(new Request()));
+    }
+
+    /**
+     * Test: createFromPluginsArray defaults weight to 0 when not provided.
+     */
+    public function testCreateFromPluginsArrayDefaultWeight(): void
+    {
+        $callOrder = [];
+
+        $manager = PluginManager::createFromPluginsArray([
+            [
+                'plugin' => TestPriorityPluginHigh::class,
+                'weight' => 10,
+                'metadata' => ['order' => &$callOrder],
+            ],
+            [
+                'plugin' => TestPriorityPluginLow::class,
+                // No weight specified, should default to 0
+                'metadata' => ['order' => &$callOrder],
+            ],
+        ]);
+
+        $manager->evaluate(new Request());
+        // Low should come first since its default weight (0) < High's weight (10)
         $this->assertSame(
             [TestPriorityPluginLow::class, TestPriorityPluginHigh::class],
             $callOrder

--- a/tests/Unit/Utility/ConfigLoaderTest.php
+++ b/tests/Unit/Utility/ConfigLoaderTest.php
@@ -727,4 +727,174 @@ YAML
         $this->assertEquals('path:/custom', $result['block']['Kanopi\Firewall\Plugins\Url']['config'][0]);
     }
 
+    public function testPluginsArrayMergingAppendsEntries(): void
+    {
+        $file1 = $this->tmp . '/plugins1.yml';
+        $file2 = $this->tmp . '/plugins2.yml';
+        $main = $this->tmp . '/main.yml';
+
+        file_put_contents($file1, <<<YAML
+plugins:
+  - plugin: Kanopi\Firewall\Plugins\IpAddress
+    response: allow
+    weight: -200
+    enable: true
+    config:
+      - 127.0.0.1
+YAML
+        );
+
+        file_put_contents($file2, <<<YAML
+plugins:
+  - plugin: Kanopi\Firewall\Plugins\Url
+    response: block
+    weight: -100
+    enable: true
+    config:
+      - path:/admin
+YAML
+        );
+
+        file_put_contents($main, <<<YAML
+configs:
+  - plugins1.yml
+  - plugins2.yml
+YAML
+        );
+
+        $result = ConfigLoader::load($main);
+
+        // Both plugins should be present (appended, not replaced)
+        $this->assertArrayHasKey('plugins', $result);
+        $this->assertCount(2, $result['plugins']);
+
+        // First plugin from file1
+        $this->assertEquals('Kanopi\Firewall\Plugins\IpAddress', $result['plugins'][0]['plugin']);
+        $this->assertEquals('allow', $result['plugins'][0]['response']);
+        $this->assertEquals(-200, $result['plugins'][0]['weight']);
+
+        // Second plugin from file2
+        $this->assertEquals('Kanopi\Firewall\Plugins\Url', $result['plugins'][1]['plugin']);
+        $this->assertEquals('block', $result['plugins'][1]['response']);
+        $this->assertEquals(-100, $result['plugins'][1]['weight']);
+    }
+
+    public function testPluginsArrayMergingWithExistingPlugins(): void
+    {
+        $file1 = $this->tmp . '/plugins1.yml';
+        $main = $this->tmp . '/main.yml';
+
+        file_put_contents($file1, <<<YAML
+plugins:
+  - plugin: Kanopi\Firewall\Plugins\RateLimit
+    response: block
+    weight: 100
+YAML
+        );
+
+        file_put_contents($main, <<<YAML
+plugins:
+  - plugin: Kanopi\Firewall\Plugins\IpAddress
+    response: allow
+    weight: -200
+
+configs:
+  - plugins1.yml
+YAML
+        );
+
+        $result = ConfigLoader::load($main);
+
+        // Both plugins should be present (main + included)
+        $this->assertCount(2, $result['plugins']);
+        $this->assertEquals('Kanopi\Firewall\Plugins\IpAddress', $result['plugins'][0]['plugin']);
+        $this->assertEquals('Kanopi\Firewall\Plugins\RateLimit', $result['plugins'][1]['plugin']);
+    }
+
+    public function testPluginsArrayMergingWithMultipleInstances(): void
+    {
+        $file1 = $this->tmp . '/plugins1.yml';
+        $file2 = $this->tmp . '/plugins2.yml';
+        $main = $this->tmp . '/main.yml';
+
+        file_put_contents($file1, <<<YAML
+plugins:
+  - plugin: Kanopi\Firewall\Plugins\IpAddress
+    response: allow
+    weight: -200
+    config:
+      - 127.0.0.1
+YAML
+        );
+
+        file_put_contents($file2, <<<YAML
+plugins:
+  - plugin: Kanopi\Firewall\Plugins\IpAddress
+    response: block
+    weight: -100
+    config:
+      - 192.168.1.100
+YAML
+        );
+
+        file_put_contents($main, <<<YAML
+configs:
+  - plugins1.yml
+  - plugins2.yml
+YAML
+        );
+
+        $result = ConfigLoader::load($main);
+
+        // Both instances of IpAddress should be present
+        $this->assertCount(2, $result['plugins']);
+        $this->assertEquals('Kanopi\Firewall\Plugins\IpAddress', $result['plugins'][0]['plugin']);
+        $this->assertEquals('allow', $result['plugins'][0]['response']);
+        $this->assertEquals('Kanopi\Firewall\Plugins\IpAddress', $result['plugins'][1]['plugin']);
+        $this->assertEquals('block', $result['plugins'][1]['response']);
+    }
+
+    public function testMixedOldAndNewFormatMerging(): void
+    {
+        $file1 = $this->tmp . '/old_format.yml';
+        $file2 = $this->tmp . '/new_format.yml';
+        $main = $this->tmp . '/main.yml';
+
+        file_put_contents($file1, <<<YAML
+bypass:
+  Kanopi\Firewall\Plugins\IpAddress:
+    priority: -200
+    enable: true
+    config:
+      - 127.0.0.1
+YAML
+        );
+
+        file_put_contents($file2, <<<YAML
+plugins:
+  - plugin: Kanopi\Firewall\Plugins\Url
+    response: block
+    weight: -100
+    enable: true
+    config:
+      - path:/admin
+YAML
+        );
+
+        file_put_contents($main, <<<YAML
+configs:
+  - old_format.yml
+  - new_format.yml
+YAML
+        );
+
+        $result = ConfigLoader::load($main);
+
+        // Both formats should be present
+        $this->assertArrayHasKey('bypass', $result);
+        $this->assertArrayHasKey('plugins', $result);
+        $this->assertArrayHasKey('Kanopi\Firewall\Plugins\IpAddress', $result['bypass']);
+        $this->assertCount(1, $result['plugins']);
+    }
+
 }

--- a/tests/Unit/Utility/PluginConfigNormalizerTest.php
+++ b/tests/Unit/Utility/PluginConfigNormalizerTest.php
@@ -1,0 +1,502 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Utility;
+
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use Kanopi\Firewall\Utility\PluginConfigNormalizer;
+
+final class PluginConfigNormalizerTest extends AbstractTestCase
+{
+    /**
+     * Test: bypass: section converts to response: allow.
+     */
+    public function testBypassConvertsToResponseAllow(): void
+    {
+        $config = [
+            'bypass' => [
+                'Kanopi\Firewall\Plugins\IpAddress' => [
+                    'priority' => -200,
+                    'enable' => true,
+                    'config' => ['127.0.0.1'],
+                ],
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::normalize($config);
+
+        $this->assertArrayHasKey('plugins', $result);
+        $this->assertCount(1, $result['plugins']);
+        $this->assertArrayNotHasKey('bypass', $result);
+
+        $plugin = $result['plugins'][0];
+        $this->assertEquals('Kanopi\Firewall\Plugins\IpAddress', $plugin['plugin']);
+        $this->assertEquals('allow', $plugin['response']);
+        $this->assertEquals(-200, $plugin['weight']);
+        $this->assertTrue($plugin['enable']);
+        $this->assertEquals(['127.0.0.1'], $plugin['config']);
+    }
+
+    /**
+     * Test: block: section converts to response: block.
+     */
+    public function testBlockConvertsToResponseBlock(): void
+    {
+        $config = [
+            'block' => [
+                'Kanopi\Firewall\Plugins\IpAddress' => [
+                    'priority' => -100,
+                    'enable' => true,
+                    'config' => ['192.168.1.100'],
+                ],
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::normalize($config);
+
+        $this->assertArrayHasKey('plugins', $result);
+        $this->assertCount(1, $result['plugins']);
+        $this->assertArrayNotHasKey('block', $result);
+
+        $plugin = $result['plugins'][0];
+        $this->assertEquals('Kanopi\Firewall\Plugins\IpAddress', $plugin['plugin']);
+        $this->assertEquals('block', $plugin['response']);
+        $this->assertEquals(-100, $plugin['weight']);
+        $this->assertTrue($plugin['enable']);
+        $this->assertEquals(['192.168.1.100'], $plugin['config']);
+    }
+
+    /**
+     * Test: priority maps to weight.
+     */
+    public function testPriorityMapsToWeight(): void
+    {
+        $config = [
+            'block' => [
+                'Kanopi\Firewall\Plugins\IpAddress' => [
+                    'priority' => 50,
+                ],
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::normalize($config);
+
+        $this->assertEquals(50, $result['plugins'][0]['weight']);
+    }
+
+    /**
+     * Test: missing priority defaults to 0.
+     */
+    public function testMissingPriorityDefaultsToZero(): void
+    {
+        $config = [
+            'block' => [
+                'Kanopi\Firewall\Plugins\IpAddress' => [
+                    'enable' => true,
+                ],
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::normalize($config);
+
+        $this->assertEquals(0, $result['plugins'][0]['weight']);
+    }
+
+    /**
+     * Test: mixed old and new format merging.
+     */
+    public function testMixedFormatMerging(): void
+    {
+        $config = [
+            'plugins' => [
+                [
+                    'plugin' => 'Kanopi\Firewall\Plugins\Url',
+                    'response' => 'block',
+                    'weight' => -50,
+                    'enable' => true,
+                    'metadata' => [],
+                    'config' => ['/admin'],
+                ],
+            ],
+            'bypass' => [
+                'Kanopi\Firewall\Plugins\IpAddress' => [
+                    'priority' => -200,
+                    'enable' => true,
+                    'config' => ['127.0.0.1'],
+                ],
+            ],
+            'block' => [
+                'Kanopi\Firewall\Plugins\RateLimit' => [
+                    'priority' => 100,
+                    'config' => [],
+                ],
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::normalize($config);
+
+        $this->assertCount(3, $result['plugins']);
+        $this->assertArrayNotHasKey('bypass', $result);
+        $this->assertArrayNotHasKey('block', $result);
+
+        // First plugin from plugins: array preserved
+        $this->assertEquals('Kanopi\Firewall\Plugins\Url', $result['plugins'][0]['plugin']);
+        $this->assertEquals('block', $result['plugins'][0]['response']);
+
+        // Second plugin from bypass: converted
+        $this->assertEquals('Kanopi\Firewall\Plugins\IpAddress', $result['plugins'][1]['plugin']);
+        $this->assertEquals('allow', $result['plugins'][1]['response']);
+
+        // Third plugin from block: converted
+        $this->assertEquals('Kanopi\Firewall\Plugins\RateLimit', $result['plugins'][2]['plugin']);
+        $this->assertEquals('block', $result['plugins'][2]['response']);
+    }
+
+    /**
+     * Test: multiple instances of the same plugin class.
+     */
+    public function testMultipleInstancesOfSamePlugin(): void
+    {
+        $config = [
+            'plugins' => [
+                [
+                    'plugin' => 'Kanopi\Firewall\Plugins\IpAddress',
+                    'response' => 'allow',
+                    'weight' => -200,
+                    'config' => ['127.0.0.1'],
+                ],
+                [
+                    'plugin' => 'Kanopi\Firewall\Plugins\IpAddress',
+                    'response' => 'block',
+                    'weight' => -100,
+                    'config' => ['192.168.1.100'],
+                ],
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::normalize($config);
+
+        $this->assertCount(2, $result['plugins']);
+        $this->assertEquals('Kanopi\Firewall\Plugins\IpAddress', $result['plugins'][0]['plugin']);
+        $this->assertEquals('Kanopi\Firewall\Plugins\IpAddress', $result['plugins'][1]['plugin']);
+        $this->assertEquals('allow', $result['plugins'][0]['response']);
+        $this->assertEquals('block', $result['plugins'][1]['response']);
+    }
+
+    /**
+     * Test: metadata is preserved.
+     */
+    public function testMetadataPreserved(): void
+    {
+        $config = [
+            'block' => [
+                'Kanopi\Firewall\Plugins\GeoLocation' => [
+                    'priority' => 0,
+                    'enable' => true,
+                    'metadata' => [
+                        'reader' => [
+                            'db' => '/path/to/GeoLite2.mmdb',
+                        ],
+                    ],
+                    'config' => ['US', 'CA'],
+                ],
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::normalize($config);
+
+        $this->assertEquals([
+            'reader' => [
+                'db' => '/path/to/GeoLite2.mmdb',
+            ],
+        ], $result['plugins'][0]['metadata']);
+    }
+
+    /**
+     * Test: config array is preserved.
+     */
+    public function testConfigPreserved(): void
+    {
+        $config = [
+            'bypass' => [
+                'Kanopi\Firewall\Plugins\IpAddress' => [
+                    'config' => ['10.0.0.0/8', '192.168.0.0/16', '172.16.0.0/12'],
+                ],
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::normalize($config);
+
+        $this->assertEquals(['10.0.0.0/8', '192.168.0.0/16', '172.16.0.0/12'], $result['plugins'][0]['config']);
+    }
+
+    /**
+     * Test: enable flag is preserved.
+     */
+    public function testEnablePreserved(): void
+    {
+        $config = [
+            'block' => [
+                'Kanopi\Firewall\Plugins\IpAddress' => [
+                    'enable' => false,
+                    'config' => ['1.2.3.4'],
+                ],
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::normalize($config);
+
+        $this->assertFalse($result['plugins'][0]['enable']);
+    }
+
+    /**
+     * Test: missing enable defaults to true.
+     */
+    public function testMissingEnableDefaultsToTrue(): void
+    {
+        $config = [
+            'block' => [
+                'Kanopi\Firewall\Plugins\IpAddress' => [
+                    'config' => ['1.2.3.4'],
+                ],
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::normalize($config);
+
+        $this->assertTrue($result['plugins'][0]['enable']);
+    }
+
+    /**
+     * Test: empty bypass section handled.
+     */
+    public function testEmptyBypassSection(): void
+    {
+        $config = [
+            'bypass' => [],
+        ];
+
+        $result = PluginConfigNormalizer::normalize($config);
+
+        $this->assertArrayHasKey('plugins', $result);
+        $this->assertEmpty($result['plugins']);
+    }
+
+    /**
+     * Test: empty block section handled.
+     */
+    public function testEmptyBlockSection(): void
+    {
+        $config = [
+            'block' => [],
+        ];
+
+        $result = PluginConfigNormalizer::normalize($config);
+
+        $this->assertArrayHasKey('plugins', $result);
+        $this->assertEmpty($result['plugins']);
+    }
+
+    /**
+     * Test: missing sections handled (no bypass, no block, no plugins).
+     */
+    public function testMissingSectionsHandled(): void
+    {
+        $config = [
+            'global' => [
+                'mode' => 'block',
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::normalize($config);
+
+        $this->assertArrayHasKey('plugins', $result);
+        $this->assertEmpty($result['plugins']);
+        $this->assertEquals('block', $result['global']['mode']);
+    }
+
+    /**
+     * Test: non-array plugin config is skipped.
+     */
+    public function testNonArrayPluginConfigSkipped(): void
+    {
+        $config = [
+            'block' => [
+                'Kanopi\Firewall\Plugins\IpAddress' => 'invalid',
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::normalize($config);
+
+        $this->assertEmpty($result['plugins']);
+    }
+
+    /**
+     * Test: partitionAndSort separates allow and block plugins.
+     */
+    public function testPartitionAndSortSeparatesPlugins(): void
+    {
+        $plugins = [
+            [
+                'plugin' => 'Kanopi\Firewall\Plugins\IpAddress',
+                'response' => 'allow',
+                'weight' => 0,
+                'enable' => true,
+            ],
+            [
+                'plugin' => 'Kanopi\Firewall\Plugins\Url',
+                'response' => 'block',
+                'weight' => 0,
+                'enable' => true,
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::partitionAndSort($plugins);
+
+        $this->assertCount(1, $result['allow']);
+        $this->assertCount(1, $result['block']);
+        $this->assertEquals('Kanopi\Firewall\Plugins\IpAddress', $result['allow'][0]['plugin']);
+        $this->assertEquals('Kanopi\Firewall\Plugins\Url', $result['block'][0]['plugin']);
+    }
+
+    /**
+     * Test: partitionAndSort sorts by weight (lower first).
+     */
+    public function testPartitionAndSortSortsByWeight(): void
+    {
+        $plugins = [
+            [
+                'plugin' => 'Plugin3',
+                'response' => 'block',
+                'weight' => 100,
+                'enable' => true,
+            ],
+            [
+                'plugin' => 'Plugin1',
+                'response' => 'block',
+                'weight' => -100,
+                'enable' => true,
+            ],
+            [
+                'plugin' => 'Plugin2',
+                'response' => 'block',
+                'weight' => 0,
+                'enable' => true,
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::partitionAndSort($plugins);
+
+        $this->assertEquals('Plugin1', $result['block'][0]['plugin']);
+        $this->assertEquals('Plugin2', $result['block'][1]['plugin']);
+        $this->assertEquals('Plugin3', $result['block'][2]['plugin']);
+    }
+
+    /**
+     * Test: partitionAndSort filters disabled plugins.
+     */
+    public function testPartitionAndSortFiltersDisabled(): void
+    {
+        $plugins = [
+            [
+                'plugin' => 'Kanopi\Firewall\Plugins\IpAddress',
+                'response' => 'allow',
+                'weight' => 0,
+                'enable' => true,
+            ],
+            [
+                'plugin' => 'Kanopi\Firewall\Plugins\Url',
+                'response' => 'block',
+                'weight' => 0,
+                'enable' => false,
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::partitionAndSort($plugins);
+
+        $this->assertCount(1, $result['allow']);
+        $this->assertCount(0, $result['block']);
+    }
+
+    /**
+     * Test: partitionAndSort defaults response to block.
+     */
+    public function testPartitionAndSortDefaultsToBlock(): void
+    {
+        $plugins = [
+            [
+                'plugin' => 'Kanopi\Firewall\Plugins\IpAddress',
+                'weight' => 0,
+                'enable' => true,
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::partitionAndSort($plugins);
+
+        $this->assertCount(0, $result['allow']);
+        $this->assertCount(1, $result['block']);
+    }
+
+    /**
+     * Test: partitionAndSort missing enable defaults to true.
+     */
+    public function testPartitionAndSortMissingEnableDefaultsToTrue(): void
+    {
+        $plugins = [
+            [
+                'plugin' => 'Kanopi\Firewall\Plugins\IpAddress',
+                'response' => 'allow',
+                'weight' => 0,
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::partitionAndSort($plugins);
+
+        $this->assertCount(1, $result['allow']);
+    }
+
+    /**
+     * Test: full workflow from legacy format to partitioned plugins.
+     */
+    public function testFullWorkflow(): void
+    {
+        // Start with legacy format
+        $config = [
+            'bypass' => [
+                'Kanopi\Firewall\Plugins\IpAddress' => [
+                    'priority' => -200,
+                    'enable' => true,
+                    'config' => ['127.0.0.1'],
+                ],
+            ],
+            'block' => [
+                'Kanopi\Firewall\Plugins\Url' => [
+                    'priority' => -100,
+                    'enable' => true,
+                    'config' => ['/admin'],
+                ],
+                'Kanopi\Firewall\Plugins\RateLimit' => [
+                    'priority' => 100,
+                    'enable' => true,
+                    'config' => [],
+                ],
+            ],
+        ];
+
+        // Normalize to new format
+        $normalized = PluginConfigNormalizer::normalize($config);
+
+        // Partition and sort
+        $partitioned = PluginConfigNormalizer::partitionAndSort($normalized['plugins']);
+
+        // Verify allow plugins (bypasses)
+        $this->assertCount(1, $partitioned['allow']);
+        $this->assertEquals('Kanopi\Firewall\Plugins\IpAddress', $partitioned['allow'][0]['plugin']);
+
+        // Verify block plugins (sorted by weight: -100 before 100)
+        $this->assertCount(2, $partitioned['block']);
+        $this->assertEquals('Kanopi\Firewall\Plugins\Url', $partitioned['block'][0]['plugin']);
+        $this->assertEquals('Kanopi\Firewall\Plugins\RateLimit', $partitioned['block'][1]['plugin']);
+    }
+}


### PR DESCRIPTION
## Description

Restructures plugin configuration to introduce a new canonical `plugins:` array format while maintaining full backward compatibility with the legacy `bypass:`/`block:` format. The new format provides explicit control over plugin behavior with `response: allow|block` and `weight` fields, and allows the same plugin class to be used multiple times with different configurations.

## Related Issue

Fixes #37

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [x] Refactoring (no functional changes)
- [ ] Security fix

## Changes Made

- Added `PluginConfigNormalizer` utility class that converts legacy `bypass:`/`block:` format to canonical `plugins:` array format
- Added `PluginManager::createFromPluginsArray()` factory method supporting the new format with unique IDs for multiple plugin instances
- Updated `Firewall::create()` to use `PluginConfigNormalizer` for config normalization and plugin partitioning
- Updated `ConfigLoader::mergeConfigs()` to append `plugins:` arrays instead of replacing them
- Added path patterns in `Config.php` for the new `plugins:` structure
- Field mapping: `priority` → `weight`, `bypass:` → `response: allow`, `block:` → `response: block`
- Comprehensive documentation updates to README.md, CLAUDE.md, and example configs
- Added 20 unit tests for `PluginConfigNormalizer`
- Added 9 unit tests for `PluginManager::createFromPluginsArray()`
- Added 4 unit tests for `Firewall` with new/mixed formats
- Added 4 unit tests for `ConfigLoader` plugins array merging

## Testing

### How to Test

1. Run `composer check` to verify code style, PHPStan, and Rector pass
2. Run `composer test` to run all unit and integration tests
3. Test with a config using the new `plugins:` format (see example below)
4. Test with a config using the legacy `bypass:`/`block:` format to verify backward compatibility
5. Test with a mixed config using both formats simultaneously

### Test Configuration

```yaml
# New canonical format
plugins:
  # Allow localhost to bypass
  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
    response: allow
    weight: -200
    enable: true
    config:
      - 127.0.0.1
      - ::1

  # Block specific IPs
  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
    response: block
    weight: -100
    enable: true
    config:
      - 192.168.1.100

  # Rate limiting
  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
    response: block
    weight: 100
    enable: true
    metadata:
      default_rate: 60
      default_sample: 60
    config:
      - path: /login
        rate: 5
        sample: 300

# Legacy format (still supported, auto-converted)
# bypass:
#   "Kanopi\\Firewall\\Plugins\\IpAddress":
#     priority: -200
#     enable: true
#     config:
#       - 127.0.0.1
```

## Checklist

### Code Quality

- [x] My code follows the project's code style (`composer cs` passes)
- [x] Static analysis passes (`composer stan` passes)
- [x] I have added appropriate code comments explaining complex logic
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have added integration tests if necessary
- [x] New and existing tests pass locally (`composer test` passes)
- [x] I have achieved 100% test coverage for new code
- [x] I have tested edge cases and error conditions

### Security Considerations

- [x] I have considered the security implications of my changes
- [x] Input validation is properly implemented
- [x] No sensitive information is logged or exposed
- [x] Rate limiting is considered for new endpoints/features
- [x] Changes don't introduce new attack vectors

### Documentation

- [x] I have updated the README.md if needed
- [x] I have added/updated configuration examples
- [x] I have documented any new plugin variables or options
- [x] I have updated inline documentation/comments

### Plugin Development (if applicable)

- [x] Plugin follows the existing plugin pattern
- [x] Plugin implements all required interface methods
- [x] Plugin has appropriate metadata configuration
- [x] Plugin properly uses logging
- [x] Plugin returns appropriate status codes

## Breaking Changes

- [ ] This PR introduces breaking changes

No breaking changes. The legacy `bypass:`/`block:` format continues to work exactly as before. It is silently converted to the new internal format without any deprecation warnings.

## Performance Impact

- [ ] This change has performance implications

Negligible performance impact. The normalization step adds minimal overhead during `Firewall::create()` initialization (not per-request). The actual request evaluation logic remains the same.

## Screenshots/Examples

### Before

Legacy format with separate `bypass:` and `block:` sections:

```yaml
bypass:
  "Kanopi\\Firewall\\Plugins\\IpAddress":
    priority: -200
    enable: true
    config:
      - 127.0.0.1

block:
  "Kanopi\\Firewall\\Plugins\\IpAddress":
    priority: -100
    enable: true
    config:
      - 192.168.1.100
```

### After

New canonical format with unified `plugins:` array:

```yaml
plugins:
  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
    response: allow
    weight: -200
    enable: true
    config:
      - 127.0.0.1

  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
    response: block
    weight: -100
    enable: true
    config:
      - 192.168.1.100
```

**Key benefits:**
- Same plugin class can be used multiple times with different configs
- Explicit `response` field clearly indicates allow/block behavior
- Single array makes plugin relationships and order clearer
- `plugins:` arrays from multiple config files are appended (not replaced) during merging

## Additional Context

### Implementation Details

1. **PluginConfigNormalizer** (`src/Utility/PluginConfigNormalizer.php`):
   - `normalize()`: Converts legacy format to canonical `plugins:` array
   - `partitionAndSort()`: Separates plugins by response type and sorts by weight

2. **Evaluation Order**: Preserves existing behavior where allow (bypass) plugins run before block plugins. Within each group, plugins are sorted by weight (lower first).

3. **Config Merging**: Updated `ConfigLoader::mergeConfigs()` to detect `plugins:` arrays at root level and append entries rather than replace. This enables modular configuration across multiple files.

4. **Files Created**:
   - `src/Utility/PluginConfigNormalizer.php`
   - `tests/Unit/Utility/PluginConfigNormalizerTest.php`

5. **Files Modified**:
   - `src/Firewall.php`
   - `src/Plugins/PluginManager.php`
   - `src/Utility/ConfigLoader.php`
   - `src/Utility/Config.php`
   - `config/config.yml`
   - `tests/Unit/Plugins/PluginManagerTest.php`
   - `tests/Unit/FirewallTest.php`
   - `tests/Unit/Utility/ConfigLoaderTest.php`
   - `README.md`
   - `CLAUDE.md`
   - `example/config.yml`
   - `example/README.md`

## Reviewer Notes

- Focus on the `PluginConfigNormalizer` logic to ensure correct field mapping
- Verify the `plugins:` array merging behavior in `ConfigLoader` is correct (append vs replace)
- Check that `createFromPluginsArray()` properly handles multiple instances of the same plugin class
- Review documentation updates for clarity and completeness

---

<!--
Remember to:
- Keep PRs focused on a single issue/feature
- Update your branch with the latest from 2.x before submitting
- Be responsive to feedback
- Be patient - reviews may take time
-->
