### PR TITLE
Docs: teach plugins: array format; migrate presets; fill test gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - [Platform Integration](#platform-integration)
 - [Advanced Examples](#advanced-examples)
 - [Testing](#testing)
+- [Legacy format (deprecated)](#legacy-format-deprecated)
 - [Contributing](#contributing)
 
 ## Features
@@ -105,16 +106,19 @@ storage:
   config:
     file: /var/log/firewall/blocked.data
 
-# Block malicious IPs
-block:
-  "Kanopi\\Firewall\\Plugins\\IpAddress":
+# Plugins evaluated for every request
+plugins:
+  # Block malicious IPs
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: block
     enable: true
     config:
       - 192.168.1.100
       - 10.0.0.0/24
 
   # Optional: Enable vulnerability scoring for advanced threat detection
-  # "Kanopi\\Firewall\\Plugins\\VulnerabilityScore":
+  # - plugin: "Kanopi\\Firewall\\Plugins\\VulnerabilityScore"
+  #   response: block
   #   enable: true
   #   config:
   #     scoring:
@@ -163,11 +167,12 @@ Follow these steps to quickly test Lite Firewall locally in a clean environment:
         config:
             storage_file: firewall.data
 
-    block:
-        "Kanopi\\Firewall\\Plugins\\Url":
-            enable: true
-            config:
-                - "query.block:1"   # Block any request that includes ?block=1
+    plugins:
+        - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+          response: block
+          enable: true
+          config:
+              - "query.block:1"   # Block any request that includes ?block=1
    ```
 
 4. **Create an `index.php` file**
@@ -219,13 +224,14 @@ echo "" > firewall.data
 
 The firewall configuration consists of four main sections:
 
-| Section   | Purpose                                                  | Required |
-|-----------|----------------------------------------------------------|----------|
-| `global`  | Defines global configuration settings                    | No       |
-| `storage` | Defines where blocked IP addresses are persisted         | Yes      |
-| `bypass`  | Plugins that allow trusted traffic through               | No       |
-| `block`   | Plugins that deny harmful or suspicious traffic          | No       |
-| `logger`  | Monolog handlers for logging firewall events             | No       |
+| Section   | Purpose                                                                    | Required |
+|-----------|----------------------------------------------------------------------------|----------|
+| `global`  | Defines global configuration settings                                      | No       |
+| `storage` | Defines where blocked IP addresses are persisted                           | Yes      |
+| `plugins` | Ordered list of plugin entries that allow (`response: allow`) or block (`response: block`) traffic | No       |
+| `logger`  | Monolog handlers for logging firewall events                               | No       |
+
+> **Legacy formats `bypass:` / `block:`** are still accepted and auto-normalized into `plugins:` entries at load time. See [Legacy format (deprecated)](#legacy-format-deprecated) at the end of this document. New configs should use the `plugins:` array.
 
 ## Configuration Loading & Includes
 
@@ -280,8 +286,9 @@ logger:
   - class: Monolog\Handler\StreamHandler
     args: ["logs/firewall.log", "Monolog\\Level::Info"]
 
-block:
-  "Kanopi\\Firewall\\Plugins\\GeoLocation":
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\GeoLocation"
+    response: block
     enable: true
     metadata:
       reader:
@@ -387,6 +394,13 @@ Some metadata values are commonly file paths. The loader automatically rewrites 
 
 ```text
 logger.*.args.0
+
+# New plugins: array format
+plugins.*.metadata.reader.db
+plugins.*.metadata.storage.config.file
+plugins.*.metadata.config.*
+
+# Legacy block:/bypass: format (still supported)
 (block|allow).Kanopi\Firewall\Plugins\GeoLocation.metadata.reader.db
 (block|allow).Kanopi\Firewall\Plugins\Asn.metadata.reader.db
 (block|allow).Kanopi\Firewall\Plugins\RateLimit.metadata.storage.config.file
@@ -560,71 +574,75 @@ storage:
 
 ## Plugin Architecture
 
-Plugins are the core components that evaluate incoming requests. They can be configured in two sections:
-
-- **`bypass`**: Plugins here allow requests to pass through without further evaluation
-- **`block`**: Plugins here can block requests based on configured rules
+Plugins are the core components that evaluate incoming requests. They are configured as an ordered list under the top-level `plugins:` key. Each entry declares one plugin instance and its `response` mode — either `allow` (let the request through) or `block` (reject the request).
 
 ### Common Plugin Configuration
 
-All plugins share these configuration options:
+All plugin entries share the same shape:
 
 ```yaml
-"Kanopi\\Firewall\\Plugins\\PluginName":
-  enable: true              # Whether the plugin is active
-  priority: 0               # Execution order (-100 runs before 100)
-  metadata: {}              # Plugin-specific configuration
-  config: []                # Rules or conditions for the plugin
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\PluginName"   # Fully qualified class name
+    response: block          # 'allow' (bypass match) or 'block' (reject match)
+    weight: 0                # Execution order within its response group (lower runs first)
+    enable: true             # Whether the plugin entry is active
+    metadata: {}             # Plugin-specific configuration (DB readers, storage, etc.)
+    config: []               # Rules or conditions for the plugin
 ```
 
-**YAML Syntax Note**: Class names in YAML configuration must be quoted with double backslashes:
-- ✅ Correct: `"Kanopi\\Firewall\\Plugins\\IpAddress"`
-- ❌ Wrong: `Kanopi\Firewall\Plugins\IpAddress` (missing quotes and single backslash)
-- ❌ Wrong: `\Kanopi\Firewall\Plugins\IpAddress` (leading backslash)
+The same class can appear multiple times in the list — each entry becomes its own plugin instance, so you can split rules across instances with different weights or response modes.
 
-This applies to all `type:` declarations (storage backends, rate limit storage) and plugin keys in `block:` and `bypass:` sections.
+**YAML Syntax Note**: The `plugin:` value must be quoted with double backslashes:
+- ✅ Correct: `plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"`
+- ❌ Wrong: `plugin: Kanopi\Firewall\Plugins\IpAddress` (missing quotes and single backslash)
+- ❌ Wrong: `plugin: \Kanopi\Firewall\Plugins\IpAddress` (leading backslash)
 
-### Plugin Priority and Execution Order
+This also applies to all `type:` declarations (storage backends, rate limit storage).
 
-Plugins execute in order based on their `priority` value (lower numbers run first):
+### Plugin Execution Order
 
-- **-200 to -100**: Early filters (IP whitelists, trusted networks)
+The firewall evaluates `response: allow` entries first (sorted by `weight`, lower runs first). If any allow plugin matches, the request is permitted immediately and no `response: block` plugins run. Otherwise, `response: block` entries run next (also sorted by `weight`), and the first match rejects the request.
+
+Suggested weight ranges:
+
+- **-200 to -100**: Early filters (IP allow-lists, trusted networks)
 - **-99 to -1**: Security checks (geo-blocking, ASN filtering)
-- **0**: Default priority (URL rules, user agent checks)
+- **0**: Default (URL rules, user agent checks)
 - **1 to 100**: Post-evaluation (rate limiting, logging)
-
-**Important**: Bypass plugins run before block plugins. If any bypass plugin returns `true`, the request is allowed immediately without evaluating block plugins.
 
 **Example: Layered Security**
 
 ```yaml
-bypass:
-  # Run first - whitelist office IPs
-  "Kanopi\\Firewall\\Plugins\\IpAddress":
+plugins:
+  # Run first - allow trusted office IPs
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: allow
+    weight: -200
     enable: true
-    priority: -200
     config:
       - 192.168.1.0/24
 
-block:
   # Run early - geographic blocking
-  "Kanopi\\Firewall\\Plugins\\GeoLocation":
+  - plugin: "Kanopi\\Firewall\\Plugins\\GeoLocation"
+    response: block
+    weight: -100
     enable: true
-    priority: -100
     config:
       - "country:CN"
 
   # Run after geo - vulnerability scoring
-  "Kanopi\\Firewall\\Plugins\\VulnerabilityScore":
+  - plugin: "Kanopi\\Firewall\\Plugins\\VulnerabilityScore"
+    response: block
+    weight: -50
     enable: true
-    priority: -50
     config:
       # ... scoring config ...
 
   # Run last - rate limiting
-  "Kanopi\\Firewall\\Plugins\\RateLimit":
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 100
     enable: true
-    priority: 100
     metadata:
       # ... rate limit config ...
 ```
@@ -634,10 +652,11 @@ block:
 Plugins can load rules from external files (local or remote) using the `metadata.config` option. This is useful for managing large rule sets separately:
 
 ```yaml
-block:
-  "Kanopi\\Firewall\\Plugins\\VulnerabilityScore":
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\VulnerabilityScore"
+    response: block
+    weight: -50
     enable: true
-    priority: -50
     metadata:
       # Load scoring rules from external file(s)
       config:
@@ -665,11 +684,12 @@ Evaluates requests based on IP addresses, supporting IPv4, IPv6, CIDR blocks, an
 #### Configuration Example
 
 ```yaml
-# In bypass section - whitelist trusted IPs
-bypass:
-  "Kanopi\\Firewall\\Plugins\\IpAddress":
+plugins:
+  # Allow list - trusted IPs bypass further evaluation
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: allow
+    weight: -100   # Run early
     enable: true
-    priority: -100  # Run early
     config:
       # Single IPv4 address
       - 192.168.1.1
@@ -682,11 +702,11 @@ bypass:
       # IP range (start-end)
       - 192.168.1.100-192.168.1.200
 
-# In block section - blacklist malicious IPs
-block:
-  "Kanopi\\Firewall\\Plugins\\IpAddress":
+  # Block list - reject malicious IPs
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: block
+    weight: -100
     enable: true
-    priority: -100
     config:
       - 192.168.1.50
       - 10.10.10.0/24
@@ -701,16 +721,17 @@ Evaluates requests based on geographic location using MaxMind GeoIP2 databases.
 #### Configuration Example
 
 ```yaml
-block:
-  "Kanopi\\Firewall\\Plugins\\GeoLocation":
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\GeoLocation"
+    response: block
+    weight: 0
     enable: true
-    priority: 0
     metadata:
       reader:
         # Option 1: Local database file
         type: reader
         db: /path/to/GeoLite2-City.mmdb
-        
+
         # Option 2: MaxMind web service
         # type: client
         # accountId: 123456
@@ -722,15 +743,15 @@ block:
       - "country:CN"
       - "country:RU"
       - "country.isoCode:KP"
-      
+
       # Block entire continents
       - "continent:AS"
       - "continent.code:AF"
-      
+
       # Block specific cities
       - "city:Moscow"
       - "city.name@contains:Beijing"
-      
+
       # Complex location rules
       - variable: location.timeZone
         operator: equals
@@ -762,36 +783,37 @@ Evaluates requests based on URL components and request parameters.
 #### Configuration Example
 
 ```yaml
-block:
-  "Kanopi\\Firewall\\Plugins\\Url":
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: block
+    weight: 0
     enable: true
-    priority: 0
     config:
       # Block all POST requests
       - "method:POST"
-      
+
       # Block specific paths
       - "path:/wp-admin"
       - "path@starts_with:/admin"
       - "path@contains:phpmyadmin"
       - "path@regex:/\.(sql|bak|old)$/i"
-      
+
       # Block based on host
       - "host:malicious.example.com"
       - "host@ends_with:.suspicious.com"
-      
+
       # Block based on query parameters
       - "query.cmd@exists"
       - "query.action:delete"
-      
+
       # Block based on POST data
       - "post.username:admin"
       - "post.action@in:drop,truncate,delete"
-      
+
       # Block based on headers
       - "header.user-agent@contains:bot"
       - "header.x-forwarded-for@exists"
-      
+
       # Complex URL rules
       - type: AND
         rules:
@@ -821,32 +843,33 @@ Analyzes user agent strings to identify bots, devices, browsers, and operating s
 #### Configuration Example
 
 ```yaml
-block:
-  "Kanopi\\Firewall\\Plugins\\UserAgent":
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\UserAgent"
+    response: block
+    weight: 0
     enable: true
-    priority: 0
     config:
       # Block all bots
       - "bot:true"
-      
+
       # Block specific device types
       - "device.type:desktop"
       - "device.type@in:smartphone,tablet"
-      
+
       # Block specific browsers
       - "client.name:Internet Explorer"
       - "client.type:browser"
       - "client.version@less_than:10"
-      
+
       # Block specific operating systems
       - "os.name:Windows XP"
       - "os.short_name:WIN"
       - "os.version@less_than:10"
-      
+
       # Block specific brands or models
       - "brand:Huawei"
       - "model@contains:Galaxy"
-      
+
       # Complex user agent rules
       - type: AND
         rules:
@@ -877,10 +900,11 @@ Evaluates requests based on Autonomous System Numbers (ASN) using MaxMind's GeoI
 #### Configuration Example
 
 ```yaml
-block:
-  "Kanopi\\Firewall\\Plugins\\Asn":
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Asn"
+    response: block
+    weight: 0
     enable: true
-    priority: 0
     metadata:
       reader:
         type: reader
@@ -889,7 +913,7 @@ block:
       # Block specific ASN numbers
       - "asn:13335"  # Cloudflare
       - "asn:15169"  # Google
-      
+
       # Block by organization name
       - "asn_org:CLOUDFLARENET"
       - "asn_org@contains:AMAZON"
@@ -910,16 +934,17 @@ Implements rate limiting to prevent abuse and DDoS attacks.
 #### Configuration Example
 
 ```yaml
-block:
-  "Kanopi\\Firewall\\Plugins\\RateLimit":
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 100   # Run after other plugins
     enable: true
-    priority: 100  # Run after other plugins
     metadata:
       # Default settings for all paths
       default_rate: 60        # Requests allowed
       default_sample: 60      # Time window in seconds
       default_expiration_time: 300  # Block duration in seconds
-      
+
       # Storage backend for rate limit data
       storage:
         # Option 1: Redis (recommended for production)
@@ -932,43 +957,43 @@ block:
             # auth: "password"
             # auth: ["password"]
             # auth: ["username", "password"]
-        
+
         # Option 2: File storage
         # type: "Kanopi\\Firewall\\RateLimitStorage\\FileRateLimitStorage"
         # config:
         #   file: /var/log/firewall/ratelimit.data
-        
+
         # Option 3: Database storage
         # type: "Kanopi\\Firewall\\RateLimitStorage\\DatabaseRateLimitStorage"
         # config:
         #   storage-table: firewall_ratelimit
         #   connection:
         #     dsn: "mysql://user:pass@localhost/db"
-        
+
         # Option 4: In-memory (testing only)
         # type: "Kanopi\\Firewall\\RateLimitStorage\\InMemoryRateLimitStorage"
-    
+
     config:
       # Strict rate limit for homepage
       - path: "/"
         rate: 10
         sample: 60
-      
+
       # API endpoints with higher limits
       - path: "/api/*"
         rate: 100
         sample: 60
-      
+
       # Admin area with moderate limits
       - path: "/admin/*"
         rate: 30
         sample: 60
-      
+
       # Login endpoint with strict limits
       - path: "/login"
         rate: 5
         sample: 300  # 5 attempts per 5 minutes
-      
+
       # Use regex for complex patterns
       - path: "/\.(php|asp|aspx)$/i"
         rate: 1
@@ -998,29 +1023,30 @@ Evaluates requests based on a comprehensive scoring system that combines multipl
 #### Configuration Example
 
 ```yaml
-block:
-  "Kanopi\\Firewall\\Plugins\\VulnerabilityScore":
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\VulnerabilityScore"
+    response: block
+    weight: -50   # Run after basic filters but before rate limiting
     enable: true
-    priority: -50  # Run after basic filters but before rate limiting
     metadata:
       # Default response settings
       default_expiration_time: 3600
       status_code: 403
-      
+
       # Optional: GeoIP database for country scoring
       country_reader:
         type: reader
         db: /path/to/GeoLite2-Country.mmdb
-      
+
       # Optional: ASN database for network scoring
       asn_reader:
         type: reader
         db: /path/to/GeoLite2-ASN.mmdb
-      
+
       # Load scoring rules from external file
       config:
         - vulnerability-score-rules.yml
-    
+
     config:
       scoring:
         # HTTP Method Scoring
@@ -1321,25 +1347,27 @@ config:
 The VulnerabilityScore plugin works well with other firewall plugins:
 
 ```yaml
-# Use IP whitelist to bypass scoring
-bypass:
-  "Kanopi\\Firewall\\Plugins\\IpAddress":
+plugins:
+  # Use IP allow-list to bypass scoring
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: allow
+    weight: -200
     enable: true
-    priority: -200
     config:
       - 192.168.1.0/24  # Internal network
 
-# Apply vulnerability scoring
-block:
-  "Kanopi\\Firewall\\Plugins\\VulnerabilityScore":
+  # Apply vulnerability scoring
+  - plugin: "Kanopi\\Firewall\\Plugins\\VulnerabilityScore"
+    response: block
+    weight: -50
     enable: true
-    priority: -50
     config: # ... scoring configuration ...
-  
+
   # Then apply rate limiting to scored requests
-  "Kanopi\\Firewall\\Plugins\\RateLimit":
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 100
     enable: true
-    priority: 100
     config:
       - path: "/*"
         rate: 60
@@ -1391,11 +1419,12 @@ Evaluates each request against the [OWASP Core Rule Set](https://coreruleset.org
 #### Configuration Example
 
 ```yaml
-block:
-  "Kanopi\\Firewall\\Plugins\\Crs":
-    enable: true
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Crs"
+    response: block
     # CRS work is non-trivial — run cheap IP / UA / ASN filters first.
-    priority: 50
+    weight: 50
+    enable: true
     config:
       # Paranoia level 1-4. 1 is the recommended starting point.
       paranoia: 1
@@ -1765,25 +1794,37 @@ For the full catalogue of available handlers (Telegram, Mandrill, Loggly, Elasti
 
 ## Dynamic Configuration Overrides
 
-For dynamic environments (Docker, multi-site installations), you can override YAML configuration with PHP arrays:
+For dynamic environments (Docker, multi-site installations), you can override YAML configuration with PHP arrays. Override paths target the **source YAML shape** (before plugin normalization runs), so the right path depends on how your YAML is written.
+
+**Overriding entries written in the `plugins:` array** — the path includes the list index (`0`, `1`, `2`, …) in declaration order:
 
 ```php
 <?php
 $overrides = [
     // Override storage location
     '[storage][config][file]' => $_ENV['FIREWALL_STORAGE_PATH'] ?? '/tmp/firewall.data',
-    
-    // Override GeoIP database path
-    '[block][\Kanopi\Firewall\Plugins\GeoLocation][metadata][reader][db]' => $_ENV['GEOIP_DB_PATH'],
-    
-    // Override Redis connection
-    '[block][\Kanopi\Firewall\Plugins\RateLimit][metadata][storage][config][redis][host]' => $_ENV['REDIS_HOST'] ?? 'localhost',
-    
-    // Disable a plugin
-    '[block][\Kanopi\Firewall\Plugins\UserAgent][enable]' => false,
+
+    // Override GeoIP database path on the 2nd plugin entry (index 1)
+    '[plugins][1][metadata][reader][db]' => $_ENV['GEOIP_DB_PATH'],
+
+    // Override Redis connection on the 4th plugin entry (index 3)
+    '[plugins][3][metadata][storage][config][redis][host]' => $_ENV['REDIS_HOST'] ?? 'localhost',
+
+    // Disable a plugin entry
+    '[plugins][2][enable]' => false,
 ];
 
 \Kanopi\Firewall\Firewall::create([__DIR__ . '/config.yml'], $overrides)->evaluate();
+```
+
+**Overriding entries written in the legacy `block:` / `bypass:` format** — paths still address the plugin by class name (legacy format is normalized after overrides are merged, so this continues to work):
+
+```php
+<?php
+$overrides = [
+    '[block][\Kanopi\Firewall\Plugins\GeoLocation][metadata][reader][db]' => $_ENV['GEOIP_DB_PATH'],
+    '[block][\Kanopi\Firewall\Plugins\UserAgent][enable]' => false,
+];
 ```
 
 ## Platform Integration
@@ -1879,22 +1920,25 @@ storage:
     connection:
       dsn: "mysql://firewall:secure@localhost/security"
 
-# Whitelist trusted sources
-bypass:
-  # Office IPs
-  "Kanopi\\Firewall\\Plugins\\IpAddress":
+plugins:
+  # =====================================================================
+  # Trusted sources (response: allow)
+  # =====================================================================
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: allow
+    weight: -200
     enable: true
-    priority: -200
     config:
       - 203.0.113.0/24  # Office network
       - 198.51.100.50   # VPN endpoint
 
-# Comprehensive blocking rules
-block:
+  # =====================================================================
   # Geographic restrictions
-  "Kanopi\\Firewall\\Plugins\\GeoLocation":
+  # =====================================================================
+  - plugin: "Kanopi\\Firewall\\Plugins\\GeoLocation"
+    response: block
+    weight: -100
     enable: true
-    priority: -100
     metadata:
       reader:
         type: reader
@@ -1905,18 +1949,21 @@ block:
         rules:
           - "country@in:CN,RU,KP,IR"
           - "continent:AF"
-  
-  # Block suspicious user agents
-  "Kanopi\\Firewall\\Plugins\\UserAgent":
+
+  # =====================================================================
+  # Suspicious user agents
+  # =====================================================================
+  - plugin: "Kanopi\\Firewall\\Plugins\\UserAgent"
+    response: block
+    weight: -50
     enable: true
-    priority: -50
     config:
       # Block all bots except Google and Bing
       - type: AND
         rules:
           - "bot:true"
           - "!client.name@in:Googlebot,Bingbot"
-      
+
       # Block outdated browsers
       - type: OR
         rules:
@@ -1927,11 +1974,14 @@ block:
             rules:
               - "client.name:Chrome"
               - "client.version < 80"
-  
+
+  # =====================================================================
   # Vulnerability scoring for comprehensive threat assessment
-  "Kanopi\\Firewall\\Plugins\\VulnerabilityScore":
+  # =====================================================================
+  - plugin: "Kanopi\\Firewall\\Plugins\\VulnerabilityScore"
+    response: block
+    weight: -25
     enable: true
-    priority: -25
     metadata:
       country_reader:
         type: reader
@@ -1964,28 +2014,34 @@ block:
           block: true
           status_code: 403
           expiration_time: 7200
-  
+
+  # =====================================================================
   # URL-based protection
-  "Kanopi\\Firewall\\Plugins\\Url":
+  # =====================================================================
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: block
+    weight: 0
     enable: true
-    priority: 0
     config:
       # Protect admin areas
       - type: AND
         rules:
           - "path@starts_with:/admin"
           - "!header.authorization@exists"
-      
+
       # Block vulnerability scanners
       - "path@regex:/(\.git|\.env|\.htaccess|wp-config\.php|phpmyadmin)/i"
-      
+
       # Block SQL injection attempts
       - "query@regex:/(union.*select|select.*from|insert.*into|drop.*table)/i"
-  
+
+  # =====================================================================
   # Aggressive rate limiting
-  "Kanopi\\Firewall\\Plugins\\RateLimit":
+  # =====================================================================
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 100
     enable: true
-    priority: 100
     metadata:
       default_rate: 120
       default_sample: 60
@@ -2001,11 +2057,11 @@ block:
       - path: "/api/v1/auth/*"
         rate: 5
         sample: 300
-      
+
       - path: "/api/v1/public/*"
         rate: 100
         sample: 60
-      
+
       - path: "/api/v1/private/*"
         rate: 30
         sample: 60
@@ -2106,10 +2162,11 @@ class ApiKeyValidator extends AbstractPluginBase
 Register the custom plugin in your configuration:
 
 ```yaml
-block:
-  \App\Security\Firewall\Plugins\ApiKeyValidator:
+plugins:
+  - plugin: "App\\Security\\Firewall\\Plugins\\ApiKeyValidator"
+    response: block
+    weight: -150   # Run before rate limiting
     enable: true
-    priority: -150  # Run before rate limiting
     metadata:
       api_keys:
         - "sk_live_abcd1234567890"
@@ -2151,12 +2208,14 @@ class FirewallTest extends TestCase
             'storage' => [
                 'type' => 'Kanopi\Firewall\Storage\InMemoryStorage'
             ],
-            'block' => [
-                'Kanopi\Firewall\Plugins\IpAddress' => [
+            'plugins' => [
+                [
+                    'plugin' => 'Kanopi\Firewall\Plugins\IpAddress',
+                    'response' => 'block',
                     'enable' => true,
-                    'config' => ['192.168.1.100']
-                ]
-            ]
+                    'config' => ['192.168.1.100'],
+                ],
+            ],
         ];
         
         $firewall = Firewall::create([$config]);
@@ -2172,6 +2231,60 @@ class FirewallTest extends TestCase
     }
 }
 ```
+
+## Legacy format (deprecated)
+
+Earlier versions of this library configured plugins in two separate top-level sections (`bypass:` and `block:`), each keyed by the plugin class name. This format is still accepted — `Kanopi\Firewall\Utility\PluginConfigNormalizer` rewrites it into the `plugins:` array shape at load time — but it will be removed in a future major release. New configs should use the `plugins:` array described above.
+
+**Side-by-side**
+
+| Legacy (deprecated)                             | New (`plugins:` array)               |
+|-------------------------------------------------|--------------------------------------|
+| `bypass:` section                               | entry with `response: allow`         |
+| `block:` section                                | entry with `response: block`         |
+| keyed by plugin class                           | `plugin: "..."` field on each entry  |
+| `priority:`                                     | `weight:`                            |
+| one instance per class per section              | multiple instances per class allowed |
+| deep-merges by class across `configs:` includes | appends entries across includes      |
+
+**Same config in both shapes**
+
+```yaml
+# Legacy (deprecated)
+bypass:
+  "Kanopi\\Firewall\\Plugins\\IpAddress":
+    priority: -200
+    enable: true
+    config:
+      - 192.168.1.0/24
+
+block:
+  "Kanopi\\Firewall\\Plugins\\Url":
+    priority: -10
+    enable: true
+    config:
+      - path:/wp-admin
+```
+
+```yaml
+# New (canonical)
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: allow
+    weight: -200
+    enable: true
+    config:
+      - 192.168.1.0/24
+
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: block
+    weight: -10
+    enable: true
+    config:
+      - path:/wp-admin
+```
+
+You can also mix both formats in the same config during migration — legacy entries are normalized first, then appended to whatever is already in `plugins:`.
 
 ## Contributing
 

--- a/example/config.notes.yml
+++ b/example/config.notes.yml
@@ -4,28 +4,32 @@
 #    connection:
 #      dsn: "pdo-mysql://user:user@127.0.0.1:33066/default?serverVersion=10.6"
 #
-##bypass:
-##  Kanopi\Firewall\Plugins\IpAddress:
+#plugins:
+##  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+##    response: allow
 ##    config:
 ##      - ::1
-#
-#block:
-#  Kanopi\Firewall\Plugins\Asn:
+#  - plugin: "Kanopi\\Firewall\\Plugins\\Asn"
+#    response: block
 #    enable: false
 ##    config:
 ##      - 'asn_org:ATT-INTERNET4'
-##  Kanopi\Firewall\Plugins\UserAgent:
+##  - plugin: "Kanopi\\Firewall\\Plugins\\UserAgent"
+##    response: block
 ##    config:
 ##      - "device.type:desktop"
-#  Kanopi\Firewall\Plugins\IpAddress:
+#  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+#    response: block
 #    config:
 #      - 127.0.0.1
 #      - ::1
 #      - 108.195.124.110
-##  Kanopi\Firewall\Plugins\Url:
+##  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+##    response: block
 ##    config:
 ##      - "method@starts_with:GET"
-#  Kanopi\Firewall\Plugins\RateLimit:
+#  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+#    response: block
 #    enable: false
 ##    config: ~
 
@@ -61,13 +65,35 @@ storage:
     #   port: 33066
     #   driver: 'pdo_mysql'
 
-# All plugins under here allow for the request to be allowed without being questioned.
-bypass:
-  # Namespace of the Plugin
-  Kanopi\Firewall\Plugins\IpAddress:
-    # Priority of the plugin. Executed in order from lowest to highest.
-    # Example -100 is higher than 100.
-    priority: 0
+# Plugins (canonical format)
+#
+# The plugins: array is the preferred way to declare firewall plugins. Each entry
+# is an associative map describing one plugin instance. Common fields:
+#   - plugin:   Fully qualified class name (double-quoted with escaped backslashes).
+#   - response: 'allow' (request bypasses the firewall) or 'block' (request is blocked
+#               when conditions match).
+#   - weight:   Execution order. Lower runs first (e.g., -100 runs before 100).
+#   - enable:   Whether the plugin is active.
+#   - metadata: Plugin-specific options (readers, storage, defaults, etc.).
+#   - config:   Rules or conditions consumed by the plugin.
+#
+# Evaluation order: all `response: allow` entries run first (sorted by weight),
+# then all `response: block` entries (sorted by weight).
+plugins:
+
+  # ---------------------------------------------------------------------
+  # response: allow
+  # Plugins listed with `response: allow` let the request pass without further
+  # questioning when they match. They are the canonical replacement for the
+  # legacy top-level `bypass:` section.
+  # ---------------------------------------------------------------------
+
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    # The request is allowed through (bypass) when this plugin matches.
+    response: allow
+    # Weight of the plugin. Executed in order from lowest to highest.
+    # Example -100 is higher priority than 100.
+    weight: 0
     # Enable the plugin.
     enable: false
     # Configuration for the plugin. This plugin takes a list of IP addresses in different formats.
@@ -82,14 +108,19 @@ bypass:
       # IP Range formatted as start-end
       - 127.0.0.1-127.0.0.5
 
-# All plugins under here are evaluated and if they request passes the conditions the request is blocked.
-block:
+  # ---------------------------------------------------------------------
+  # response: block
+  # Plugins listed with `response: block` are evaluated and, if the request
+  # passes their conditions, the request is blocked. This is the canonical
+  # replacement for the legacy top-level `block:` section.
+  # ---------------------------------------------------------------------
 
   # Evaluate IP Addresses.
-  Kanopi\Firewall\Plugins\IpAddress:
-    # Priority of the plugin. Executed in order from lowest to highest.
-    # Example -100 is higher than 100.
-    priority: 0
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: block
+    # Weight of the plugin. Executed in order from lowest to highest.
+    # Example -100 is higher priority than 100.
+    weight: 0
     # Enable the plugin.
     enable: false
     # Configuration for the plugin. This plugin takes a list of IP addresses in different formats.
@@ -105,8 +136,9 @@ block:
       - 127.0.0.1-127.0.0.5
 
   # Using the MaxMind GeoIP service (either local database or service),
-  Kanopi\Firewall\Plugins\GeoLocation:
-    priority: 0
+  - plugin: "Kanopi\\Firewall\\Plugins\\GeoLocation"
+    response: block
+    weight: 0
     enable: false
     # Information fed into the plugin.
     metadata:
@@ -136,8 +168,9 @@ block:
     config: ~
 
   # URLs to check against for possible spam related activity.
-  Kanopi\Firewall\Plugins\Url:
-    priority: 0
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: block
+    weight: 0
     enable: false
     # Reference the Condition section
     # Possible variables:
@@ -158,8 +191,9 @@ block:
 
   # Details related to the User Agent that is being used.
   # More information: https://devicedetector.lw1.at/
-  Kanopi\Firewall\Plugins\UserAgent:
-    priority: 0
+  - plugin: "Kanopi\\Firewall\\Plugins\\UserAgent"
+    response: block
+    weight: 0
     enable: false
     # Reference the Condition section
     # Possible variables:
@@ -178,8 +212,9 @@ block:
 
   # Use MaxMind's GeoIP database to get the ASN (Autonomous System Number).
   # More Information: https://www.arin.net/resources/guide/asn/
-  Kanopi\Firewall\Plugins\Asn:
-    priority: 0
+  - plugin: "Kanopi\\Firewall\\Plugins\\Asn"
+    response: block
+    weight: 0
     enable: false
     metadata:
       # Follows same information as the Kanopi\Firewall\Plugins\Geolocation Metadata
@@ -196,8 +231,9 @@ block:
   # The following is limited as it only takes into account the request as long as this file is located and processed.
   # This plugin won't take into account files, assets (css, js, images), or any possible other requests where this isn't
   # included as part of the bootstrapping process.
-  Kanopi\Firewall\Plugins\RateLimit:
-    priority: 0
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 0
     enable: false
     metadata:
       # Default amount of requests that can be made in the following
@@ -277,11 +313,12 @@ block:
   # CRS ruleset (SQLi, XSS, LFI, RCE, scanner detection, protocol
   # enforcement). Backed by the kanopi/crs-engine composer package, which
   # ships the parsed rules and refreshes them weekly from upstream.
-  Kanopi\Firewall\Plugins\Crs:
-    # Plugins are executed in priority order (lowest first). CRS is fairly
+  - plugin: "Kanopi\\Firewall\\Plugins\\Crs"
+    response: block
+    # Plugins are executed in weight order (lowest first). CRS is fairly
     # expensive (~3-4 ms per request once warm), so put it after the cheap
     # IP / UA / ASN filters but before any heavier downstream work.
-    priority: 50
+    weight: 50
     enable: false
     config:
       # Paranoia level 1-4. 1 has the lowest false-positive rate; higher
@@ -404,3 +441,29 @@ logger:
 #
 #
 # When referring to conditions they can be a mixture of Simple Format, Complex Format, or Grouping Format
+
+# =====================================================================
+# Legacy format (deprecated)
+# =====================================================================
+# The firewall still accepts the older top-level `bypass:` and `block:`
+# sections; they are auto-normalized into the canonical `plugins:` array
+# at load time. The new format above is preferred for all new configs.
+#
+# Mapping: `bypass:` -> `response: allow`, `block:` -> `response: block`,
+# and per-plugin `priority:` -> `weight:`.
+#
+# Mini example:
+#
+# bypass:
+#   Kanopi\Firewall\Plugins\IpAddress:
+#     priority: -200
+#     enable: true
+#     config:
+#       - 1.2.3.4
+#
+# block:
+#   Kanopi\Firewall\Plugins\Url:
+#     priority: -10
+#     enable: true
+#     config:
+#       - path:/foo

--- a/presets/RATE-LIMITING-REFERENCE.md
+++ b/presets/RATE-LIMITING-REFERENCE.md
@@ -193,8 +193,11 @@ This document provides a quick reference for all rate limits defined in the `rat
 ### Stricter Login Protection
 
 ```yaml
-block:
-  Kanopi\Firewall\Plugins\RateLimit:
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 0
+    enable: true
     config:
       - path: /login
         rate: 3      # Only 3 attempts
@@ -204,9 +207,15 @@ block:
 ### Higher API Limits for Premium Tier
 
 ```yaml
-- path: /api/premium/*
-  rate: 500
-  sample: 60
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 0
+    enable: true
+    config:
+      - path: /api/premium/*
+        rate: 500
+        sample: 60
 ```
 
 ### Disable Rate Limiting for Specific Path
@@ -214,17 +223,29 @@ block:
 Remove the path from config or set very high limits:
 
 ```yaml
-- path: /unlimited-endpoint
-  rate: 999999
-  sample: 60
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 0
+    enable: true
+    config:
+      - path: /unlimited-endpoint
+        rate: 999999
+        sample: 60
 ```
 
 ### Custom Endpoint
 
 ```yaml
-- path: /my-custom-api
-  rate: 50
-  sample: 60
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 0
+    enable: true
+    config:
+      - path: /my-custom-api
+        rate: 50
+        sample: 60
 ```
 
 ## Troubleshooting
@@ -239,7 +260,7 @@ Remove the path from config or set very high limits:
 ### Too many false positives
 
 1. Increase rate limits for affected endpoints
-2. Add IP bypass rules for trusted sources
+2. Add an IpAddress `response: allow` plugin entry for trusted sources
 3. Increase time window (sample)
 4. Check if behind proxy (ensure X-Forwarded-For is trusted)
 
@@ -278,3 +299,38 @@ Approximate overhead per request:
 - **Cache**: 1-3ms (varies by implementation)
 
 For high-traffic sites (>1000 req/sec), Redis is strongly recommended.
+
+## Legacy format (deprecated)
+
+Earlier releases configured plugins via top-level `bypass:` and `block:` sections keyed by class name. That format is still accepted but is auto-normalized at load time by `Kanopi\Firewall\Utility\PluginConfigNormalizer` into the canonical `plugins:` array, and **it will be removed in a future major version**. New configs should use the `plugins:` array.
+
+Mini side-by-side for the RateLimit plugin:
+
+Legacy (deprecated):
+
+```yaml
+block:
+  Kanopi\Firewall\Plugins\RateLimit:
+    priority: 0
+    enable: true
+    config:
+      - path: /login
+        rate: 5
+        sample: 300
+```
+
+Canonical (new):
+
+```yaml
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 0
+    enable: true
+    config:
+      - path: /login
+        rate: 5
+        sample: 300
+```
+
+Mapping: `bypass:` → `response: allow`, `block:` → `response: block`, `priority:` → `weight:`, and the class-keyed map becomes a flat list of entries with `plugin:` set to the (double-quoted, backslash-escaped) class name.

--- a/presets/README.md
+++ b/presets/README.md
@@ -86,6 +86,46 @@ Blocks common malicious PHP files, attack patterns, and suspicious URLs includin
 
 **Note**: `.well-known` directory is NOT blocked by default (required for SSL cert validation).
 
+## Configuration Format
+
+The firewall uses a canonical `plugins:` array format. Each entry in the array configures one plugin and supports the following keys:
+
+- `plugin` — Fully-qualified plugin class name (string, double-quoted with escaped backslashes, e.g. `"Kanopi\\Firewall\\Plugins\\Url"`).
+- `response` — Either `allow` (bypass / whitelist behavior) or `block` (deny / blacklist behavior).
+- `weight` — Integer execution order. Lower weights run first (e.g. `-200` before `-10` before `0`).
+- `enable` — `true`/`false` toggle for the entry.
+- `metadata` — Plugin-specific metadata (e.g. storage backends, GeoIP readers, external config file references).
+- `config` — Plugin-specific rule list or scalar configuration.
+
+Example skeleton:
+
+```yaml
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: allow
+    weight: -200
+    enable: true
+    config:
+      - 203.0.113.100/32
+
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: block
+    weight: -10
+    enable: true
+    config:
+      - path:/blocked-path
+```
+
+### Preset composition and merging
+
+When a preset is pulled in through `configs:`, the loader **appends** each included file's `plugins:` entries onto a single combined list — it does not class-key-merge entries. This means:
+
+- Two files can each declare an entry for `Kanopi\Firewall\Plugins\Url` and both will be kept as separate entries with their own `response`, `weight`, `enable`, and `config`. They are not folded into one.
+- Order of `configs:` includes does not collapse duplicates; instead, all entries land in the combined list and are then partitioned by `response` and sorted by `weight` at runtime.
+- To override an entry from a preset, add another `plugins:` entry in your main config with a lower `weight` so it runs first, or disable an unwanted plugin upstream by republishing it with `enable: false`.
+
+This is a meaningful behavior difference from the legacy `block:`/`bypass:` format (which keyed entries by class name and deep-merged). See the **Legacy format (deprecated)** section at the bottom of this document.
+
 ## Usage
 
 ### Quick Start with Malicious Request Detection
@@ -115,11 +155,14 @@ configs:
   - presets/rate-limiting.yml
 
 # Rate limiting requires storage - configure Redis (recommended)
-block:
-  Kanopi\Firewall\Plugins\RateLimit:
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 0
+    enable: true
     metadata:
       storage:
-        type: Kanopi\Firewall\RateLimitStorage\RedisRateLimitStorage
+        type: "Kanopi\\Firewall\\RateLimitStorage\\RedisRateLimitStorage"
         config:
           redis:
             host: redis
@@ -157,9 +200,10 @@ configs:
   - presets/malicious-urls.yml
 
 # Allow specific files that would otherwise be blocked
-bypass:
-  Kanopi\Firewall\Plugins\Url:
-    priority: -200
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: allow
+    weight: -200
     enable: true
     config:
       # Allow custom API endpoint
@@ -187,8 +231,11 @@ configs:
   - presets/malicious-requests.yml
 
 # Override to enable GeoIP
-block:
-  Kanopi\Firewall\Plugins\VulnerabilityScore:
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\VulnerabilityScore"
+    response: block
+    weight: -75
+    enable: true
     metadata:
       country_reader:
         type: reader
@@ -218,8 +265,11 @@ Adjust blocking sensitivity by modifying risk level thresholds:
 configs:
   - presets/malicious-requests.yml
 
-block:
-  Kanopi\Firewall\Plugins\VulnerabilityScore:
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\VulnerabilityScore"
+    response: block
+    weight: -75
+    enable: true
     config:
       risk_levels:
         # More aggressive: Lower thresholds
@@ -263,11 +313,14 @@ The rate limiting preset requires persistent storage. Choose based on your infra
 #### Redis (Recommended for Production)
 
 ```yaml
-block:
-  Kanopi\Firewall\Plugins\RateLimit:
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 0
+    enable: true
     metadata:
       storage:
-        type: Kanopi\Firewall\RateLimitStorage\RedisRateLimitStorage
+        type: "Kanopi\\Firewall\\RateLimitStorage\\RedisRateLimitStorage"
         config:
           redis:
             host: localhost
@@ -283,11 +336,14 @@ block:
 #### Database Storage
 
 ```yaml
-block:
-  Kanopi\Firewall\Plugins\RateLimit:
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 0
+    enable: true
     metadata:
       storage:
-        type: Kanopi\Firewall\RateLimitStorage\DatabaseRateLimitStorage
+        type: "Kanopi\\Firewall\\RateLimitStorage\\DatabaseRateLimitStorage"
         config:
           storage-table: firewall_ratelimit
           connection:
@@ -305,11 +361,14 @@ block:
 #### File Storage (Simple Deployments)
 
 ```yaml
-block:
-  Kanopi\Firewall\Plugins\RateLimit:
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 0
+    enable: true
     metadata:
       storage:
-        type: Kanopi\Firewall\RateLimitStorage\FileRateLimitStorage
+        type: "Kanopi\\Firewall\\RateLimitStorage\\FileRateLimitStorage"
         config:
           file: /var/lib/firewall/ratelimit.data
 ```
@@ -320,11 +379,14 @@ block:
 #### PSR-6 Cache
 
 ```yaml
-block:
-  Kanopi\Firewall\Plugins\RateLimit:
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 0
+    enable: true
     metadata:
       storage:
-        type: Kanopi\Firewall\RateLimitStorage\CacheRateLimitStorage
+        type: "Kanopi\\Firewall\\RateLimitStorage\\CacheRateLimitStorage"
         config:
           cache: '@cache.app'  # Your PSR-6 service
 ```
@@ -339,8 +401,11 @@ Override specific endpoints while keeping preset defaults:
 configs:
   - presets/rate-limiting.yml
 
-block:
-  Kanopi\Firewall\Plugins\RateLimit:
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 0
+    enable: true
     config:
       # More strict login limits
       - path: /login
@@ -412,17 +477,19 @@ This blocks **any PHP file except index.php**. This is useful for:
 
 ### Adapting the Generic PHP Block
 
-If you need to allow specific PHP files, add them to your bypass rules:
+If you need to allow specific PHP files, add an `allow` entry to your `plugins:` array:
 
 ```yaml
-bypass:
-  Kanopi\Firewall\Plugins\Url:
-    priority: -200
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: allow
+    weight: -200
+    enable: true
     config:
       - path:/contact.php
       - path:/api.php
       - path:/webhook.php
-      - path@regex:^/api/.*\.php$  # Allow all files in /api/ directory
+      - path@regex:#^/api/.*\.php$#  # Allow all files in /api/ directory
 ```
 
 Or modify the preset to exclude specific patterns:
@@ -493,7 +560,7 @@ curl -I https://yoursite.com/index.php
 curl -I https://yoursite.com/test.php
 curl -I https://yoursite.com/random.php
 
-# Should work if in bypass rules
+# Should work if explicitly allowed (response: allow entry)
 curl -I https://yoursite.com/contact.php
 ```
 
@@ -562,12 +629,14 @@ tail -f /var/log/firewall-debug.log | grep "Total vulnerability score"
 
 **Problem**: Your application has legitimate PHP files that are blocked.
 
-**Solution**: Add bypass rules for those specific files:
+**Solution**: Add an `allow` entry for those specific files:
 
 ```yaml
-bypass:
-  Kanopi\Firewall\Plugins\Url:
-    priority: -200
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: allow
+    weight: -200
+    enable: true
     config:
       - path:/my-file.php
 ```
@@ -579,9 +648,11 @@ bypass:
 **Solution**: The preset already allows `/wp-content/plugins/` and `/wp-content/themes/`. If you're still having issues:
 
 ```yaml
-bypass:
-  Kanopi\Firewall\Plugins\Url:
-    priority: -200
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: allow
+    weight: -200
+    enable: true
     config:
       - path@starts_with:/wp-content/plugins/
       - path@starts_with:/wp-content/themes/
@@ -591,12 +662,14 @@ bypass:
 
 **Problem**: Your REST API endpoints are being blocked.
 
-**Solution**: Add specific bypasses for API routes:
+**Solution**: Add specific `allow` entries for API routes:
 
 ```yaml
-bypass:
-  Kanopi\Firewall\Plugins\Url:
-    priority: -200
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: allow
+    weight: -200
+    enable: true
     config:
       - path@starts_with:/api/
       - path@starts_with:/wp-json/
@@ -608,20 +681,21 @@ You can create your own presets by following the same structure:
 
 ```yaml
 # presets/my-custom-rules.yml
-block:
-  Kanopi\Firewall\Plugins\Url:
-    priority: -100
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: allow
+    weight: -200
+    enable: true
+    config:
+      - path:/my-allowed-path
+
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: block
+    weight: -100
     enable: true
     config:
       - path:/my-blocked-path
       - path@contains:/sensitive
-
-bypass:
-  Kanopi\Firewall\Plugins\Url:
-    priority: -200
-    enable: true
-    config:
-      - path:/my-allowed-path
 ```
 
 Then include it in your main config:
@@ -630,6 +704,8 @@ Then include it in your main config:
 configs:
   - presets/my-custom-rules.yml
 ```
+
+Both entries will be appended to the combined `plugins:` list at load time. The `allow` entry runs first (lower `weight`) so trusted paths are short-circuited before the block rules execute.
 
 ## Security Recommendations
 
@@ -644,7 +720,7 @@ configs:
 - **Minimal**: URL pattern matching is very fast
 - **Regex Rules**: Slightly slower than simple string matching, but still negligible
 - **Rule Count**: Having 100+ rules has minimal performance impact
-- **Plugin Priority**: URL plugin runs early (-100) to block bad requests quickly
+- **Plugin Weight**: URL plugin runs early (`weight: -100`) to block bad requests quickly
 
 ## Contributing
 
@@ -663,3 +739,55 @@ For questions or issues:
 - Check the main [documentation](../docs/)
 - Review [example configurations](../example/)
 - Open an issue on GitHub
+
+## Legacy format (deprecated)
+
+Older configurations used top-level `bypass:` and `block:` sections keyed by plugin class. That shape is still accepted, but it is normalized at load time by `Kanopi\Firewall\Utility\PluginConfigNormalizer` into the canonical `plugins:` array, and **it will be removed in a future major version**. New configs should use the `plugins:` array directly.
+
+Mini side-by-side:
+
+Legacy (deprecated):
+
+```yaml
+bypass:
+  Kanopi\Firewall\Plugins\IpAddress:
+    priority: -200
+    enable: true
+    config:
+      - 203.0.113.100
+
+block:
+  Kanopi\Firewall\Plugins\Url:
+    priority: -10
+    enable: true
+    config:
+      - path:/foo
+```
+
+Canonical (new):
+
+```yaml
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: allow
+    weight: -200
+    enable: true
+    config:
+      - 203.0.113.100
+
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: block
+    weight: -10
+    enable: true
+    config:
+      - path:/foo
+```
+
+Mapping:
+
+- `bypass:` → `response: allow`
+- `block:` → `response: block`
+- `priority:` → `weight:`
+- Class-keyed map → flat list of entries with `plugin:` set to the (double-quoted, escaped) class name
+
+Note that the legacy format keyed entries by class name, so a class could appear at most once per file. The canonical format allows multiple entries for the same plugin class, and entries from preset includes are appended (not class-merged) into a single combined list.

--- a/presets/example-malicious-requests-usage.yml
+++ b/presets/example-malicious-requests-usage.yml
@@ -33,8 +33,9 @@ logging:
 
 # Optional: Override specific risk thresholds
 # Uncomment and adjust based on your false positive tolerance
-# block:
-#   Kanopi\Firewall\Plugins\VulnerabilityScore:
+# plugins:
+#   - plugin: "Kanopi\\Firewall\\Plugins\\VulnerabilityScore"
+#     response: block
 #     config:
 #       risk_levels:
 #         # More aggressive blocking (lower thresholds)
@@ -52,8 +53,9 @@ logging:
 
 # Optional: Enable GeoIP scoring for enhanced detection
 # Requires GeoIP databases - see example/README.md for setup
-# block:
-#   Kanopi\Firewall\Plugins\VulnerabilityScore:
+# plugins:
+#   - plugin: "Kanopi\\Firewall\\Plugins\\VulnerabilityScore"
+#     response: block
 #     metadata:
 #       country_reader:
 #         type: reader
@@ -98,11 +100,12 @@ logging:
 #           proxy: 20
 #           hosting: 5
 
-# Optional: Add bypass rules for trusted IPs or specific paths
-# bypass:
-#   # Bypass for internal/trusted IPs
-#   Kanopi\Firewall\Plugins\IpAddress:
-#     priority: -200  # Run before blocking rules
+# Optional: Add allow rules for trusted IPs or specific paths
+# plugins:
+#   # Allow internal/trusted IPs
+#   - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+#     response: allow
+#     weight: -200  # Run before blocking rules
 #     enable: true
 #     config:
 #       - 192.168.1.0/24      # Internal network
@@ -110,9 +113,10 @@ logging:
 #       - 127.0.0.1           # Localhost
 #       - 203.0.113.50        # Office IP
 #
-#   # Bypass for specific paths (e.g., webhooks, APIs)
-#   Kanopi\Firewall\Plugins\Url:
-#     priority: -200
+#   # Allow specific paths (e.g., webhooks, APIs)
+#   - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+#     response: allow
+#     weight: -200
 #     enable: true
 #     config:
 #       - path:/api/webhook
@@ -120,10 +124,11 @@ logging:
 #       - path@starts_with:/.well-known/
 
 # Optional: Add additional blocking rules
-# block:
+# plugins:
 #   # Block specific countries (requires GeoIP)
-#   Kanopi\Firewall\Plugins\GeoLocation:
-#     priority: 10
+#   - plugin: "Kanopi\\Firewall\\Plugins\\GeoLocation"
+#     response: block
+#     weight: 10
 #     enable: false  # Set to true if using
 #     metadata:
 #       reader:
@@ -134,8 +139,9 @@ logging:
 #       - country:RU
 #
 #   # Rate limiting
-#   Kanopi\Firewall\Plugins\RateLimit:
-#     priority: 100
+#   - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+#     response: block
+#     weight: 100
 #     enable: false  # Set to true if using
 #     metadata:
 #       storage:

--- a/presets/example-rate-limiting-usage.yml
+++ b/presets/example-rate-limiting-usage.yml
@@ -11,8 +11,9 @@ configs:
   - presets/rate-limiting.yml
 
 # Override to use your Redis configuration
-block:
-  Kanopi\Firewall\Plugins\RateLimit:
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
     metadata:
       storage:
         type: Kanopi\Firewall\RateLimitStorage\RedisRateLimitStorage
@@ -30,8 +31,9 @@ block:
 # configs:
 #   - presets/rate-limiting.yml
 #
-# block:
-#   Kanopi\Firewall\Plugins\RateLimit:
+# plugins:
+#   - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+#     response: block
 #     metadata:
 #       storage:
 #         type: Kanopi\Firewall\RateLimitStorage\DatabaseRateLimitStorage
@@ -52,8 +54,9 @@ block:
 # configs:
 #   - presets/rate-limiting.yml
 #
-# block:
-#   Kanopi\Firewall\Plugins\RateLimit:
+# plugins:
+#   - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+#     response: block
 #     config:
 #       # More strict API limits
 #       - path: /api/*
@@ -61,7 +64,7 @@ block:
 #         sample: 60
 #
 #       # Allow more login attempts for internal network
-#       # (Use with IP bypass rules)
+#       # (Use with IP allow rules)
 #       - path: /login
 #         rate: 20      # 20 instead of default 10
 #         sample: 300
@@ -73,13 +76,15 @@ block:
 # configs:
 #   - presets/rate-limiting.yml
 #
-# block:
-#   Kanopi\Firewall\Plugins\RateLimit:
+# plugins:
+#   - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+#     response: block
 #     enable: false  # Completely disable in dev
 #
 # OR use very high limits:
-# block:
-#   Kanopi\Firewall\Plugins\RateLimit:
+# plugins:
+#   - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+#     response: block
 #     metadata:
 #       default_rate: 10000
 #       default_sample: 60
@@ -88,9 +93,10 @@ block:
 # EXAMPLE 5: API-Only Application
 # =============================================================================
 # Simplified rate limiting for API-only apps
-# block:
-#   Kanopi\Firewall\Plugins\RateLimit:
-#     priority: 100
+# plugins:
+#   - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+#     response: block
+#     weight: 100
 #     enable: true
 #     metadata:
 #       default_rate: 100
@@ -138,8 +144,9 @@ block:
 # configs:
 #   - presets/rate-limiting.yml
 #
-# block:
-#   Kanopi\Firewall\Plugins\RateLimit:
+# plugins:
+#   - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+#     response: block
 #     config:
 #       # Free tier
 #       - path: /api/free/*
@@ -164,8 +171,9 @@ block:
 #   - presets/rate-limiting.yml
 #   - presets/wordpress.yml  # Combine with WordPress preset
 #
-# block:
-#   Kanopi\Firewall\Plugins\RateLimit:
+# plugins:
+#   - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+#     response: block
 #     metadata:
 #       default_rate: 100
 #       default_sample: 60
@@ -200,9 +208,10 @@ block:
 # EXAMPLE 8: E-Commerce Site
 # =============================================================================
 # Rate limits optimized for online stores
-# block:
-#   Kanopi\Firewall\Plugins\RateLimit:
-#     priority: 100
+# plugins:
+#   - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+#     response: block
+#     weight: 100
 #     enable: true
 #     metadata:
 #       default_rate: 120
@@ -249,16 +258,17 @@ block:
 #         sample: 300
 
 # =============================================================================
-# EXAMPLE 9: Bypass Rate Limits for Trusted IPs
+# EXAMPLE 9: Allow Rate Limits for Trusted IPs
 # =============================================================================
-# Combine rate limiting with IP bypass rules
+# Combine rate limiting with IP allow rules
 configs:
   - presets/rate-limiting.yml
 
-bypass:
-  # Bypass ALL checks for trusted IPs (including rate limits)
-  Kanopi\Firewall\Plugins\IpAddress:
-    priority: -200  # Execute before rate limiting
+plugins:
+  # Allow ALL checks for trusted IPs (including rate limits)
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: allow
+    weight: -200  # Execute before rate limiting
     enable: true
     config:
       - 192.168.1.0/24  # Internal network
@@ -272,8 +282,9 @@ bypass:
 # configs:
 #   - presets/rate-limiting.yml
 #
-# block:
-#   Kanopi\Firewall\Plugins\RateLimit:
+# plugins:
+#   - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+#     response: block
 #     metadata:
 #       storage:
 #         type: Kanopi\Firewall\RateLimitStorage\FileRateLimitStorage

--- a/presets/example-usage.yml
+++ b/presets/example-usage.yml
@@ -19,12 +19,16 @@ storage:
     file: /tmp/firewall-blocked-ips.data
 
 # =====================================================================
-# Bypass Rules (Whitelist)
+# Plugin Configuration
+#
+# Allow entries (response: allow) run first, then block entries
+# (response: block), sorted by weight (lower runs first).
 # =====================================================================
-bypass:
+plugins:
   # Allow admin access from office/VPN IPs
-  Kanopi\Firewall\Plugins\IpAddress:
-    priority: -200
+  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+    response: allow
+    weight: -200
     enable: true
     config:
       # Office IP
@@ -35,8 +39,9 @@ bypass:
       - 198.51.100.50/32
 
   # Allow legitimate PHP files that would be blocked by generic rule
-  Kanopi\Firewall\Plugins\Url:
-    priority: -200
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: allow
+    weight: -200
     enable: true
     config:
       # Custom contact form
@@ -54,14 +59,11 @@ bypass:
       # Allow WordPress REST API (if needed)
       - path@starts_with:/wp-json/
 
-# =====================================================================
-# Additional Blocking Rules
-# =====================================================================
-block:
   # Rate limiting for login attempts
-  Kanopi\Firewall\Plugins\RateLimit:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: -90
     enable: true
-    priority: -90
     metadata:
       default_rate: 5              # Max 5 requests
       default_sample: 60           # Per 60 seconds
@@ -84,8 +86,9 @@ block:
           - method:POST
 
   # Optional: Block specific countries (requires GeoLocation plugin + GeoIP database)
-  # Kanopi\Firewall\Plugins\GeoLocation:
-  #   priority: -50
+  # - plugin: "Kanopi\\Firewall\\Plugins\\GeoLocation"
+  #   response: block
+  #   weight: -50
   #   enable: true
   #   metadata:
   #     reader:
@@ -98,8 +101,9 @@ block:
   #     - country:KP
 
   # Optional: Block specific ASNs (requires ASN plugin + GeoIP database)
-  # Kanopi\Firewall\Plugins\Asn:
-  #   priority: -50
+  # - plugin: "Kanopi\\Firewall\\Plugins\\Asn"
+  #   response: block
+  #   weight: -50
   #   enable: true
   #   metadata:
   #     reader:

--- a/presets/malicious-requests.yml
+++ b/presets/malicious-requests.yml
@@ -29,9 +29,10 @@
 # For country and ASN scoring, you must configure GeoIP databases.
 # See example/README.md for setup instructions.
 
-block:
-  Kanopi\Firewall\Plugins\VulnerabilityScore:
-    priority: 50
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\VulnerabilityScore"
+    response: block
+    weight: 50
     enable: true
 
     metadata:

--- a/presets/malicious-urls.yml
+++ b/presets/malicious-urls.yml
@@ -6,9 +6,10 @@
 # Note: This is a complement to the WordPress blocking configuration and can be
 # used with any PHP application (WordPress, Drupal, Laravel, etc.)
 
-block:
-  Kanopi\Firewall\Plugins\Url:
-    priority: -100
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: block
+    weight: -100
     enable: true
     config:
       # =====================================================================
@@ -157,9 +158,10 @@ block:
 # 2. If you have custom PHP files at the root level (like contact.php, api.php),
 #    you'll need to add bypass rules:
 #
-#    bypass:
-#      Kanopi\Firewall\Plugins\Url:
-#        priority: -200
+#    plugins:
+#      - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+#        response: allow
+#        weight: -200
 #        config:
 #          - path:/contact.php
 #          - path:/api.php

--- a/presets/rate-limiting.yml
+++ b/presets/rate-limiting.yml
@@ -22,9 +22,10 @@
 #
 # See configuration examples below.
 
-block:
-  Kanopi\Firewall\Plugins\RateLimit:
-    priority: 100
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\RateLimit"
+    response: block
+    weight: 100
     enable: true
 
     metadata:

--- a/presets/wordpress.yml
+++ b/presets/wordpress.yml
@@ -3,9 +3,10 @@
 # Blocks common WordPress admin pages, sensitive files, and attack vectors
 # while allowing normal website functionality.
 
-block:
-  Kanopi\Firewall\Plugins\Url:
-    priority: -100
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: block
+    weight: -100
     enable: true
     config:
       # =====================================================================
@@ -113,9 +114,10 @@ block:
 # Uncomment and configure if you need to allow specific IPs to access
 # WordPress admin or other blocked endpoints
 #
-# bypass:
-#   Kanopi\Firewall\Plugins\IpAddress:
-#     priority: -200
+# plugins:
+#   - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+#     response: allow
+#     weight: -200
 #     enable: true
 #     config:
 #       # Allow office IP

--- a/tests/Unit/FirewallTest.php
+++ b/tests/Unit/FirewallTest.php
@@ -606,6 +606,100 @@ class FirewallTest extends AbstractTestCase
     }
 
     /**
+     * Test that a `response: block` entry actually blocks at runtime when no
+     * `response: allow` entries match. The counterpart to
+     * testBypassEvaluatedBeforeBlock, verifying that response: block entries
+     * are routed to the blocking PluginManager (not the bypass manager) and
+     * reach sendBlockingResponse().
+     */
+    public function testResponseBlockEntryBlocksAtRuntime(): void
+    {
+        $config = [
+            'plugins' => [
+                [
+                    'plugin' => IpAddress::class,
+                    'response' => 'allow',
+                    'weight' => -100,
+                    'enable' => true,
+                    'config' => ['10.0.0.1'],  // does NOT match the request below
+                ],
+                [
+                    'plugin' => IpAddress::class,
+                    'response' => 'block',
+                    'weight' => 0,
+                    'enable' => true,
+                    'config' => ['127.0.0.1'], // matches the request below
+                ],
+            ],
+            'global' => [
+                'mode' => 'exception',
+            ],
+        ];
+
+        $firewall = Firewall::create([$config]);
+        $request = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '127.0.0.1']);
+
+        $this->expectException(FirewallBlockedException::class);
+        $firewall->evaluate($request);
+    }
+
+    /**
+     * Regression test for end-to-end routing in mixed (new + legacy) configs:
+     * the normalizer must put `bypass:` entries into the bypass manager and
+     * `block:` entries into the block manager, alongside any `plugins:` array
+     * entries, with all weights respected.
+     */
+    public function testMixedFormatRoutesLegacyAndNewEntriesToCorrectManager(): void
+    {
+        $config = [
+            // New-format allow entry for 10.0.0.1
+            'plugins' => [
+                [
+                    'plugin' => IpAddress::class,
+                    'response' => 'allow',
+                    'weight' => -100,
+                    'enable' => true,
+                    'config' => ['10.0.0.1'],
+                ],
+            ],
+            // Legacy bypass for 10.0.0.2
+            'bypass' => [
+                IpAddress::class => [
+                    'priority' => -100,
+                    'enable' => true,
+                    'config' => ['10.0.0.2'],
+                ],
+            ],
+            // Legacy block for 127.0.0.1
+            'block' => [
+                IpAddress::class => [
+                    'priority' => 0,
+                    'enable' => true,
+                    'config' => ['127.0.0.1'],
+                ],
+            ],
+            'global' => [
+                'mode' => 'exception',
+            ],
+        ];
+
+        $firewall = Firewall::create([$config]);
+
+        // Request from a new-format allow IP: passes.
+        $allowRequestNew = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.1']);
+        $this->assertTrue($firewall->evaluate($allowRequestNew), 'New-format allow should pass.');
+
+        // Request from a legacy bypass IP: passes.
+        $allowRequestLegacy = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.2']);
+        $this->assertTrue($firewall->evaluate($allowRequestLegacy), 'Legacy bypass should pass.');
+
+        // Request from the legacy block IP: blocks.
+        $blockRequest = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '127.0.0.1']);
+        $this->expectException(FirewallBlockedException::class);
+        $firewall->evaluate($blockRequest);
+    }
+
+    /**
      * Test that bypass (allow) plugins are evaluated before block plugins.
      */
     public function testBypassEvaluatedBeforeBlock(): void

--- a/tests/Unit/Plugins/PluginManagerTest.php
+++ b/tests/Unit/Plugins/PluginManagerTest.php
@@ -7,6 +7,7 @@ namespace Kanopi\Firewall\Tests\Unit\Plugins;
 use Kanopi\Firewall\Plugins\PluginInterface;
 use Kanopi\Firewall\Plugins\PluginManager;
 use Kanopi\Firewall\Tests\Plugins\TestFalsePlugin;
+use Kanopi\Firewall\Tests\Plugins\TestPluginWithMetadata;
 use Kanopi\Firewall\Tests\Plugins\TestPriorityPluginHigh;
 use Kanopi\Firewall\Tests\Plugins\TestPriorityPluginLow;
 use Kanopi\Firewall\Tests\Plugins\TestTruePlugin;
@@ -281,5 +282,110 @@ class PluginManagerTest extends AbstractTestCase
             [TestPriorityPluginLow::class, TestPriorityPluginHigh::class],
             $callOrder
         );
