### PR TITLE
Document additional logging examples (Fixes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1445,13 +1445,24 @@ Combine multiple conditions with logical operators:
 
 ## Logging Configuration
 
-The firewall uses Monolog for flexible logging.
-Relative log file paths (e.g., in `args[0]` for `StreamHandler`) are resolved **relative to the YAML file** that declares them.
-Multiple handlers can be configured:
+The firewall uses [Monolog](https://github.com/Seldaek/monolog) for flexible logging, so any Monolog handler can be wired up through the `logger` key. Each entry under `logger` is a separate handler — combine as many as you need (file + Slack + email is a common pattern).
+
+Each handler entry accepts:
+
+- `class` — fully qualified handler class name (must implement `Monolog\Handler\HandlerInterface`).
+- `args` — positional constructor arguments, in order.
+- `formatter` *(optional)* — `class` + `args` for a `Monolog\Formatter\FormatterInterface` implementation, applied to that handler.
+
+Log levels are passed as strings like `Monolog\Level::Info` (Debug, Info, Notice, Warning, Error, Critical, Alert, Emergency). Relative log file paths (e.g., `args[0]` for `StreamHandler`) are resolved **relative to the YAML file** that declares them.
+
+> **Heads up:** several Monolog handlers require additional PHP extensions or third-party packages. Slack/IFTTT/Pushover/Telegram need `ext-curl`; `SendGridHandler` and `SymfonyMailerHandler` may require `composer require` of the relevant transport package. See the [Monolog handler docs](https://seldaek.github.io/monolog/doc/02-handlers-formatters-processors.html) for each handler's prerequisites.
+
+### File logging
+
+Write every event to a flat file:
 
 ```yaml
 logger:
-  # File logging
   - class: Monolog\Handler\StreamHandler
     args:
       - /var/log/firewall/firewall.log
@@ -1461,15 +1472,173 @@ logger:
       args:
         - "[%datetime%] [%level_name%] [%context.plugin%] %message% %context% %extra%\n"
         - "Y-m-d H:i:s"
-  
-  # Syslog
+```
+
+### Rotating file logging
+
+Rotate logs daily and keep the last seven days. Useful when StreamHandler files grow unbounded:
+
+```yaml
+logger:
+  - class: Monolog\Handler\RotatingFileHandler
+    args:
+      - /var/log/firewall/firewall.log
+      - 7                          # maxFiles to keep (0 = unlimited)
+      - Monolog\Level::Info
+```
+
+### JSON-structured logging
+
+Emit one JSON object per line — easy to ingest into Loki, ELK, Datadog, etc:
+
+```yaml
+logger:
+  - class: Monolog\Handler\StreamHandler
+    args:
+      - /var/log/firewall/firewall.ndjson
+      - Monolog\Level::Info
+    formatter:
+      class: Monolog\Formatter\JsonFormatter
+```
+
+### Syslog
+
+Forward events to the host's syslog (handy on managed/cloud platforms that scrape syslog automatically):
+
+```yaml
+logger:
   - class: Monolog\Handler\SyslogHandler
     args:
-      - firewall
-      - LOG_USER
+      - firewall                   # ident / tag
+      - LOG_USER                   # facility
       - Monolog\Level::Warning
-  
-  # Email alerts for critical events
+```
+
+### PHP error log
+
+Pipe firewall events into the configured PHP `error_log` — useful in shared hosting or when you don't control filesystem paths:
+
+```yaml
+logger:
+  - class: Monolog\Handler\ErrorLogHandler
+    args:
+      - 0                          # 0 = operating system, 4 = SAPI
+      - Monolog\Level::Warning
+```
+
+### Email alerts
+
+Send an email when something critical happens. `NativeMailerHandler` uses PHP's `mail()` — no extra package required:
+
+```yaml
+logger:
+  - class: Monolog\Handler\NativeMailerHandler
+    args:
+      - security@example.com       # to (string or list of recipients)
+      - "Firewall Alert"           # subject
+      - noreply@example.com        # from
+      - Monolog\Level::Critical
+```
+
+For higher-volume alerting via SendGrid (requires `ext-curl`):
+
+```yaml
+logger:
+  - class: Monolog\Handler\SendGridHandler
+    args:
+      - apikey                     # SendGrid API user (use "apikey" for API key auth)
+      - "${SENDGRID_API_KEY}"      # API key
+      - noreply@example.com        # from
+      - security@example.com       # to (string or list)
+      - "Firewall Alert"           # subject
+      - Monolog\Level::Critical
+```
+
+### Slack alerts
+
+Post directly to a Slack channel through an [Incoming Webhook](https://api.slack.com/messaging/webhooks). Requires `ext-curl`:
+
+```yaml
+logger:
+  - class: Monolog\Handler\SlackWebhookHandler
+    args:
+      - "${SLACK_WEBHOOK_URL}"     # webhook URL
+      - "#security-alerts"         # channel override (or null)
+      - "Firewall"                 # bot username
+      - true                       # useAttachment
+      - ":shield:"                 # iconEmoji
+      - false                      # useShortAttachment
+      - true                       # includeContextAndExtra
+      - Monolog\Level::Warning
+```
+
+If you prefer the Slack Web API (legacy token-based handler):
+
+```yaml
+logger:
+  - class: Monolog\Handler\SlackHandler
+    args:
+      - "${SLACK_BOT_TOKEN}"       # Slack bot token
+      - "#security-alerts"         # channel
+      - "Firewall"                 # username
+      - true                       # useAttachment
+      - ":shield:"                 # iconEmoji
+      - Monolog\Level::Critical
+```
+
+### Pushover (push notifications)
+
+Send mobile push notifications via [Pushover](https://pushover.net/):
+
+```yaml
+logger:
+  - class: Monolog\Handler\PushoverHandler
+    args:
+      - "${PUSHOVER_APP_TOKEN}"    # application API token
+      - "${PUSHOVER_USER_KEY}"     # user/group key (string or list)
+      - "Firewall Alert"           # notification title
+      - Monolog\Level::Critical
+```
+
+### IFTTT webhooks
+
+Trigger an [IFTTT Maker](https://ifttt.com/maker_webhooks) applet — useful for chaining custom automations (SMS, smart lights, voice assistants, etc.):
+
+```yaml
+logger:
+  - class: Monolog\Handler\IFTTTHandler
+    args:
+      - firewall_alert             # event name configured in the IFTTT applet
+      - "${IFTTT_MAKER_KEY}"       # Maker webhook key
+      - Monolog\Level::Error
+```
+
+IFTTT receives three values: `value1` = channel, `value2` = level name, `value3` = message.
+
+### Telegram bot
+
+Send messages to a Telegram channel or chat via a bot token:
+
+```yaml
+logger:
+  - class: Monolog\Handler\TelegramBotHandler
+    args:
+      - "${TELEGRAM_BOT_TOKEN}"    # bot token from @BotFather
+      - "@my_security_channel"     # chat ID or @channel
+      - Monolog\Level::Critical
+```
+
+### Per-handler severity thresholds
+
+Each handler entry has its own `level` argument, so you can tune verbosity per destination. The pattern below writes every Info-and-above event to file but only escalates Critical events to email:
+
+```yaml
+logger:
+  - class: Monolog\Handler\StreamHandler
+    args:
+      - /var/log/firewall/firewall.log
+      - Monolog\Level::Info
+
   - class: Monolog\Handler\NativeMailerHandler
     args:
       - security@example.com
@@ -1477,6 +1646,51 @@ logger:
       - noreply@example.com
       - Monolog\Level::Critical
 ```
+
+> Handlers that wrap other handlers (e.g. `FingersCrossedHandler`, `BufferHandler`, `FilterHandler`, `GroupHandler`) take a `HandlerInterface` as a constructor argument, which the YAML loader cannot construct recursively. To use those, build the logger programmatically with `Monolog\Logger` and inject it via `LoggingFactory::setLogger()` before calling `Firewall::create()`.
+
+### Combining multiple handlers
+
+You can stack any number of handlers — each entry under `logger` is independent. A common production setup tees everything to a file, surfaces warnings to syslog, and pages humans via Slack/Pushover only on critical events:
+
+```yaml
+logger:
+  # Everything to file
+  - class: Monolog\Handler\RotatingFileHandler
+    args:
+      - /var/log/firewall/firewall.log
+      - 14
+      - Monolog\Level::Info
+
+  # Warnings and above to syslog
+  - class: Monolog\Handler\SyslogHandler
+    args:
+      - firewall
+      - LOG_USER
+      - Monolog\Level::Warning
+
+  # Critical events ping the on-call channel
+  - class: Monolog\Handler\SlackWebhookHandler
+    args:
+      - "${SLACK_WEBHOOK_URL}"
+      - "#security-oncall"
+      - "Firewall"
+      - true
+      - ":rotating_light:"
+      - false
+      - true
+      - Monolog\Level::Critical
+
+  # And buzz a phone if no one acks
+  - class: Monolog\Handler\PushoverHandler
+    args:
+      - "${PUSHOVER_APP_TOKEN}"
+      - "${PUSHOVER_USER_KEY}"
+      - "Firewall CRITICAL"
+      - Monolog\Level::Critical
+```
+
+For the full catalogue of available handlers (Telegram, Mandrill, Loggly, Elasticsearch, Sentry via PSR, etc.), see the [Monolog handlers reference](https://seldaek.github.io/monolog/doc/02-handlers-formatters-processors.html).
 
 ## Dynamic Configuration Overrides
 

--- a/README.md
+++ b/README.md
@@ -1510,9 +1510,11 @@ logger:
   - class: Monolog\Handler\SyslogHandler
     args:
       - firewall                   # ident / tag
-      - LOG_USER                   # facility
+      - user                       # facility — see below
       - Monolog\Level::Warning
 ```
+
+> `SyslogHandler` accepts a facility *name* (string) such as `user`, `daemon`, `mail`, `auth`, `local0`–`local7`. The PHP `LOG_*` constants are integers that YAML cannot reference; passing the literal string `LOG_USER` triggers `UnexpectedValueException`. Stick to the lowercase names above.
 
 ### PHP error log
 
@@ -1666,7 +1668,7 @@ logger:
   - class: Monolog\Handler\SyslogHandler
     args:
       - firewall
-      - LOG_USER
+      - user
       - Monolog\Level::Warning
 
   # Critical events ping the on-call channel

--- a/tests/Unit/Logging/ReadmeLoggingExamplesTest.php
+++ b/tests/Unit/Logging/ReadmeLoggingExamplesTest.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Logging;
+
+use Kanopi\Firewall\Logging\LoggingFactory;
+use Monolog\Handler\ErrorLogHandler;
+use Monolog\Handler\HandlerInterface;
+use Monolog\Handler\IFTTTHandler;
+use Monolog\Handler\NativeMailerHandler;
+use Monolog\Handler\PushoverHandler;
+use Monolog\Handler\RotatingFileHandler;
+use Monolog\Handler\SendGridHandler;
+use Monolog\Handler\SlackHandler;
+use Monolog\Handler\SlackWebhookHandler;
+use Monolog\Handler\StreamHandler;
+use Monolog\Handler\SyslogHandler;
+use Monolog\Handler\TelegramBotHandler;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Verifies that every logger example documented in README.md actually
+ * constructs cleanly via LoggingFactory::create().
+ *
+ * Each case below mirrors a YAML block from the "Logging Configuration"
+ * section of the README. The test parses the YAML the same way the
+ * firewall does at boot, feeds it to the factory, and checks that the
+ * expected Monolog handler ends up wired into the Logger. Construction
+ * is enough — we deliberately do not attempt to send a real message
+ * (no Slack, no email, no syslog daemon) because the goal here is to
+ * catch signature drift in the docs, not to integration-test Monolog.
+ *
+ * When updating examples in README.md, mirror the change here so the
+ * doc keeps shipping configs that actually work.
+ */
+final class ReadmeLoggingExamplesTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: string, 1: class-string<HandlerInterface>}>
+     */
+    public static function readmeExampleProvider(): array
+    {
+        return [
+            'File logging (StreamHandler + LineFormatter)' => [
+                <<<'YAML'
+                logger:
+                  - class: Monolog\Handler\StreamHandler
+                    args:
+                      - /tmp/firewall-readme-test.log
+                      - Monolog\Level::Info
+                    formatter:
+                      class: Monolog\Formatter\LineFormatter
+                      args:
+                        - "[%datetime%] [%level_name%] [%context.plugin%] %message% %context% %extra%\n"
+                        - "Y-m-d H:i:s"
+                YAML,
+                StreamHandler::class,
+            ],
+
+            'Rotating file logging (RotatingFileHandler)' => [
+                <<<'YAML'
+                logger:
+                  - class: Monolog\Handler\RotatingFileHandler
+                    args:
+                      - /tmp/firewall-readme-test.log
+                      - 7
+                      - Monolog\Level::Info
+                YAML,
+                RotatingFileHandler::class,
+            ],
+
+            'JSON-structured logging (StreamHandler + JsonFormatter)' => [
+                <<<'YAML'
+                logger:
+                  - class: Monolog\Handler\StreamHandler
+                    args:
+                      - /tmp/firewall-readme-test.ndjson
+                      - Monolog\Level::Info
+                    formatter:
+                      class: Monolog\Formatter\JsonFormatter
+                YAML,
+                StreamHandler::class,
+            ],
+
+            'Syslog (SyslogHandler with named facility)' => [
+                <<<'YAML'
+                logger:
+                  - class: Monolog\Handler\SyslogHandler
+                    args:
+                      - firewall
+                      - user
+                      - Monolog\Level::Warning
+                YAML,
+                SyslogHandler::class,
+            ],
+
+            'PHP error log (ErrorLogHandler)' => [
+                <<<'YAML'
+                logger:
+                  - class: Monolog\Handler\ErrorLogHandler
+                    args:
+                      - 0
+                      - Monolog\Level::Warning
+                YAML,
+                ErrorLogHandler::class,
+            ],
+
+            'Email — NativeMailerHandler' => [
+                <<<'YAML'
+                logger:
+                  - class: Monolog\Handler\NativeMailerHandler
+                    args:
+                      - security@example.com
+                      - "Firewall Alert"
+                      - noreply@example.com
+                      - Monolog\Level::Critical
+                YAML,
+                NativeMailerHandler::class,
+            ],
+
+            'Email — SendGridHandler' => [
+                <<<'YAML'
+                logger:
+                  - class: Monolog\Handler\SendGridHandler
+                    args:
+                      - apikey
+                      - SG.test-key
+                      - noreply@example.com
+                      - security@example.com
+                      - "Firewall Alert"
+                      - Monolog\Level::Critical
+                YAML,
+                SendGridHandler::class,
+            ],
+
+            'Slack — SlackWebhookHandler' => [
+                <<<'YAML'
+                logger:
+                  - class: Monolog\Handler\SlackWebhookHandler
+                    args:
+                      - https://hooks.slack.com/services/T000/B000/test
+                      - "#security-alerts"
+                      - "Firewall"
+                      - true
+                      - ":shield:"
+                      - false
+                      - true
+                      - Monolog\Level::Warning
+                YAML,
+                SlackWebhookHandler::class,
+            ],
+
+            'Slack — SlackHandler (token-based)' => [
+                <<<'YAML'
+                logger:
+                  - class: Monolog\Handler\SlackHandler
+                    args:
+                      - xoxb-test-token
+                      - "#security-alerts"
+                      - "Firewall"
+                      - true
+                      - ":shield:"
+                      - Monolog\Level::Critical
+                YAML,
+                SlackHandler::class,
+            ],
+
+            'Pushover — PushoverHandler' => [
+                <<<'YAML'
+                logger:
+                  - class: Monolog\Handler\PushoverHandler
+                    args:
+                      - test-app-token
+                      - test-user-key
+                      - "Firewall Alert"
+                      - Monolog\Level::Critical
+                YAML,
+                PushoverHandler::class,
+            ],
+
+            'IFTTT — IFTTTHandler' => [
+                <<<'YAML'
+                logger:
+                  - class: Monolog\Handler\IFTTTHandler
+                    args:
+                      - firewall_alert
+                      - test-maker-key
+                      - Monolog\Level::Error
+                YAML,
+                IFTTTHandler::class,
+            ],
+
+            'Telegram — TelegramBotHandler' => [
+                <<<'YAML'
+                logger:
+                  - class: Monolog\Handler\TelegramBotHandler
+                    args:
+                      - test-bot-token
+                      - "@my_security_channel"
+                      - Monolog\Level::Critical
+                YAML,
+                TelegramBotHandler::class,
+            ],
+        ];
+    }
+
+    /**
+     * Parse a README YAML block via the same parser the firewall uses
+     * and assert LoggingFactory::create() wires up the expected handler.
+     */
+    #[DataProvider('readmeExampleProvider')]
+    public function testReadmeExampleConstructsHandler(string $yaml, string $expectedHandlerClass): void
+    {
+        $parsed = Yaml::parse($yaml);
+
+        $this->assertIsArray($parsed, 'README example should parse as YAML');
+        $this->assertArrayHasKey('logger', $parsed, 'README example must have a logger: key');
+        $this->assertIsArray($parsed['logger'], 'logger: must be a list of handlers');
+
+        $logger = LoggingFactory::create($parsed['logger']);
+
+        $handlers = $logger->getHandlers();
+        $this->assertCount(1, $handlers, 'Exactly one handler expected from the example');
+        $this->assertInstanceOf(
+            $expectedHandlerClass,
+            $handlers[0],
+            sprintf('Expected %s but got %s', $expectedHandlerClass, $handlers[0]::class)
+        );
+    }
+
+    /**
+     * The combined multi-handler example from README.md should produce
+     * one Logger with all four handlers attached in order. If a future
+     * Monolog upgrade reshuffles a constructor and breaks the args list,
+     * this test catches it.
+     */
+    public function testReadmeCombinedExampleConstructsAllFourHandlers(): void
+    {
+        $yaml = <<<'YAML'
+        logger:
+          - class: Monolog\Handler\RotatingFileHandler
+            args:
+              - /tmp/firewall-readme-combined.log
+              - 14
+              - Monolog\Level::Info
+
+          - class: Monolog\Handler\SyslogHandler
+            args:
+              - firewall
+              - user
+              - Monolog\Level::Warning
+
+          - class: Monolog\Handler\SlackWebhookHandler
+            args:
+              - https://hooks.slack.com/services/T000/B000/test
+              - "#security-oncall"
+              - "Firewall"
+              - true
+              - ":rotating_light:"
+              - false
+              - true
+              - Monolog\Level::Critical
+
+          - class: Monolog\Handler\PushoverHandler
+            args:
+              - test-app-token
+              - test-user-key
+              - "Firewall CRITICAL"
+              - Monolog\Level::Critical
+        YAML;
+
+        $parsed = Yaml::parse($yaml);
+        $logger = LoggingFactory::create($parsed['logger']);
+
+        $handlers = $logger->getHandlers();
+        $this->assertCount(4, $handlers);
+
+        // Monolog stores handlers in reverse insertion order (LIFO).
+        $this->assertInstanceOf(PushoverHandler::class, $handlers[0]);
+        $this->assertInstanceOf(SlackWebhookHandler::class, $handlers[1]);
+        $this->assertInstanceOf(SyslogHandler::class, $handlers[2]);
+        $this->assertInstanceOf(RotatingFileHandler::class, $handlers[3]);
+    }
+
+    /**
+     * Documentation contract: passing the literal string "LOG_USER" as
+     * the syslog facility breaks because YAML does not resolve PHP
+     * constants. This test guards the README callout that warns against
+     * it — if Monolog ever starts accepting that string, the warning
+     * should be revisited.
+     */
+    public function testSyslogRejectsLiteralPhpConstantStringAsFacility(): void
+    {
+        $yaml = <<<'YAML'
+        logger:
+          - class: Monolog\Handler\SyslogHandler
+            args:
+              - firewall
+              - LOG_USER
+              - Monolog\Level::Warning
+        YAML;
+
+        $parsed = Yaml::parse($yaml);
+
+        $this->expectException(\UnexpectedValueException::class);
+        LoggingFactory::create($parsed['logger']);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #8 — expands the *Logging Configuration* section of the README with worked examples for the Monolog handlers that the issue called out (Slack, Email, Pushover, IFTTT), plus a few other commonly-requested destinations and patterns.

Added or refreshed examples:

- **File** — StreamHandler with custom LineFormatter
- **Rotating file** — RotatingFileHandler with daily rotation + retention
- **JSON-structured** — JsonFormatter for ingest into Loki/ELK/Datadog
- **Syslog** — refreshed
- **PHP error_log** — ErrorLogHandler
- **Email** — NativeMailerHandler + SendGridHandler
- **Slack** — SlackWebhookHandler (incoming webhook) + SlackHandler (token)
- **Pushover** — PushoverHandler
- **IFTTT** — IFTTTHandler
- **Telegram** — TelegramBotHandler
- **Per-handler severity thresholds** — tee Info to file, Critical to email
- **Combining multiple handlers** — production fan-out pattern

Also adds a heads-up callout that wrapper handlers like `FingersCrossedHandler`, `BufferHandler`, and `FilterHandler` take a `HandlerInterface` argument and so can't be configured purely from YAML — they need to be wired up programmatically via `LoggingFactory::setLogger()`. This is a real limitation of `LoggingFactory::create()` (it does not recursively instantiate nested handler configs in `args`), so it's worth flagging.

## Test plan

- [ ] Render the README on GitHub and confirm the new subsections show up under *Logging Configuration*
- [ ] Spot-check at least one of the new examples by pasting it into a local `config.yml` and verifying `Firewall::create()` boots without errors
- [ ] Confirm constructor argument order matches the installed Monolog 3.9.x for each handler (already cross-checked against `vendor/monolog/monolog/src/Monolog/Handler/*.php`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)