+    }
+
+    /**
+     * Test: createFromPluginsArray passes the entry's metadata to the plugin
+     * constructor. Regression for a coverage gap where metadata propagation
+     * for the new plugins: array format was unverified end-to-end.
+     */
+    public function testCreateFromPluginsArrayPropagatesMetadataToPlugin(): void
+    {
+        TestPluginWithMetadata::$lastMetadata = [];
+        TestPluginWithMetadata::$lastConfig = [];
+
+        $manager = PluginManager::createFromPluginsArray([
+            [
+                'plugin' => TestPluginWithMetadata::class,
+                'weight' => 0,
+                'enable' => true,
+                'metadata' => [
+                    'db' => '/path/to/file.mmdb',
+                    'nested' => ['key' => 'value'],
+                ],
+                'config' => ['rule-a', 'rule-b'],
+            ],
+        ]);
+
+        // Iterating the manager forces lazy instantiation of the plugin.
+        $manager->evaluate(new Request());
+
+        $this->assertSame(
+            ['db' => '/path/to/file.mmdb', 'nested' => ['key' => 'value']],
+            TestPluginWithMetadata::$lastMetadata
+        );
+    }
+
+    /**
+     * Test: createFromPluginsArray passes the entry's config rules to the plugin
+     * constructor. Companion to the metadata propagation test above.
+     */
+    public function testCreateFromPluginsArrayPropagatesConfigToPlugin(): void
+    {
+        TestPluginWithMetadata::$lastMetadata = [];
+        TestPluginWithMetadata::$lastConfig = [];
+
+        $manager = PluginManager::createFromPluginsArray([
+            [
+                'plugin' => TestPluginWithMetadata::class,
+                'weight' => 0,
+                'enable' => true,
+                'config' => ['rule-a', 'rule-b', ['nested' => 'rule-c']],
+            ],
+        ]);
+
+        $manager->evaluate(new Request());
+
+        $this->assertSame(
+            ['rule-a', 'rule-b', ['nested' => 'rule-c']],
+            TestPluginWithMetadata::$lastConfig
+        );
+    }
+
+    /**
+     * Test: createFromPluginsArray defaults missing metadata and config to
+     * empty arrays rather than failing or passing nulls.
+     */
+    public function testCreateFromPluginsArrayDefaultsMissingMetadataAndConfig(): void
+    {
+        TestPluginWithMetadata::$lastMetadata = ['stale'];
+        TestPluginWithMetadata::$lastConfig = ['stale'];
+
+        $manager = PluginManager::createFromPluginsArray([
+            [
+                'plugin' => TestPluginWithMetadata::class,
+                'weight' => 0,
+                'enable' => true,
+                // No metadata, no config keys.
+            ],
+        ]);
+
+        $manager->evaluate(new Request());
+
+        $this->assertSame([], TestPluginWithMetadata::$lastMetadata);
+        $this->assertSame([], TestPluginWithMetadata::$lastConfig);
+    }
+
+    /**
+     * Test: createFromPluginsArray registers an entry that omits `enable`.
+     *
+     * The new format documents enable defaulting to true. PluginManager itself
+     * registers every entry — the disabled filter lives in
+     * PluginConfigNormalizer::partitionAndSort(), but a defensive default in
+     * the manager is still worth pinning down so that a config that skips
+     * `enable` doesn't silently drop the plugin if it ever bypasses the
+     * normalizer (e.g., direct callers, future code paths).
+     */
+    public function testCreateFromPluginsArrayRegistersEntryWithoutEnableKey(): void
+    {
+        $manager = PluginManager::createFromPluginsArray([
+            [
+                'plugin' => TestFalsePlugin::class,
+                'weight' => 0,
+                // No `enable` key — entry should still register.
+            ],
+        ]);
+
+        $this->assertCount(1, $manager->getPlugins());
     }
 }


### PR DESCRIPTION
## Summary

- Rewrites all user-facing docs to teach the canonical `plugins:` array format (with `response: allow|block`, `weight:`, `enable:`, `metadata:`, `config:`) instead of the legacy `bypass:`/`block:` class-keyed format. The legacy format is still accepted — `PluginConfigNormalizer` rewrites it at load time — and is now documented in a single "Legacy format (deprecated)" subsection at the end of each doc.
- Migrates the 4 production preset YAMLs and 3 `example-*-usage.yml` files to the new format so the canonical shape is what users copy from.
- Adds tests for the coverage gaps the audit surfaced for the new format (metadata/config propagation, defaults, runtime response routing).

## What changed

**Docs (4 files)**
- `README.md` — every plugin example (IpAddress, GeoLocation, Url, UserAgent, Asn, RateLimit, VulnerabilityScore, Crs, custom plugin), Configuration Overview table, Plugin Architecture section, Dynamic Configuration Overrides (now shows both source shapes since override paths address the YAML pre-normalization), Example Test Case. New trailing "Legacy format (deprecated)" subsection with side-by-side comparison.
- `example/config.notes.yml` — full reference file converted (8 plugin entries: 1 allow, 7 block) + legacy mini-example trailer.
- `presets/README.md` — added "Configuration Format" and "Preset composition and merging" sections; converted 11 inline YAML snippets; appended Legacy section.
- `presets/RATE-LIMITING-REFERENCE.md` — 4 snippets converted; Legacy section appended.

**Preset YAMLs (7 files)**
- `wordpress.yml`, `malicious-requests.yml`, `malicious-urls.yml`, `rate-limiting.yml` — 4 production presets migrated.
- `example-usage.yml`, `example-malicious-requests-usage.yml`, `example-rate-limiting-usage.yml` — 22+ plugin entries migrated across teaching scenarios (including commented examples).

**Tests (2 files)**
- `tests/Unit/Plugins/PluginManagerTest.php` — 3 new tests for `createFromPluginsArray()`: metadata propagation, config propagation, missing-`enable`-key default. (Uses the previously-orphaned `TestPluginWithMetadata`.)
- `tests/Unit/FirewallTest.php` — 2 new tests: `response: block` actually blocks at runtime (counterpart to the existing allow-first test), and mixed new+legacy configs route entries from both shapes to the correct manager.

## Behavioral note (no code change)

Preset composition semantics differ slightly between the two formats: under `plugins:`, `ConfigLoader` *appends* entries across `configs:` includes (no class-keyed deep-merge). This is the existing behavior of `ConfigLoader.php:272-273`; it's now documented explicitly in `presets/README.md` so preset consumers know how to override (use `weight:` / `enable:` rather than relying on class-keyed merge).

## Test plan

- [x] `vendor/bin/phpunit --filter "PluginManagerTest|PluginConfigNormalizerTest|FirewallTest"` — 71/71 pass
- [x] `vendor/bin/phpunit` (full suite) — 700/700 non-Redis tests pass. The 6 Redis-related errors are pre-existing on `2.x` (local env lacks `ext-redis`) and are not caused by this change.
- [ ] CI on this PR is green.
- [ ] Spot-check rendered README on GitHub — TOC link to "Legacy format (deprecated)" works and tables render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)