### PR TITLE
Add `response: challenge` plugin type (Fixes #39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - [Multiple Offenses Defense](#multiple-offenses-defense)
 - [Storage Configuration](#storage-configuration)
 - [Plugin Architecture](#plugin-architecture)
+  - [Challenge Response Type](#challenge-response-type)
 - [Available Plugins](#available-plugins)
   - [IP Address Plugin](#ip-address-plugin)
   - [GeoLocation Plugin](#geolocation-plugin)
@@ -222,14 +223,15 @@ echo "" > firewall.data
 
 ## Configuration Overview
 
-The firewall configuration consists of four main sections:
+The firewall configuration consists of five main sections:
 
-| Section   | Purpose                                                                    | Required |
-|-----------|----------------------------------------------------------------------------|----------|
-| `global`  | Defines global configuration settings                                      | No       |
-| `storage` | Defines where blocked IP addresses are persisted                           | Yes      |
-| `plugins` | Ordered list of plugin entries that allow (`response: allow`) or block (`response: block`) traffic | No       |
-| `logger`  | Monolog handlers for logging firewall events                               | No       |
+| Section     | Purpose                                                                    | Required |
+|-------------|----------------------------------------------------------------------------|----------|
+| `global`    | Defines global configuration settings                                      | No       |
+| `storage`   | Defines where blocked IP addresses are persisted                           | Yes      |
+| `plugins`   | Ordered list of plugin entries that allow (`response: allow`), challenge (`response: challenge`), or block (`response: block`) traffic | No       |
+| `challenge` | Settings for the interstitial flow (provider, HMAC secret, cookie / header names). Required iff any plugin uses `response: challenge`. See [Challenge Response Type](#challenge-response-type). | Conditional |
+| `logger`    | Monolog handlers for logging firewall events                               | No       |
 
 > **Legacy formats `bypass:` / `block:`** are still accepted and auto-normalized into `plugins:` entries at load time. See [Legacy format (deprecated)](#legacy-format-deprecated) at the end of this document. New configs should use the `plugins:` array.
 
@@ -574,7 +576,7 @@ storage:
 
 ## Plugin Architecture
 
-Plugins are the core components that evaluate incoming requests. They are configured as an ordered list under the top-level `plugins:` key. Each entry declares one plugin instance and its `response` mode — either `allow` (let the request through) or `block` (reject the request).
+Plugins are the core components that evaluate incoming requests. They are configured as an ordered list under the top-level `plugins:` key. Each entry declares one plugin instance and its `response` mode — either `allow` (let the request through), `block` (reject the request), or `challenge` (require the visitor to solve an interstitial before continuing).
 
 ### Common Plugin Configuration
 
@@ -583,7 +585,7 @@ All plugin entries share the same shape:
 ```yaml
 plugins:
   - plugin: "Kanopi\\Firewall\\Plugins\\PluginName"   # Fully qualified class name
-    response: block          # 'allow' (bypass match) or 'block' (reject match)
+    response: block          # 'allow', 'block', or 'challenge'
     weight: 0                # Execution order within its response group (lower runs first)
     enable: true             # Whether the plugin entry is active
     metadata: {}             # Plugin-specific configuration (DB readers, storage, etc.)
@@ -601,7 +603,12 @@ This also applies to all `type:` declarations (storage backends, rate limit stor
 
 ### Plugin Execution Order
 
-The firewall evaluates `response: allow` entries first (sorted by `weight`, lower runs first). If any allow plugin matches, the request is permitted immediately and no `response: block` plugins run. Otherwise, `response: block` entries run next (also sorted by `weight`), and the first match rejects the request.
+The firewall evaluates `response: allow` entries first (sorted by `weight`, lower runs first). If any allow plugin matches, the request is permitted immediately and no other plugins run. Otherwise:
+
+1. `response: challenge` entries run next. If one matches and the visitor does **not** already hold a valid pass token, an interstitial is served and the request is paused until the challenge is solved.
+2. `response: block` entries run last and the first match rejects the request.
+
+A valid pass token (set by a previously solved challenge) short-circuits the challenge bucket but does **not** suppress block plugins. See [Challenge Response Type](#challenge-response-type) below.
 
 Suggested weight ranges:
 
@@ -646,6 +653,53 @@ plugins:
     metadata:
       # ... rate limit config ...
 ```
+
+### Challenge Response Type
+
+`response: challenge` serves an interstitial (a CAPTCHA-style proof-of-effort page) when a plugin matches, instead of rejecting the request outright. A visitor who solves the challenge is issued an HMAC-signed pass token that short-circuits any future `response: challenge` plugin until the token expires.
+
+The pass token is:
+
+- **Signed** with the configured `challenge.secret` (HMAC-SHA256) so it cannot be forged.
+- **IP-bound** — the token only verifies for the same client IP that solved the challenge.
+- **Delivered two ways** — as an `HttpOnly; Secure; SameSite=Strict` cookie *and* as a value the interstitial JS writes to `localStorage` so SPA callers can attach it to XHRs via a custom header (defaults to `X-Firewall-Challenge`).
+- **Expires** after `metadata.default_expiration_time` seconds for the matched plugin (default `3600`).
+
+#### Minimum configuration
+
+```yaml
+challenge:
+  provider: math                # 'math' is the built-in; or a FQCN that implements ChallengeProviderInterface
+  secret: "${FIREWALL_SECRET}"  # REQUIRED. Long random string, ideally from an env var.
+  cookie_name: fw_challenge_pass
+  header_name: X-Firewall-Challenge
+  path: /_firewall/challenge    # The URL the interstitial POSTs to
+
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Asn"
+    response: challenge
+    weight: -10
+    enable: true
+    metadata:
+      default_expiration_time: 3600   # Pass token TTL in seconds
+    config:
+      - "asn:AS14618"   # Show the challenge to AWS traffic
+```
+
+If any plugin uses `response: challenge`, `challenge.secret` is **required**. Startup fails fast with `ConfigurationException` when it is empty — the firewall will not silently fall back to plaintext tokens.
+
+#### Built-in provider
+
+The `math` provider asks "What is A + B?" with single-digit operands. It's a low-friction proof-of-effort, not a CAPTCHA. For stronger bot resistance, implement `Kanopi\Firewall\Challenge\ChallengeProviderInterface` (Turnstile, hCaptcha, reCAPTCHA, etc.) and set `challenge.provider` to its FQCN.
+
+#### How dispatch interacts with allow / block
+
+| Visitor state                          | Result                                       |
+|----------------------------------------|----------------------------------------------|
+| Matched by an `allow` plugin           | Allowed (challenge skipped).                 |
+| Holds a valid pass token + matches `challenge` | Allowed (challenge bucket skipped).  |
+| No token, matches a `challenge` plugin | Interstitial served; original URL is remembered for the post-success redirect. |
+| Matches a `block` plugin               | Blocked, even if a valid pass token is held. |
 
 ### Loading External Plugin Configuration
 

--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,32 @@
         "test:coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit -c ./phpunit.xml --coverage-html reports/ --coverage-text",
         "cs": "@check:code",
         "cs:fix": "@fix:code",
-        "stan": "@check:security"
+        "stan": "@check:security",
+        "demo:reset": "rm -f /tmp/firewall-demo.data",
+        "demo": [
+            "Composer\\Config::disableProcessTimeout",
+            "@demo:reset",
+            "php -S localhost:8000 -t example/demo example/demo/index.php"
+        ],
+        "demo:workers": [
+            "Composer\\Config::disableProcessTimeout",
+            "@demo:reset",
+            "PHP_CLI_SERVER_WORKERS=8 php -S localhost:8000 -t example/demo example/demo/index.php"
+        ],
+        "demo:perf": [
+            "Composer\\Config::disableProcessTimeout",
+            "docker compose -f example/demo/docker-compose.perf.yml up"
+        ],
+        "demo:perf:down": "docker compose -f example/demo/docker-compose.perf.yml down",
+        "demo:perf:restart": "docker compose -f example/demo/docker-compose.perf.yml restart php"
+    },
+    "scripts-descriptions": {
+        "demo": "Run the demo on PHP's built-in server (single-process) at http://localhost:8000",
+        "demo:workers": "Same as `demo` but with PHP_CLI_SERVER_WORKERS=8 for concurrent request handling",
+        "demo:reset": "Delete the demo's FileStorage data file (/tmp/firewall-demo.data) so the next request starts with a clean slate",
+        "demo:perf": "Run the production-shaped demo stack (nginx + php-fpm) at http://localhost:8000",
+        "demo:perf:down": "Tear down the nginx + php-fpm demo stack",
+        "demo:perf:restart": "Restart only the php-fpm container (handy when opcache holds stale bytecode after edits)"
     },
     "prefer-stable": true,
     "minimum-stability": "dev",

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,6 +1,26 @@
 global: ~
 storage: ~
 plugins: []
+# Settings for the `response: challenge` flow. Defaults below apply when
+# at least one plugin uses `response: challenge`; if no challenge plugins
+# are configured this section is ignored.
+#   secret:      HMAC key for signing pass tokens. REQUIRED when challenge
+#                plugins are active. Use a long random string, typically
+#                injected from an env var (Config supports `${VAR}`).
+#   provider:    Built-in short name (`math`) or a FQCN that implements
+#                Kanopi\Firewall\Challenge\ChallengeProviderInterface.
+#   path:        URL the interstitial form POSTs to.
+#   cookie_name: Cookie that carries the pass token after a successful
+#                challenge. Set to "" to disable the cookie delivery path.
+#   header_name: Header the interstitial JS stashes in localStorage and
+#                that SPA callers send on subsequent XHRs. Set to "" to
+#                disable the localStorage delivery path.
+challenge:
+  provider: math
+  secret: ''
+  path: /_firewall/challenge
+  cookie_name: fw_challenge_pass
+  header_name: X-Firewall-Challenge
 # Legacy format (deprecated, auto-converted to plugins:)
 bypass: ~
 block: ~

--- a/example/config.notes.yml
+++ b/example/config.notes.yml
@@ -65,20 +65,54 @@ storage:
     #   port: 33066
     #   driver: 'pdo_mysql'
 
+# Challenge configuration
+#
+# Settings that govern the `response: challenge` interstitial flow. This whole
+# section is ignored when no plugin uses `response: challenge`. When any
+# plugin does, `secret` is REQUIRED — startup throws ConfigurationException
+# if it is empty.
+challenge:
+  # Short name of a built-in provider ("math") or FQCN of a class that
+  # implements Kanopi\Firewall\Challenge\ChallengeProviderInterface.
+  # The built-in "math" provider asks "What is A + B?" with single-digit
+  # operands — a low-friction proof-of-effort, not a CAPTCHA.
+  provider: math
+  # HMAC secret used to sign pass tokens. MUST be a long, random value. The
+  # `${VAR}` syntax loads it from an env var so it stays out of source control.
+  secret: '${FIREWALL_CHALLENGE_SECRET}'
+  # URL the interstitial form POSTs to. Configurable so it can avoid colliding
+  # with application routes.
+  path: /_firewall/challenge
+  # Cookie that carries the pass token (HttpOnly; Secure; SameSite=Strict).
+  # Set to "" to disable the cookie delivery path.
+  cookie_name: fw_challenge_pass
+  # Custom request header that SPA callers can send with the same pass token
+  # (read back from localStorage after a successful challenge). Set to "" to
+  # disable the localStorage / header delivery path.
+  header_name: X-Firewall-Challenge
+
 # Plugins (canonical format)
 #
 # The plugins: array is the preferred way to declare firewall plugins. Each entry
 # is an associative map describing one plugin instance. Common fields:
 #   - plugin:   Fully qualified class name (double-quoted with escaped backslashes).
-#   - response: 'allow' (request bypasses the firewall) or 'block' (request is blocked
-#               when conditions match).
+#   - response: 'allow'     - request bypasses the firewall when matched.
+#               'block'     - request is rejected when matched.
+#               'challenge' - visitor is shown a CAPTCHA-style interstitial; on
+#                             success they get a signed pass token that
+#                             short-circuits future challenge plugins for
+#                             metadata.default_expiration_time seconds.
 #   - weight:   Execution order. Lower runs first (e.g., -100 runs before 100).
 #   - enable:   Whether the plugin is active.
 #   - metadata: Plugin-specific options (readers, storage, defaults, etc.).
 #   - config:   Rules or conditions consumed by the plugin.
 #
-# Evaluation order: all `response: allow` entries run first (sorted by weight),
-# then all `response: block` entries (sorted by weight).
+# Evaluation order: `response: allow` runs first, then `response: challenge`
+# (skipped if the visitor already holds a valid pass token), then `response: block`.
+# Each bucket is sorted by weight independently.
+#
+# `response: challenge` also requires a top-level `challenge:` section. See the
+# Challenge Configuration block below.
 plugins:
 
   # ---------------------------------------------------------------------
@@ -107,6 +141,34 @@ plugins:
       - 10.0.0.1/24
       # IP Range formatted as start-end
       - 127.0.0.1-127.0.0.5
+
+  # ---------------------------------------------------------------------
+  # response: challenge
+  # Plugins listed with `response: challenge` serve an interstitial when they
+  # match. The visitor solves a CAPTCHA-style proof-of-effort (the built-in
+  # provider asks "What is A + B?") and on success receives an HMAC-signed
+  # pass token bound to their IP. Subsequent requests carrying that token
+  # (via cookie or via a custom header populated from localStorage) skip
+  # the challenge bucket until the token expires.
+  #
+  # `metadata.default_expiration_time` controls the pass-token TTL (seconds).
+  # Block plugins still apply — a pass token only attests "I am human", not
+  # "I am allowed everywhere."
+  #
+  # Requires a top-level `challenge:` section (see further down in this file).
+  # ---------------------------------------------------------------------
+
+  - plugin: "Kanopi\\Firewall\\Plugins\\Asn"
+    response: challenge
+    weight: -10
+    enable: false
+    metadata:
+      # Pass-token TTL after a successful challenge (seconds).
+      default_expiration_time: 3600
+    config:
+      # Challenge traffic from cloud / hosting ASNs without outright blocking.
+      - "asn:AS14618"
+      - "asn:AS16509"
 
   # ---------------------------------------------------------------------
   # response: block

--- a/example/demo/Dockerfile
+++ b/example/demo/Dockerfile
@@ -1,0 +1,26 @@
+# Demo container for the Lite Firewall.
+#
+# Build from the repo root so the COPY pulls the whole project:
+#
+#   docker build -t firewall-demo -f example/demo/Dockerfile .
+#   docker run --rm -p 8000:8000 firewall-demo
+#
+# Then open http://localhost:8000.
+FROM php:8.4-cli-alpine
+
+WORKDIR /app
+
+# composer + git for VCS-backed packages composer.lock might reference
+RUN apk add --no-cache git unzip \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --no-interaction --no-progress --prefer-dist
+
+COPY . .
+
+EXPOSE 8000
+
+# `sh -c` so the rm runs before the server starts; without it, exec form
+# would skip the cleanup.
+CMD ["sh", "-c", "rm -f /tmp/firewall-demo.data && php -S 0.0.0.0:8000 -t example/demo example/demo/index.php"]

--- a/example/demo/README.md
+++ b/example/demo/README.md
@@ -1,0 +1,131 @@
+# Lite Firewall local demo
+
+A throwaway harness for poking at the firewall in a browser. Demonstrates all three response modes (`allow`, `block`, `challenge`) in one config, and ships a production-shaped nginx → php-fpm stack so you can run perf experiments against something that looks like a real deployment.
+
+## TL;DR — composer shortcuts
+
+| Command                       | What it does                                                                 |
+|-------------------------------|------------------------------------------------------------------------------|
+| `composer demo`               | PHP built-in server, single-process, <http://localhost:8000>.                |
+| `composer demo:workers`       | Same as `composer demo` but with `PHP_CLI_SERVER_WORKERS=8` for concurrency. |
+| `composer demo:perf`          | nginx + php-fpm via Docker, <http://localhost:8000>.                          |
+| `composer demo:perf:restart`  | Restart only the php-fpm container (clears stale opcache after edits).        |
+| `composer demo:perf:down`     | Tear down the perf stack.                                                     |
+
+The longer-form invocations and tuning knobs are documented below.
+
+## Routes
+
+The config keys rules off the URL so behavior is identical on any networking setup:
+
+| Path     | Result                                                                                          |
+|----------|-------------------------------------------------------------------------------------------------|
+| `/`      | Allowed — nothing matches.                                                                      |
+| `/admin` | Blocked — a `response: block` URL plugin returns 400 with the configured banning message.       |
+| `/secure`| Challenged — `response: challenge` serves a math interstitial. Solve it once, get a 60s pass cookie. |
+
+## Option 1 — PHP built-in server (quick)
+
+```sh
+# from the repo root
+composer install
+php -S localhost:8000 -t example/demo example/demo/index.php
+```
+
+The `-t example/demo` flag scopes the docroot so only `example/demo/index.php` is reachable — without it the built-in server would happily serve `composer.json`, `src/`, etc. as static files. nginx (Option 3) already scopes its root via `nginx.conf`.
+
+Single process by default. Set `PHP_CLI_SERVER_WORKERS` for multi-worker concurrency (modern PHP only, marked experimental):
+
+```sh
+PHP_CLI_SERVER_WORKERS=8 php -S localhost:8000 -t example/demo example/demo/index.php
+```
+
+### How URL rewriting works
+
+All three stacks route every request to `index.php` (front-controller pattern), with the original path preserved in `REQUEST_URI`. So `/admin/users/123/delete` invokes `index.php`, and `$_SERVER['REQUEST_URI']` is `/admin/users/123/delete` — which is what the URL plugin matches against. No `.htaccess` or app-side rewriting needed.
+
+Open <http://localhost:8000>.
+
+## Option 2 — Docker (matches Option 1, hot-reloaded)
+
+```sh
+cd example/demo
+docker compose up
+```
+
+Bind-mounts the repo and runs the built-in server with 8 workers by default. `PHP_CLI_SERVER_WORKERS=32 docker compose up` to crank it.
+
+## Option 3 — Docker, nginx → php-fpm (production-shaped, for perf)
+
+```sh
+cd example/demo
+docker compose -f docker-compose.perf.yml up
+```
+
+This is the realistic stack:
+
+- `nginx:alpine` fronts the request, routes everything through `index.php` via FastCGI.
+- `php:8.4-fpm-alpine` runs the firewall under php-fpm with a tuned pool (see `www.conf` — defaults to 64 max children).
+- Source is bind-mounted, so code edits hot-reload (you may want `docker compose -f docker-compose.perf.yml restart php` if opcache caches old bytecode).
+
+Tuning levers:
+
+| File         | Knob                                       | Default |
+|--------------|--------------------------------------------|---------|
+| `www.conf`   | `pm.max_children`                          | 64      |
+| `www.conf`   | `pm.max_requests` (worker recycle)         | 500     |
+| `nginx.conf` | nginx access logs                          | on (uncomment `access_log off` to silence) |
+
+## Perf testing
+
+The challenge feature has two distinct hot paths:
+
+1. **Token verification** (one HMAC-SHA256 + JSON decode per request that carries a valid token). This is what production traffic exercises once visitors have passed the challenge.
+2. **Interstitial render + verify** (HMAC sign + random_int + verify on POST). Only the very first request from a new visitor hits this.
+
+To exercise #1 cleanly, pre-mint a token, then hammer `/secure` with it as a cookie:
+
+```sh
+# 1. Get the interstitial
+curl -sS http://localhost:8000/secure > /tmp/i.html
+
+# 2. The signed state is "answer|exp.signature" — pull out both
+STATE=$(grep -oE 'name="challenge_state" value="[^"]+"' /tmp/i.html | sed 's/.*value="\([^"]*\)".*/\1/')
+ANSWER=$(echo "$STATE" | cut -d'|' -f1)
+
+# 3. POST the solution; capture the token from the response JSON
+TOKEN=$(curl -sS -X POST http://localhost:8000/_firewall/challenge \
+  -d "challenge_state=$STATE" -d "challenge_answer=$ANSWER" \
+  -d "redirect_to=/secure" -d "ttl=60" \
+  | sed 's/.*"token":"\([^"]*\)".*/\1/')
+
+# 4. Hammer /secure with the token attached
+wrk -t8 -c64 -d30s -H "Cookie: fw_challenge_pass=$TOKEN" http://localhost:8000/secure
+```
+
+For raw "no challenge" baseline numbers, run the same `wrk` against `/`. The delta tells you the per-request cost of token verification.
+
+## Storage / repeat-offender behavior
+
+The demo uses `FileStorage` at `/tmp/firewall-demo.data` so blocks persist across HTTP requests (which is how a real deployment behaves). Watch for this:
+
+1. `GET /admin` → URL block plugin matches → IP recorded to the storage file → 400 response.
+2. **Next** `GET /secure` → `storage->isBlocked()` finds the prior record → **repeat-offender** path fires → 400 response **before** the challenge plugin ever runs.
+
+So one hit on `/admin` blanket-blocks the source IP across every other route until the storage file is wiped or the entry expires.
+
+To start over without restarting the server:
+
+```sh
+composer demo:reset            # rm -f /tmp/firewall-demo.data
+```
+
+Each of the start scripts (`composer demo`, `composer demo:workers`, `composer demo:perf`, and the `Dockerfile` CMD) wipes the storage file on startup, so a fresh `up` always begins clean. `composer demo:perf:restart` re-runs the php container's startup command and therefore also clears it.
+
+> Why not `InMemoryStorage`? `InMemoryStorage` only persists within a single PHP execution — every HTTP request gets a fresh `StorageFactory::create()` call and therefore a fresh empty store, so repeat-offender behavior never surfaces. `FileStorage` is what makes the demo behave like production.
+
+## Caveats
+
+- **HTTPS / `Secure` cookies.** Browsers treat `localhost` as a secure origin, so the `Secure; HttpOnly; SameSite=Strict` pass cookie works for the demo. Behind a non-localhost plain-HTTP hostname it will be rejected — terminate TLS in front, or add a config knob to relax the flag in that environment.
+- **Trusted proxies.** With the Docker stack, `REMOTE_ADDR` is whatever nginx sees as the upstream client (the Docker bridge in Docker Desktop). For real edge-proxy setups, call `Request::setTrustedProxies(...)` before `Firewall::create()` so the firewall reads the true client IP from `X-Forwarded-For`.
+- **Demo secret.** `config.yml` ships with a hardcoded HMAC secret so the demo runs out of the box. Replace it with a long random value (e.g. `openssl rand -hex 32`) in any real deployment.

--- a/example/demo/config.yml
+++ b/example/demo/config.yml
@@ -1,0 +1,56 @@
+# General-purpose demo config for the Lite Firewall.
+#
+# Shows all three response modes in one config, keyed by URL so the demo
+# behaves the same whether you hit it via the PHP built-in server (where
+# REMOTE_ADDR is 127.0.0.1) or via Docker (where nginx forwards a bridge
+# IP). Hit these paths from a browser to exercise each mode:
+#
+#   /            → allowed (no rule matches)
+#   /admin       → blocked (response: block)
+#   /admin/foo   → blocked
+#   /secure      → challenged (response: challenge)
+#   /secure/foo  → challenged
+#
+# Replace the hardcoded HMAC secret before reusing this anywhere real.
+
+global:
+  # Plain string body for blocks; full template syntax (e.g. {{request.id}})
+  # is documented in the main README.
+  banning_message: "Blocked: {{request.path}} is restricted (request {{request.id}})."
+
+# Persistent storage so a block on /admin is observed by a later /secure
+# request from the same IP (repeat-offender path). The composer demo
+# scripts and the docker compose files wipe this file on startup so each
+# `composer demo` / `docker compose up` starts with a clean slate.
+storage:
+  type: Kanopi\Firewall\Storage\FileStorage
+  config:
+    storage_file: /tmp/firewall-demo.data
+
+challenge:
+  provider: math
+  secret: 'demo-secret-do-not-reuse-in-prod'
+  cookie_name: fw_challenge_pass
+  header_name: X-Firewall-Challenge
+  path: /_firewall/challenge
+
+plugins:
+  # Block administrative paths outright. Weight is negative so it runs
+  # before any default-weighted entries.
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: block
+    weight: -10
+    enable: true
+    config:
+      - "path@starts_with:/admin"
+
+  # Challenge anything under /secure. The pass token lasts 60s so the
+  # interstitial is easy to re-trigger during testing.
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: challenge
+    weight: 0
+    enable: true
+    metadata:
+      default_expiration_time: 60
+    config:
+      - "path@starts_with:/secure"

--- a/example/demo/docker-compose.perf.yml
+++ b/example/demo/docker-compose.perf.yml
@@ -1,0 +1,45 @@
+# Production-shaped stack for performance testing the firewall.
+#
+# nginx fronts php-fpm over a FastCGI socket. Every request is routed
+# through example/demo/index.php — the firewall handles allow / block /
+# challenge dispatch and the POST /_firewall/challenge submission.
+#
+# From inside example/demo/:
+#
+#   docker compose -f docker-compose.perf.yml up
+#
+# Then hit http://localhost:8000.
+#
+# Tuning knobs:
+#   - PHP workers: see pm.max_children in www.conf
+#   - nginx worker_connections: edit nginx.conf
+#   - opcache: enabled by default on the fpm image; restart for cleanest results
+services:
+  php:
+    image: php:8.4-fpm-alpine
+    working_dir: /app
+    volumes:
+      - ../..:/app
+      - ./www.conf:/usr/local/etc/php-fpm.d/www.conf:ro
+    command: >
+      sh -c "
+        if [ ! -d /app/vendor ]; then
+          apk add --no-cache git unzip &&
+          curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer &&
+          composer install --no-dev --no-interaction --no-progress --prefer-dist;
+        fi;
+        rm -f /tmp/firewall-demo.data;
+        php-fpm
+      "
+    expose:
+      - "9000"
+
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - ../..:/app:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "8000:80"
+    depends_on:
+      - php

--- a/example/demo/docker-compose.yml
+++ b/example/demo/docker-compose.yml
@@ -1,0 +1,29 @@
+# One-shot demo: `docker compose up` from inside example/demo/
+# then open http://localhost:8000.
+#
+# Source is bind-mounted so edits to src/ or config.yml hot-reload on the
+# next request — no rebuild needed.
+#
+# PHP_CLI_SERVER_WORKERS turns the built-in server into a multi-worker
+# server so concurrent requests aren't serialized. Bump it up for perf
+# playgrounds (`PHP_CLI_SERVER_WORKERS=32 docker compose up`).
+services:
+  firewall:
+    image: php:8.4-cli-alpine
+    working_dir: /app
+    environment:
+      PHP_CLI_SERVER_WORKERS: ${PHP_CLI_SERVER_WORKERS:-8}
+    volumes:
+      - ../..:/app
+    ports:
+      - "8000:8000"
+    command: >
+      sh -c "
+        if [ ! -d /app/vendor ]; then
+          apk add --no-cache git unzip &&
+          curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer &&
+          composer install --no-dev --no-interaction --no-progress --prefer-dist;
+        fi;
+        rm -f /tmp/firewall-demo.data;
+        php -S 0.0.0.0:8000 -t example/demo example/demo/index.php
+      "

--- a/example/demo/index.php
+++ b/example/demo/index.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Front controller for the Lite Firewall demo.
+ *
+ * Three demo routes — see example/demo/config.yml for the rules:
+ *
+ *   /            allowed
+ *   /admin       blocked
+ *   /secure      challenged (interstitial → solve → pass token → reload)
+ *
+ * Run with the PHP built-in server (single-process):
+ *
+ *   php -S localhost:8000 example/demo/index.php
+ *
+ * Or with the nginx + php-fpm stack for production-shaped concurrency:
+ *
+ *   cd example/demo && docker compose -f docker-compose.perf.yml up
+ */
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+\Kanopi\Firewall\Firewall::create([__DIR__ . '/config.yml'])->evaluate();
+
+// Anything past evaluate() means the firewall allowed the request through:
+// either nothing matched, or a pass token is held.
+$ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+$path = $_SERVER['REQUEST_URI'] ?? '/';
+$cookiePresent = isset($_COOKIE['fw_challenge_pass']);
+
+header('Content-Type: text/html; charset=utf-8');
+
+?><!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Lite Firewall demo</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto; line-height: 1.5; padding: 0 1rem; }
+    h1 { color: #137333; }
+    code { background: #eef; padding: 0.1rem 0.3rem; border-radius: 3px; font-size: 0.95em; }
+    table { border-collapse: collapse; margin-top: 1rem; width: 100%; }
+    th, td { padding: 0.4rem 0.8rem; border-bottom: 1px solid #ddd; text-align: left; vertical-align: top; }
+    th { background: #f3f3f5; }
+    .meta { color: #555; font-size: 0.9rem; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #ddd; }
+  </style>
+</head>
+<body>
+  <h1>You passed the firewall.</h1>
+  <p>The request hit <code><?= htmlspecialchars($path, ENT_QUOTES, 'UTF-8') ?></code> and nothing blocked or challenged it.</p>
+
+  <h2>Try the other routes</h2>
+  <table>
+    <thead>
+      <tr><th>URL</th><th>Expected behavior</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><a href="/">/</a></td><td>Allowed — this page.</td></tr>
+      <tr><td><a href="/admin">/admin</a></td><td>Blocked — the URL plugin rejects anything under <code>/admin</code> with a 400.</td></tr>
+      <tr><td><a href="/secure">/secure</a></td><td>Challenged — math interstitial. Solve it once, then <code>/secure</code> stays accessible for 60s via the pass cookie.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Re-triggering the challenge</h2>
+  <p>The pass token TTL is 60s in this demo. To force the interstitial again sooner:</p>
+  <ul>
+    <li>Delete the <code>fw_challenge_pass</code> cookie via browser dev tools, or</li>
+    <li>Reload <code>/secure</code> in an incognito window.</li>
+  </ul>
+
+  <p class="meta">
+    Request path: <code><?= htmlspecialchars($path, ENT_QUOTES, 'UTF-8') ?></code><br>
+    Client IP (as the firewall sees it): <code><?= htmlspecialchars($ip, ENT_QUOTES, 'UTF-8') ?></code><br>
+    Pass cookie present: <code><?= $cookiePresent ? 'yes' : 'no' ?></code>
+  </p>
+</body>
+</html>

--- a/example/demo/nginx.conf
+++ b/example/demo/nginx.conf
@@ -1,0 +1,30 @@
+# Front-controller routing for the firewall demo.
+#
+# Every request — including POST /_firewall/challenge — is funneled
+# through index.php; the firewall itself decides whether to serve the
+# interstitial, accept a solution, or pass through to the app.
+server {
+    listen 80 default_server;
+    server_name _;
+    root /app/example/demo;
+    index index.php;
+
+    # Quiet down nginx access logs for benchmarks (uncomment to enable).
+    # access_log off;
+
+    location / {
+        try_files $uri /index.php$is_args$args;
+    }
+
+    location ~ \.php$ {
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root/index.php;
+        include fastcgi_params;
+
+        # Pass the real client IP through. With a real edge proxy in front
+        # you would also set HTTP_X_FORWARDED_FOR and configure
+        # Request::setTrustedProxies(...) before Firewall::create().
+        fastcgi_param REMOTE_ADDR $remote_addr;
+    }
+}

--- a/example/demo/www.conf
+++ b/example/demo/www.conf
@@ -1,0 +1,26 @@
+; PHP-FPM worker pool tuned for the perf playground.
+;
+; pm.max_children is the cap on concurrent PHP processes. Each one holds
+; ~20MB RAM minimum (your mileage varies with autoloader + bootstraps),
+; so 64 workers ≈ 1.3GB RSS at saturation. Raise it past your free RAM
+; and the kernel will start swapping — request latency will fall off a
+; cliff well before nginx complains.
+[www]
+user = www-data
+group = www-data
+listen = 9000
+
+pm = dynamic
+pm.max_children = 64
+pm.start_servers = 16
+pm.min_spare_servers = 8
+pm.max_spare_servers = 32
+pm.max_requests = 500
+
+; Surface fpm status at /fpm-status if you wire it up in nginx; useful
+; for confirming workers are actually busy during a benchmark run.
+pm.status_path = /fpm-status
+
+; Catch hard failures (segfaults, OOMs) without losing them to the void.
+catch_workers_output = yes
+decorate_workers_output = no

--- a/presets/README.md
+++ b/presets/README.md
@@ -91,7 +91,10 @@ Blocks common malicious PHP files, attack patterns, and suspicious URLs includin
 The firewall uses a canonical `plugins:` array format. Each entry in the array configures one plugin and supports the following keys:
 
 - `plugin` — Fully-qualified plugin class name (string, double-quoted with escaped backslashes, e.g. `"Kanopi\\Firewall\\Plugins\\Url"`).
-- `response` — Either `allow` (bypass / whitelist behavior) or `block` (deny / blacklist behavior).
+- `response` — One of:
+  - `allow` — bypass / whitelist behavior.
+  - `block` — deny / blacklist behavior.
+  - `challenge` — serve a CAPTCHA-style interstitial; on success the visitor receives an HMAC-signed pass token (cookie + custom header) valid for `metadata.default_expiration_time` seconds. Requires a top-level `challenge:` section with a non-empty `secret`. See the main [README → Challenge Response Type](../README.md#challenge-response-type) for the full contract.
 - `weight` — Integer execution order. Lower weights run first (e.g. `-200` before `-10` before `0`).
 - `enable` — `true`/`false` toggle for the entry.
 - `metadata` — Plugin-specific metadata (e.g. storage backends, GeoIP readers, external config file references).

--- a/src/Challenge/ChallengeProviderFactory.php
+++ b/src/Challenge/ChallengeProviderFactory.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kanopi\Firewall\Challenge;
+
+use Kanopi\Firewall\Exception\ConfigurationException;
+use Kanopi\Firewall\Logging\LoggingFactory;
+
+/**
+ * Resolves a provider short name or FQCN into a ChallengeProviderInterface.
+ *
+ * Mirrors StorageFactory in shape: built-in short names map to first-party
+ * classes, FQCN strings are instantiated if they implement the contract.
+ * Anything else throws — there is no silent fallback because misconfiguring
+ * the provider while challenge plugins exist should be a startup failure.
+ */
+final class ChallengeProviderFactory
+{
+    /**
+     * @var array<string, class-string<ChallengeProviderInterface>>
+     */
+    private const BUILTINS = [
+        'math' => MathChallengeProvider::class,
+    ];
+
+    /**
+     * Build a provider from `challenge.provider` config.
+     *
+     * @param string $provider
+     *   Built-in short name ("math") or fully-qualified class name.
+     * @param TokenManager $tokenManager
+     *   Shared HMAC manager. Providers that need to sign per-challenge
+     *   state (like MathChallengeProvider) receive it via constructor.
+     *
+     * @throws ConfigurationException
+     *   When the provider name resolves to nothing or to a class that
+     *   does not implement ChallengeProviderInterface.
+     */
+    public static function create(string $provider, TokenManager $tokenManager): ChallengeProviderInterface
+    {
+        $class = self::BUILTINS[$provider] ?? $provider;
+
+        if (!class_exists($class)) {
+            throw new ConfigurationException(sprintf(
+                'Challenge provider "%s" is not a built-in name or a loadable class.',
+                $provider
+            ));
+        }
+
+        if (!is_subclass_of($class, ChallengeProviderInterface::class)) {
+            throw new ConfigurationException(sprintf(
+                'Challenge provider "%s" must implement %s.',
+                $class,
+                ChallengeProviderInterface::class
+            ));
+        }
+
+        $instance = new $class($tokenManager);
+
+        LoggingFactory::logMessage('debug', 'Challenge provider created', [
+            'provider' => $instance->getName(),
+            'class' => $class,
+        ]);
+
+        return $instance;
+    }
+}

--- a/src/Challenge/ChallengeProviderInterface.php
+++ b/src/Challenge/ChallengeProviderInterface.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kanopi\Firewall\Challenge;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Contract for challenge providers (math, Turnstile, hCaptcha, …).
+ *
+ * A provider owns two halves of the challenge round-trip:
+ *   1. Rendering the interstitial body that asks the visitor to prove they
+ *      are human.
+ *   2. Verifying the answer the visitor posts back.
+ *
+ * Implementations MUST be self-contained: any nonce / signed state required
+ * to verify the answer should be embedded in the interstitial output (typically
+ * as a hidden form field) so the server stays stateless between the render
+ * and verify steps.
+ */
+interface ChallengeProviderInterface
+{
+    /**
+     * Short identifier used in `challenge.provider` config (e.g. "math").
+     */
+    public function getName(): string;
+
+    /**
+     * Render the challenge interstitial HTML body.
+     *
+     * @param Request $request
+     *   The blocked request that triggered the challenge.
+     * @param array<string, string> $context
+     *   Render-time data injected by the Firewall:
+     *     - submit_url:    URL the form should POST to.
+     *     - redirect_to:   URL to send the visitor to after success.
+     *     - ttl:           Token TTL in seconds (per-plugin metadata).
+     *     - cookie_name:   Cookie that will carry the pass token.
+     *     - header_name:   Header for the localStorage delivery path.
+     *
+     * @return string
+     *   Complete HTML document.
+     */
+    public function renderInterstitial(Request $request, array $context): string;
+
+    /**
+     * Verify a posted challenge solution.
+     *
+     * @param Request $request
+     *   The POST request carrying the visitor's answer.
+     *
+     * @return bool
+     *   TRUE if the solution is valid, FALSE otherwise.
+     */
+    public function verifySolution(Request $request): bool;
+}

--- a/src/Challenge/MathChallengeProvider.php
+++ b/src/Challenge/MathChallengeProvider.php
@@ -62,7 +62,7 @@ final class MathChallengeProvider implements ChallengeProviderInterface
 
     private const STATE_LIFETIME = 300;
 
-    public function __construct(private TokenManager $tokenManager)
+    public function __construct(private readonly TokenManager $tokenManager)
     {
     }
 

--- a/src/Challenge/MathChallengeProvider.php
+++ b/src/Challenge/MathChallengeProvider.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kanopi\Firewall\Challenge;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Built-in arithmetic challenge.
+ *
+ * Renders "What is A + B?" where A and B are small random integers. The
+ * expected answer is signed into a hidden form field (`challenge_state`)
+ * with a short embedded expiry, so the server stays stateless between
+ * the render and verify steps — there is no per-challenge record to
+ * store or look up.
+ *
+ * Wire format of the signed state: `answer|exp.signature`
+ *   answer    = the expected integer answer (server-side truth)
+ *   exp       = unix timestamp after which the challenge is stale
+ *   signature = HMAC over "answer|exp" via TokenManager::sign()
+ *
+ * The challenge_state lifetime is short (5 minutes) — long enough that a
+ * legitimate visitor can read and type, short enough that a precomputed
+ * answer harvested from a bot farm goes stale before it can be replayed
+ * at scale.
+ *
+ * This is deliberately a low-friction proof-of-effort, not a CAPTCHA.
+ * Operators who need stronger bot resistance can implement
+ * ChallengeProviderInterface against Turnstile/hCaptcha/etc.
+ */
+final class MathChallengeProvider implements ChallengeProviderInterface
+{
+    /**
+     * Form field that carries the signed `answer|exp.signature` payload
+     * from render → verify.
+     */
+    public const STATE_FIELD = 'challenge_state';
+
+    /**
+     * Form field that carries the visitor's typed answer.
+     */
+    public const ANSWER_FIELD = 'challenge_answer';
+
+    /**
+     * Form field carrying the post-success redirect target.
+     */
+    public const REDIRECT_FIELD = 'redirect_to';
+
+    /**
+     * Form field carrying the per-plugin TTL (so the Firewall knows how
+     * long to mint the resulting pass token for).
+     */
+    public const TTL_FIELD = 'ttl';
+
+    private const STATE_LIFETIME = 300;
+
+    public function __construct(private TokenManager $tokenManager)
+    {
+    }
+
+    public function getName(): string
+    {
+        return 'math';
+    }
+
+    public function renderInterstitial(Request $request, array $context): string
+    {
+        $a = random_int(1, 9);
+        $b = random_int(1, 9);
+        $expected = (string) ($a + $b);
+        $exp = time() + self::STATE_LIFETIME;
+
+        $stateData = $expected . '|' . $exp;
+        $signedState = $stateData . '.' . $this->tokenManager->sign($stateData);
+
+        return $this->renderTemplate([
+            'question' => sprintf('What is %d + %d?', $a, $b),
+            'submit_url' => $context['submit_url'] ?? '',
+            'redirect_to' => $context['redirect_to'] ?? '/',
+            'ttl' => $context['ttl'] ?? '3600',
+            'cookie_name' => $context['cookie_name'] ?? '',
+            'header_name' => $context['header_name'] ?? '',
+            'state' => $signedState,
+            'state_field' => self::STATE_FIELD,
+            'answer_field' => self::ANSWER_FIELD,
+            'redirect_field' => self::REDIRECT_FIELD,
+            'ttl_field' => self::TTL_FIELD,
+        ]);
+    }
+
+    public function verifySolution(Request $request): bool
+    {
+        $state = (string) $request->request->get(self::STATE_FIELD, '');
+        $answer = trim((string) $request->request->get(self::ANSWER_FIELD, ''));
+
+        if ($state === '' || $answer === '' || substr_count($state, '.') !== 1) {
+            return false;
+        }
+
+        [$data, $signature] = explode('.', $state, 2);
+        if (!$this->tokenManager->verifySignature($data, $signature)) {
+            return false;
+        }
+
+        if (substr_count($data, '|') !== 1) {
+            return false;
+        }
+
+        [$expected, $exp] = explode('|', $data, 2);
+
+        if (!ctype_digit($exp) || (int) $exp <= time()) {
+            return false;
+        }
+
+        return hash_equals($expected, $answer);
+    }
+
+    /**
+     * Inline HTML + JS template.
+     *
+     * Every {{key}} substitution is HTML-escaped — `question` is the only
+     * server-generated text, but we treat the rest defensively in case a
+     * future caller passes a user-controlled `redirect_to`.
+     *
+     * @param array<string, string|int> $vars
+     */
+    private function renderTemplate(array $vars): string
+    {
+        $escape = static fn(string|int $v): string => htmlspecialchars(
+            (string) $v,
+            ENT_QUOTES | ENT_SUBSTITUTE,
+            'UTF-8'
+        );
+
+        $e = array_map($escape, $vars);
+
+        return <<<HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Verification required</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #f5f6f8; color: #1a1a1a; margin: 0; display: flex; min-height: 100vh; align-items: center; justify-content: center; }
+    .card { background: #fff; padding: 2rem 2.5rem; border-radius: 8px; box-shadow: 0 4px 24px rgba(0,0,0,0.08); max-width: 28rem; width: 90%; }
+    h1 { font-size: 1.25rem; margin: 0 0 0.75rem; }
+    p { margin: 0 0 1.25rem; color: #555; }
+    label { display: block; font-weight: 600; margin-bottom: 0.5rem; }
+    input[type="text"] { width: 100%; padding: 0.6rem 0.75rem; font-size: 1rem; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; }
+    button { margin-top: 1rem; width: 100%; padding: 0.65rem 1rem; font-size: 1rem; background: #1f6feb; color: #fff; border: 0; border-radius: 4px; cursor: pointer; }
+    button:hover { background: #1858c4; }
+    .error { color: #b42318; margin-top: 0.75rem; font-size: 0.9rem; display: none; }
+    .error.visible { display: block; }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <h1>Quick verification</h1>
+    <p>Please answer the question below to continue.</p>
+    <form id="challenge-form" method="post" action="{$e['submit_url']}">
+      <label for="answer">{$e['question']}</label>
+      <input type="text" id="answer" name="{$e['answer_field']}" inputmode="numeric" autocomplete="off" autofocus required>
+      <input type="hidden" name="{$e['state_field']}" value="{$e['state']}">
+      <input type="hidden" name="{$e['redirect_field']}" value="{$e['redirect_to']}">
+      <input type="hidden" name="{$e['ttl_field']}" value="{$e['ttl']}">
+      <button type="submit">Continue</button>
+      <div id="error" class="error" role="alert">Incorrect answer. Please try again.</div>
+    </form>
+  </main>
+  <script>
+    (function () {
+      var form = document.getElementById('challenge-form');
+      var err = document.getElementById('error');
+      var cookieName = "{$e['cookie_name']}";
+      var headerName = "{$e['header_name']}";
+      var redirectTo = "{$e['redirect_to']}";
+
+      form.addEventListener('submit', function (event) {
+        event.preventDefault();
+        err.classList.remove('visible');
+
+        var data = new FormData(form);
+        fetch(form.action, {
+          method: 'POST',
+          body: data,
+          headers: { 'Accept': 'application/json' },
+          credentials: 'same-origin'
+        }).then(function (resp) {
+          return resp.json().then(function (body) { return { ok: resp.ok, body: body }; });
+        }).then(function (result) {
+          if (!result.ok || !result.body || !result.body.token) {
+            err.classList.add('visible');
+            return;
+          }
+          try {
+            if (headerName) {
+              localStorage.setItem('firewall.' + headerName, result.body.token);
+            }
+          } catch (e) { /* localStorage blocked — cookie still works */ }
+          window.location.href = result.body.redirect || redirectTo;
+        }).catch(function () {
+          err.classList.add('visible');
+        });
+      });
+    })();
+  </script>
+</body>
+</html>
+HTML;
+    }
+}

--- a/src/Challenge/TokenManager.php
+++ b/src/Challenge/TokenManager.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kanopi\Firewall\Challenge;
+
+use Kanopi\Firewall\Exception\ConfigurationException;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Mints and verifies HMAC-signed challenge pass tokens.
+ *
+ * Tokens are stateless: the server holds no per-token record. Verification
+ * relies purely on the embedded payload (IP, expiry, nonce) and HMAC
+ * signature. This keeps the firewall horizontally scalable without a shared
+ * session store, at the cost of being unable to revoke a single token before
+ * it expires (rotating the secret invalidates everything).
+ *
+ * Wire format: `base64url(payload).base64url(hmac)`
+ *   payload = JSON{ip, exp, nonce}
+ *   hmac    = HMAC-SHA256(payload, secret)
+ *
+ * Token binding (verified on every request):
+ *   - `ip`    must equal `$request->getClientIp()` at verify time.
+ *   - `exp`   is a unix timestamp; tokens past it are rejected.
+ *   - `nonce` is 128 random bits to keep two same-second mints distinct in
+ *             downstream logs and to prevent precomputed-token attacks.
+ *
+ * The signature is verified with `hash_equals` so a wrong token reveals
+ * nothing through timing. Payload parsing errors return FALSE rather than
+ * throwing — verification must never blow up on attacker-controlled input.
+ */
+final class TokenManager
+{
+    /**
+     * @param string $secret
+     *   HMAC key. Must be non-empty when challenge plugins are active —
+     *   `Firewall::create()` fails fast if a challenge plugin is configured
+     *   without a secret.
+     *
+     * @throws ConfigurationException
+     *   When the secret is empty.
+     */
+    public function __construct(private string $secret)
+    {
+        if ($this->secret === '') {
+            throw new ConfigurationException(
+                'Challenge token secret is empty. Set `challenge.secret` in '
+                . 'firewall config (typically via env var) before enabling '
+                . 'response: challenge plugins.'
+            );
+        }
+    }
+
+    /**
+     * Mint a pass token bound to the request's client IP.
+     *
+     * @param Request $request
+     *   The request that just solved the challenge.
+     * @param int $ttl
+     *   Token lifetime in seconds. Falls back to 3600 (1h) if non-positive.
+     *
+     * @return string
+     *   The serialized token, ready to set as a cookie value.
+     */
+    public function mint(Request $request, int $ttl): string
+    {
+        $ttl = $ttl > 0 ? $ttl : 3600;
+
+        $payload = [
+            'ip' => (string) $request->getClientIp(),
+            'exp' => time() + $ttl,
+            'nonce' => bin2hex(random_bytes(16)),
+        ];
+
+        $payloadEncoded = self::base64UrlEncode((string) json_encode($payload));
+        $signature = self::base64UrlEncode(hash_hmac('sha256', $payloadEncoded, $this->secret, true));
+
+        return $payloadEncoded . '.' . $signature;
+    }
+
+    /**
+     * Verify a token against the current request.
+     *
+     * @param string $token
+     *   The candidate token (from cookie or header).
+     * @param Request $request
+     *   The request being evaluated.
+     *
+     * @return bool
+     *   TRUE only if signature, IP binding, and expiry all pass.
+     */
+    public function verify(string $token, Request $request): bool
+    {
+        if ($token === '' || substr_count($token, '.') !== 1) {
+            return false;
+        }
+
+        [$payloadEncoded, $signature] = explode('.', $token, 2);
+        if ($payloadEncoded === '' || $signature === '') {
+            return false;
+        }
+
+        $expectedSignature = self::base64UrlEncode(
+            hash_hmac('sha256', $payloadEncoded, $this->secret, true)
+        );
+
+        if (!hash_equals($expectedSignature, $signature)) {
+            return false;
+        }
+
+        $payloadJson = self::base64UrlDecode($payloadEncoded);
+        if ($payloadJson === false) {
+            return false;
+        }
+
+        $payload = json_decode($payloadJson, true);
+        if (!is_array($payload)) {
+            return false;
+        }
+
+        if (!isset($payload['ip'], $payload['exp']) || !is_int($payload['exp'])) {
+            return false;
+        }
+
+        if ($payload['exp'] <= time()) {
+            return false;
+        }
+
+        return $payload['ip'] === $request->getClientIp();
+    }
+
+    /**
+     * Sign an arbitrary opaque string (used by providers to sign their
+     * per-challenge nonces — e.g. the MathChallengeProvider signs the
+     * expected answer + expiry so it stays stateless).
+     */
+    public function sign(string $data): string
+    {
+        return self::base64UrlEncode(hash_hmac('sha256', $data, $this->secret, true));
+    }
+
+    /**
+     * Constant-time signature check for provider-signed payloads.
+     */
+    public function verifySignature(string $data, string $signature): bool
+    {
+        return hash_equals($this->sign($data), $signature);
+    }
+
+    private static function base64UrlEncode(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    private static function base64UrlDecode(string $data): string|false
+    {
+        $padded = $data . str_repeat('=', (4 - strlen($data) % 4) % 4);
+        return base64_decode(strtr($padded, '-_', '+/'), true);
+    }
+}

--- a/src/Challenge/TokenManager.php
+++ b/src/Challenge/TokenManager.php
@@ -48,7 +48,7 @@ final class TokenManager
      * @throws ConfigurationException
      *   When the secret is empty.
      */
-    public function __construct(private string $secret)
+    public function __construct(private readonly string $secret)
     {
         if ($this->secret === '') {
             throw new ConfigurationException(
@@ -80,8 +80,8 @@ final class TokenManager
             'nonce' => bin2hex(random_bytes(16)),
         ];
 
-        $payloadEncoded = self::base64UrlEncode((string) json_encode($payload));
-        $signature = self::base64UrlEncode(hash_hmac('sha256', $payloadEncoded, $this->secret, true));
+        $payloadEncoded = $this->base64UrlEncode((string) json_encode($payload));
+        $signature = $this->base64UrlEncode(hash_hmac('sha256', $payloadEncoded, $this->secret, true));
 
         return $payloadEncoded . '.' . $signature;
     }
@@ -108,15 +108,13 @@ final class TokenManager
             return false;
         }
 
-        $expectedSignature = self::base64UrlEncode(
-            hash_hmac('sha256', $payloadEncoded, $this->secret, true)
-        );
+        $expectedSignature = $this->base64UrlEncode(hash_hmac('sha256', $payloadEncoded, $this->secret, true));
 
         if (!hash_equals($expectedSignature, $signature)) {
             return false;
         }
 
-        $payloadJson = self::base64UrlDecode($payloadEncoded);
+        $payloadJson = $this->base64UrlDecode($payloadEncoded);
         if ($payloadJson === false) {
             return false;
         }
@@ -144,7 +142,7 @@ final class TokenManager
      */
     public function sign(string $data): string
     {
-        return self::base64UrlEncode(hash_hmac('sha256', $data, $this->secret, true));
+        return $this->base64UrlEncode(hash_hmac('sha256', $data, $this->secret, true));
     }
 
     /**
@@ -155,12 +153,12 @@ final class TokenManager
         return hash_equals($this->sign($data), $signature);
     }
 
-    private static function base64UrlEncode(string $data): string
+    private function base64UrlEncode(string $data): string
     {
         return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
     }
 
-    private static function base64UrlDecode(string $data): string|false
+    private function base64UrlDecode(string $data): string|false
     {
         $padded = $data . str_repeat('=', (4 - strlen($data) % 4) % 4);
         return base64_decode(strtr($padded, '-_', '+/'), true);

--- a/src/Exception/ChallengeRequiredException.php
+++ b/src/Exception/ChallengeRequiredException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kanopi\Firewall\Exception;
+
+/**
+ * Thrown in FirewallMode::Exception when a `response: challenge` plugin
+ * matches.
+ *
+ * Mirrors FirewallBlockedException for the challenge path so test suites
+ * can assert that an interstitial *would have* been served without the
+ * Firewall actually `exit()`-ing the process.
+ */
+class ChallengeRequiredException extends FirewallException
+{
+    public function __construct(string $message, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/src/Exception/ChallengeSolvedException.php
+++ b/src/Exception/ChallengeSolvedException.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kanopi\Firewall\Exception;
+
+/**
+ * Thrown in FirewallMode::Exception when a challenge POST is successfully
+ * verified.
+ *
+ * In production the Firewall would set the pass-token cookie and emit a
+ * JSON/303 response — neither is observable from a test suite. This
+ * exception carries the minted token so tests can assert that a follow-up
+ * request bearing the token will pass evaluation.
+ */
+class ChallengeSolvedException extends FirewallException
+{
+    public function __construct(
+        private readonly string $token,
+        private readonly string $redirect,
+        ?\Throwable $previous = null
+    ) {
+        parent::__construct('Challenge solved', 0, $previous);
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    public function getRedirect(): string
+    {
+        return $this->redirect;
+    }
+}

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -11,6 +11,12 @@ declare(strict_types=1);
 
 namespace Kanopi\Firewall;
 
+use Kanopi\Firewall\Challenge\ChallengeProviderFactory;
+use Kanopi\Firewall\Challenge\ChallengeProviderInterface;
+use Kanopi\Firewall\Challenge\MathChallengeProvider;
+use Kanopi\Firewall\Challenge\TokenManager;
+use Kanopi\Firewall\Exception\ChallengeRequiredException;
+use Kanopi\Firewall\Exception\ChallengeSolvedException;
 use Kanopi\Firewall\Exception\ConfigurationException;
 use Kanopi\Firewall\Exception\FirewallBlockedException;
 use Kanopi\Firewall\Logging\LoggingFactory;
@@ -44,19 +50,40 @@ final class Firewall
      *   Plugin manager for Blocking Plugins.
      * @param PluginManager $bypassPluginManager
      *   Plugin manager for Bypass Plugins.
+     * @param PluginManager $challengePluginManager
+     *   Plugin manager for Challenge Plugins.
      * @param array $config
      *   Global configuration that can be set as defaults.
+     * @param ChallengeProviderInterface|null $challengeProvider
+     *   Provider that renders + verifies challenges. Required iff at
+     *   least one challenge plugin is configured.
+     * @param TokenManager|null $tokenManager
+     *   Mints / verifies the pass token issued after a challenge is
+     *   solved. Required iff $challengeProvider is set.
+     * @param array<string, mixed> $challengeConfig
+     *   Subset of config relevant to the challenge flow: path,
+     *   cookie_name, header_name.
      */
-    protected function __construct(private StorageInterface $storage, private PluginManager $blockingPluginManager, private PluginManager $bypassPluginManager, private array $config)
-    {
+    protected function __construct(
+        private StorageInterface $storage,
+        private PluginManager $blockingPluginManager,
+        private PluginManager $bypassPluginManager,
+        private PluginManager $challengePluginManager,
+        private array $config,
+        private ?ChallengeProviderInterface $challengeProvider = null,
+        private ?TokenManager $tokenManager = null,
+        private array $challengeConfig = []
+    ) {
         $this->firewallMode = FirewallMode::tryFrom($config['mode'] ?? 'block') ?? FirewallMode::Block;
 
         $this->getLogger()->debug('Firewall instance created', [
             'storage_type' => $storage::class,
             'blocking_plugins_count' => count($blockingPluginManager->getPlugins()),
             'bypass_plugins_count' => count($bypassPluginManager->getPlugins()),
+            'challenge_plugins_count' => count($challengePluginManager->getPlugins()),
             'config_keys' => array_keys($config), // Log keys instead of full config to avoid sensitive data
             'mode' => $this->firewallMode->value,
+            'challenge_enabled' => $challengeProvider !== null,
         ]);
         $this->storage->expire();
     }
@@ -94,6 +121,7 @@ final class Firewall
         $config['logger'] = isset($config['logger']) && is_array($config['logger']) ? array_filter($config['logger']) : [];
         $config['storage'] = isset($config['storage']) && is_array($config['storage']) ? array_filter($config['storage']) : [];
         $config['global'] = isset($config['global']) && is_array($config['global']) ? array_filter($config['global']) : [];
+        $config['challenge'] = isset($config['challenge']) && is_array($config['challenge']) ? $config['challenge'] : [];
 
         LoggingFactory::setLogger(LoggingFactory::create($config['logger']));
 
@@ -125,14 +153,24 @@ final class Firewall
             'storage_config_keys' => array_keys($config['storage']),
             'allow_plugins_count' => count($partitioned['allow']),
             'block_plugins_count' => count($partitioned['block']),
+            'challenge_plugins_count' => count($partitioned['challenge']),
             'global_config_keys' => array_keys($config['global']),
         ]);
+
+        [$challengeProvider, $tokenManager, $challengeConfig] = self::createChallengePieces(
+            $config['challenge'],
+            $partitioned['challenge'] !== []
+        );
 
         $firewall = new self(
             StorageFactory::create($config['storage']),
             PluginManager::createFromPluginsArray($partitioned['block']),
             PluginManager::createFromPluginsArray($partitioned['allow']),
-            $config['global']
+            PluginManager::createFromPluginsArray($partitioned['challenge']),
+            $config['global'],
+            $challengeProvider,
+            $tokenManager,
+            $challengeConfig
         );
 
         LoggingFactory::logger()->debug('Firewall initialized', [
@@ -140,10 +178,67 @@ final class Firewall
             'storage_config_keys' => array_keys($config['storage']),
             'allow_plugins_count' => count($partitioned['allow']),
             'block_plugins_count' => count($partitioned['block']),
+            'challenge_plugins_count' => count($partitioned['challenge']),
             'global_config_keys' => array_keys($config['global']),
         ]);
 
         return $firewall;
+    }
+
+    /**
+     * Build the challenge collaborators (or skip if not needed).
+     *
+     * Returns `[provider|null, tokenManager|null, normalizedChallengeConfig]`.
+     * When no challenge plugins are present and no challenge block was
+     * declared, all three slots are empty/null and the firewall acts as
+     * if the feature did not exist.
+     *
+     * Failing here (rather than at first request) keeps a missing secret
+     * from looking like a 500 deep in the request lifecycle.
+     *
+     * @param array<string, mixed> $challengeConfig
+     *   The `challenge:` section from the loaded YAML.
+     * @param bool $hasChallengePlugins
+     *   Whether any plugin partitioned into the challenge bucket.
+     *
+     * @return array{0: ?ChallengeProviderInterface, 1: ?TokenManager, 2: array<string, mixed>}
+     *
+     * @throws ConfigurationException
+     *   When challenge plugins exist but no secret is configured, or
+     *   when the configured provider cannot be resolved.
+     */
+    private static function createChallengePieces(array $challengeConfig, bool $hasChallengePlugins): array
+    {
+        $defaults = [
+            'provider' => 'math',
+            'secret' => '',
+            'cookie_name' => 'fw_challenge_pass',
+            'header_name' => 'X-Firewall-Challenge',
+            'path' => '/_firewall/challenge',
+        ];
+
+        $challengeConfig = array_replace($defaults, $challengeConfig);
+
+        if (!$hasChallengePlugins) {
+            return [null, null, $challengeConfig];
+        }
+
+        $secret = (string) ($challengeConfig['secret'] ?? '');
+        if ($secret === '') {
+            throw new ConfigurationException(
+                'response: challenge plugins are configured but `challenge.secret` is '
+                . 'empty. Set a long, random secret (typically from an env var) so '
+                . 'pass tokens can be HMAC-signed.'
+            );
+        }
+
+        $tokenManager = new TokenManager($secret);
+        $provider = ChallengeProviderFactory::create(
+            (string) $challengeConfig['provider'],
+            $tokenManager
+        );
+
+        return [$provider, $tokenManager, $challengeConfig];
     }
 
     /**
@@ -229,6 +324,14 @@ final class Firewall
             $this->getLogger()->debug('Request evaluation started', $this->getContext($request));
         }
 
+        // Intercept challenge solutions before any plugin evaluation so a
+        // POST to the magic path can never be blocked by an unrelated rule
+        // (e.g. a URL plugin matching the magic path itself).
+        if ($this->isChallengeSubmission($request)) {
+            $this->handleChallengeSubmission($request);
+            return true;
+        }
+
         if (($plugin = $this->bypassPluginManager->evaluate($request)) !== false) {
             $this->getLogger()->info('Request bypassed', $this->getContext($request, [
                 'plugin_name' => $plugin->getName(),
@@ -244,6 +347,24 @@ final class Firewall
 
             $this->repeatOffender($request);
             $this->sendBlockingResponse($request, intval($this->config['repeat_offender_status'] ?? 0));
+        }
+
+        // A held pass token short-circuits the challenge bucket. Block
+        // plugins still run — the token only attests "I am human", not
+        // "I am allowed everywhere".
+        $hasValidToken = $this->hasValidChallengeToken($request);
+
+        if (!$hasValidToken && ($plugin = $this->challengePluginManager->evaluate($request)) !== false) {
+            if ($this->firewallMode === FirewallMode::Log) {
+                $this->getLogger()->warning('Request would be challenged (log mode)', $this->getContext($request, [
+                    'mode' => 'log',
+                    'plugin_name' => $plugin->getName(),
+                    'plugin_type' => $plugin::class,
+                ]));
+                return true;
+            }
+
+            $this->sendChallengeResponse($request, $plugin);
         }
 
         if (($plugin = $this->blockingPluginManager->evaluate($request)) !== false) {
@@ -263,6 +384,215 @@ final class Firewall
         $this->getLogger()->debug('Request allowed', $this->getContext($request));
 
         return true;
+    }
+
+    /**
+     * Is this request a POST to the configured challenge submission path?
+     *
+     * Only matches when challenge support is actually wired up — a host
+     * app without challenge plugins won't accidentally intercept POSTs to
+     * the default magic path.
+     */
+    protected function isChallengeSubmission(Request $request): bool
+    {
+        if ($this->challengeProvider === null || $this->tokenManager === null) {
+            return false;
+        }
+
+        if ($request->getMethod() !== 'POST') {
+            return false;
+        }
+
+        $path = (string) ($this->challengeConfig['path'] ?? '');
+        return $path !== '' && $request->getPathInfo() === $path;
+    }
+
+    /**
+     * Verify a posted challenge solution and mint a pass token on success.
+     *
+     * Always terminates the request — either with `exit()` in production
+     * (cookie + JSON/303 body) or by throwing in Exception mode.
+     *
+     * @throws ChallengeSolvedException
+     *   In Exception mode when the solution is valid. Carries the minted
+     *   token and the redirect target so tests can assert both.
+     * @throws ChallengeRequiredException
+     *   In Exception mode when the solution is invalid.
+     */
+    protected function handleChallengeSubmission(Request $request): void
+    {
+        if ($this->challengeProvider === null || $this->tokenManager === null) {
+            // Defensive — isChallengeSubmission() already gated this.
+            return;
+        }
+
+        $valid = $this->challengeProvider->verifySolution($request);
+
+        if (!$valid) {
+            $this->getLogger()->info('Challenge solution rejected', $this->getContext($request, [
+                'provider' => $this->challengeProvider->getName(),
+            ]));
+
+            if ($this->firewallMode === FirewallMode::Exception) {
+                throw new ChallengeRequiredException('Invalid challenge solution');
+            }
+
+            // @codeCoverageIgnoreStart
+            http_response_code(400);
+            if (!headers_sent()) {
+                header('Content-Type: application/json; charset=utf-8');
+            }
+            exit((string) json_encode(['error' => 'invalid_solution']));
+            // @codeCoverageIgnoreEnd
+        }
+
+        $ttl = max(0, (int) $request->request->get(MathChallengeProvider::TTL_FIELD, 3600));
+        $token = $this->tokenManager->mint($request, $ttl);
+        $redirect = $this->sanitizeRedirect((string) $request->request->get(MathChallengeProvider::REDIRECT_FIELD, '/'));
+
+        $this->getLogger()->info('Challenge solution accepted', $this->getContext($request, [
+            'provider' => $this->challengeProvider->getName(),
+            'ttl' => $ttl,
+        ]));
+
+        if ($this->firewallMode === FirewallMode::Exception) {
+            throw new ChallengeSolvedException($token, $redirect);
+        }
+
+        // @codeCoverageIgnoreStart
+        $this->setPassTokenCookie($token, $ttl);
+
+        if (!headers_sent()) {
+            header('Content-Type: application/json; charset=utf-8');
+        }
+        exit((string) json_encode(['token' => $token, 'redirect' => $redirect]));
+        // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Render the challenge interstitial for the matched plugin.
+     *
+     * @throws ChallengeRequiredException
+     *   In Exception mode.
+     */
+    protected function sendChallengeResponse(Request $request, PluginInterface $plugin): void
+    {
+        if ($this->challengeProvider === null) {
+            // Should be impossible — partitioning would have routed this
+            // request to the block path instead — but guard anyway so a
+            // misconfigured firewall fails loud rather than serving an
+            // empty page.
+            throw new ConfigurationException(
+                'A challenge plugin matched but no ChallengeProviderInterface is configured.'
+            );
+        }
+
+        $ttl = (int) $plugin->getExpirationTime($request);
+        if ($ttl <= 0) {
+            $ttl = 3600;
+        }
+
+        $this->getLogger()->notice('Sending challenge response', $this->getContext($request, [
+            'plugin_name' => $plugin->getName(),
+            'plugin_type' => $plugin::class,
+            'provider' => $this->challengeProvider->getName(),
+            'ttl' => $ttl,
+        ]));
+
+        if ($this->firewallMode === FirewallMode::Exception) {
+            throw new ChallengeRequiredException(sprintf(
+                'Challenge required by plugin: %s',
+                $plugin->getName()
+            ));
+        }
+
+        // @codeCoverageIgnoreStart
+        $body = $this->challengeProvider->renderInterstitial($request, [
+            'submit_url' => (string) ($this->challengeConfig['path'] ?? '/_firewall/challenge'),
+            'redirect_to' => $this->sanitizeRedirect($request->getRequestUri()),
+            'ttl' => (string) $ttl,
+            'cookie_name' => (string) ($this->challengeConfig['cookie_name'] ?? ''),
+            'header_name' => (string) ($this->challengeConfig['header_name'] ?? ''),
+        ]);
+
+        http_response_code(200);
+        if (!headers_sent()) {
+            header('Content-Type: text/html; charset=utf-8');
+            header('Cache-Control: no-store');
+        }
+        exit($body);
+        // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Does the request carry a pass token that verifies for this client?
+     *
+     * Looks first in the cookie, then in the configured custom header
+     * (the localStorage delivery path used by SPA callers whose XHRs
+     * cannot rely on cookies).
+     */
+    protected function hasValidChallengeToken(Request $request): bool
+    {
+        if ($this->tokenManager === null) {
+            return false;
+        }
+
+        $cookieName = (string) ($this->challengeConfig['cookie_name'] ?? '');
+        $headerName = (string) ($this->challengeConfig['header_name'] ?? '');
+
+        $token = '';
+        if ($cookieName !== '' && $request->cookies->has($cookieName)) {
+            $token = (string) $request->cookies->get($cookieName);
+        }
+
+        if ($token === '' && $headerName !== '' && $request->headers->has($headerName)) {
+            $token = (string) $request->headers->get($headerName);
+        }
+
+        if ($token === '') {
+            return false;
+        }
+
+        return $this->tokenManager->verify($token, $request);
+    }
+
+    /**
+     * Sanitize a redirect target so the interstitial can't be turned into
+     * an open redirect by attacker-controlled hidden form values.
+     *
+     * Accepts only same-origin paths (must start with `/` and must NOT
+     * start with `//` or `/\`). Falls back to "/" otherwise.
+     */
+    protected function sanitizeRedirect(string $target): string
+    {
+        if ($target === '' || $target[0] !== '/') {
+            return '/';
+        }
+        if (str_starts_with($target, '//') || str_starts_with($target, '/\\')) {
+            return '/';
+        }
+        return $target;
+    }
+
+    /**
+     * Set the pass-token cookie with conservative defaults.
+     *
+     * @codeCoverageIgnore
+     */
+    protected function setPassTokenCookie(string $token, int $ttl): void
+    {
+        $cookieName = (string) ($this->challengeConfig['cookie_name'] ?? '');
+        if ($cookieName === '' || headers_sent()) {
+            return;
+        }
+
+        setcookie($cookieName, $token, [
+            'expires' => time() + $ttl,
+            'path' => '/',
+            'secure' => true,
+            'httponly' => true,
+            'samesite' => 'Strict',
+        ]);
     }
 
     /**

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -83,7 +83,7 @@ final class Firewall
             'challenge_plugins_count' => count($challengePluginManager->getPlugins()),
             'config_keys' => array_keys($config), // Log keys instead of full config to avoid sensitive data
             'mode' => $this->firewallMode->value,
-            'challenge_enabled' => $challengeProvider !== null,
+            'challenge_enabled' => $challengeProvider instanceof \Kanopi\Firewall\Challenge\ChallengeProviderInterface,
         ]);
         $this->storage->expire();
     }
@@ -233,12 +233,12 @@ final class Firewall
         }
 
         $tokenManager = new TokenManager($secret);
-        $provider = ChallengeProviderFactory::create(
+        $challengeProvider = ChallengeProviderFactory::create(
             (string) $challengeConfig['provider'],
             $tokenManager
         );
 
-        return [$provider, $tokenManager, $challengeConfig];
+        return [$challengeProvider, $tokenManager, $challengeConfig];
     }
 
     /**
@@ -395,7 +395,7 @@ final class Firewall
      */
     protected function isChallengeSubmission(Request $request): bool
     {
-        if ($this->challengeProvider === null || $this->tokenManager === null) {
+        if (!$this->challengeProvider instanceof \Kanopi\Firewall\Challenge\ChallengeProviderInterface || !$this->tokenManager instanceof \Kanopi\Firewall\Challenge\TokenManager) {
             return false;
         }
 
@@ -421,7 +421,7 @@ final class Firewall
      */
     protected function handleChallengeSubmission(Request $request): void
     {
-        if ($this->challengeProvider === null || $this->tokenManager === null) {
+        if (!$this->challengeProvider instanceof \Kanopi\Firewall\Challenge\ChallengeProviderInterface || !$this->tokenManager instanceof \Kanopi\Firewall\Challenge\TokenManager) {
             // Defensive — isChallengeSubmission() already gated this.
             return;
         }
@@ -442,6 +442,7 @@ final class Firewall
             if (!headers_sent()) {
                 header('Content-Type: application/json; charset=utf-8');
             }
+
             exit((string) json_encode(['error' => 'invalid_solution']));
             // @codeCoverageIgnoreEnd
         }
@@ -465,6 +466,7 @@ final class Firewall
         if (!headers_sent()) {
             header('Content-Type: application/json; charset=utf-8');
         }
+
         exit((string) json_encode(['token' => $token, 'redirect' => $redirect]));
         // @codeCoverageIgnoreEnd
     }
@@ -477,7 +479,7 @@ final class Firewall
      */
     protected function sendChallengeResponse(Request $request, PluginInterface $plugin): void
     {
-        if ($this->challengeProvider === null) {
+        if (!$this->challengeProvider instanceof \Kanopi\Firewall\Challenge\ChallengeProviderInterface) {
             // Should be impossible — partitioning would have routed this
             // request to the block path instead — but guard anyway so a
             // misconfigured firewall fails loud rather than serving an
@@ -487,7 +489,7 @@ final class Firewall
             );
         }
 
-        $ttl = (int) $plugin->getExpirationTime($request);
+        $ttl = $plugin->getExpirationTime($request);
         if ($ttl <= 0) {
             $ttl = 3600;
         }
@@ -520,6 +522,7 @@ final class Firewall
             header('Content-Type: text/html; charset=utf-8');
             header('Cache-Control: no-store');
         }
+
         exit($body);
         // @codeCoverageIgnoreEnd
     }
@@ -533,7 +536,7 @@ final class Firewall
      */
     protected function hasValidChallengeToken(Request $request): bool
     {
-        if ($this->tokenManager === null) {
+        if (!$this->tokenManager instanceof \Kanopi\Firewall\Challenge\TokenManager) {
             return false;
         }
 
@@ -568,9 +571,11 @@ final class Firewall
         if ($target === '' || $target[0] !== '/') {
             return '/';
         }
+
         if (str_starts_with($target, '//') || str_starts_with($target, '/\\')) {
             return '/';
         }
+
         return $target;
     }
 

--- a/src/Utility/PluginConfigNormalizer.php
+++ b/src/Utility/PluginConfigNormalizer.php
@@ -114,16 +114,20 @@ final class PluginConfigNormalizer
     /**
      * Partition plugins array by response type and sort by weight.
      *
+     * Unknown response values default to 'block' so a typo never silently
+     * promotes a plugin to 'allow' or 'challenge'.
+     *
      * @param array<int, array<string, mixed>> $plugins
      *   The plugins array to partition.
      *
-     * @return array{allow: array<int, array<string, mixed>>, block: array<int, array<string, mixed>>}
-     *   Partitioned plugins: 'allow' plugins and 'block' plugins, each sorted by weight.
+     * @return array{allow: array<int, array<string, mixed>>, block: array<int, array<string, mixed>>, challenge: array<int, array<string, mixed>>}
+     *   Partitioned plugins: 'allow', 'block', and 'challenge', each sorted by weight.
      */
     public static function partitionAndSort(array $plugins): array
     {
         $allowPlugins = [];
         $blockPlugins = [];
+        $challengePlugins = [];
 
         foreach ($plugins as $plugin) {
             // Skip disabled plugins
@@ -131,20 +135,27 @@ final class PluginConfigNormalizer
                 continue;
             }
 
-            if (($plugin['response'] ?? 'block') === 'allow') {
-                $allowPlugins[] = $plugin;
-            } else {
-                $blockPlugins[] = $plugin;
+            switch ($plugin['response'] ?? 'block') {
+                case 'allow':
+                    $allowPlugins[] = $plugin;
+                    break;
+                case 'challenge':
+                    $challengePlugins[] = $plugin;
+                    break;
+                default:
+                    $blockPlugins[] = $plugin;
             }
         }
 
-        // Sort each group by weight (lower weights execute first)
-        usort($allowPlugins, static fn(array $a, array $b): int => ($a['weight'] ?? 0) <=> ($b['weight'] ?? 0));
-        usort($blockPlugins, static fn(array $a, array $b): int => ($a['weight'] ?? 0) <=> ($b['weight'] ?? 0));
+        $byWeight = static fn(array $a, array $b): int => ($a['weight'] ?? 0) <=> ($b['weight'] ?? 0);
+        usort($allowPlugins, $byWeight);
+        usort($blockPlugins, $byWeight);
+        usort($challengePlugins, $byWeight);
 
         return [
             'allow' => $allowPlugins,
             'block' => $blockPlugins,
+            'challenge' => $challengePlugins,
         ];
     }
 }

--- a/tests/Integration/ChallengeFlowTest.php
+++ b/tests/Integration/ChallengeFlowTest.php
@@ -1,0 +1,403 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Integration;
+
+use Kanopi\Firewall\Challenge\MathChallengeProvider;
+use Kanopi\Firewall\Exception\ChallengeRequiredException;
+use Kanopi\Firewall\Exception\ChallengeSolvedException;
+use Kanopi\Firewall\Exception\ConfigurationException;
+use Kanopi\Firewall\Firewall;
+use Kanopi\Firewall\Traits\FileTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * End-to-end coverage for the `response: challenge` flow.
+ *
+ * Walks the full lifecycle: a matching plugin triggers an interstitial,
+ * the visitor submits the (correct) answer, the firewall mints a pass
+ * token, and the next request bearing that token sails through.
+ */
+class ChallengeFlowTest extends TestCase
+{
+    use FileTrait;
+
+    private string $tempDir;
+
+    private const SECRET = 'integration-test-secret-value';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        putenv('FIREWALL_BYPASS_CLI=1');
+
+        $this->tempDir = sys_get_temp_dir() . '/firewall_challenge_' . uniqid();
+        if (!mkdir($this->tempDir, 0777, true)) {
+            throw new \RuntimeException('Failed to create temp directory: ' . $this->tempDir);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveRemoveDirectory($this->tempDir);
+        parent::tearDown();
+    }
+
+    public function testMatchedChallengePluginThrowsRequired(): void
+    {
+        $firewall = Firewall::create([$this->configWithChallenge()]);
+
+        $request = $this->blockedRequest('10.0.0.50', '/protected');
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($request);
+    }
+
+    public function testSubmissionWithCorrectAnswerMintsToken(): void
+    {
+        $firewall = Firewall::create([$this->configWithChallenge()]);
+
+        [$state, $answer] = $this->generateSolvedState($firewall, '10.0.0.50');
+
+        $request = Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [
+                MathChallengeProvider::STATE_FIELD => $state,
+                MathChallengeProvider::ANSWER_FIELD => $answer,
+                MathChallengeProvider::REDIRECT_FIELD => '/protected',
+                MathChallengeProvider::TTL_FIELD => '600',
+            ],
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.50']
+        );
+
+        try {
+            $firewall->evaluate($request);
+            $this->fail('Expected ChallengeSolvedException');
+        } catch (ChallengeSolvedException $e) {
+            $this->assertNotEmpty($e->getToken());
+            $this->assertSame('/protected', $e->getRedirect());
+        }
+    }
+
+    public function testSubmissionWithWrongAnswerThrowsChallengeRequired(): void
+    {
+        $firewall = Firewall::create([$this->configWithChallenge()]);
+
+        [$state, $answer] = $this->generateSolvedState($firewall, '10.0.0.50');
+        $wrong = (string) ((int) $answer + 1);
+
+        $request = Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [
+                MathChallengeProvider::STATE_FIELD => $state,
+                MathChallengeProvider::ANSWER_FIELD => $wrong,
+            ],
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.50']
+        );
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($request);
+    }
+
+    public function testValidTokenInCookieAllowsRequest(): void
+    {
+        $firewall = Firewall::create([$this->configWithChallenge()]);
+
+        $token = $this->mintTokenViaSolution($firewall, '10.0.0.50');
+
+        $request = Request::create(
+            '/protected',
+            'GET',
+            [],
+            ['fw_challenge_pass' => $token],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.50']
+        );
+
+        $this->assertTrue($firewall->evaluate($request));
+    }
+
+    public function testValidTokenInHeaderAllowsRequest(): void
+    {
+        $firewall = Firewall::create([$this->configWithChallenge()]);
+
+        $token = $this->mintTokenViaSolution($firewall, '10.0.0.50');
+
+        $request = Request::create(
+            '/protected',
+            'GET',
+            [],
+            [],
+            [],
+            [
+                'REMOTE_ADDR' => '10.0.0.50',
+                'HTTP_X_FIREWALL_CHALLENGE' => $token,
+            ]
+        );
+
+        $this->assertTrue($firewall->evaluate($request));
+    }
+
+    public function testTokenFromDifferentIpIsRejected(): void
+    {
+        // Use a CIDR so two distinct IPs both fall inside the challenge
+        // plugin's scope — otherwise the second IP wouldn't be challenged
+        // even without a token, masking the IP-binding behaviour.
+        $configFile = $this->writeConfig([
+            'global' => ['mode' => 'exception'],
+            'challenge' => [
+                'provider' => 'math',
+                'secret' => self::SECRET,
+                'cookie_name' => 'fw_challenge_pass',
+                'header_name' => 'X-Firewall-Challenge',
+                'path' => '/_firewall/challenge',
+            ],
+            'plugins' => [
+                [
+                    'plugin' => 'Kanopi\Firewall\Plugins\IpAddress',
+                    'response' => 'challenge',
+                    'weight' => 0,
+                    'enable' => true,
+                    'metadata' => ['default_expiration_time' => 600],
+                    'config' => ['10.0.0.0/24'],
+                ],
+            ],
+        ], 'cidr_challenge.yml');
+
+        $firewall = Firewall::create([$configFile]);
+
+        $token = $this->mintTokenViaSolution($firewall, '10.0.0.50');
+
+        // Same token presented by a different client IP — token binding
+        // fails, plugin still applies → challenge fires again.
+        $request = Request::create(
+            '/protected',
+            'GET',
+            [],
+            ['fw_challenge_pass' => $token],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.99']
+        );
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($request);
+    }
+
+    public function testTamperedTokenIsRejected(): void
+    {
+        $firewall = Firewall::create([$this->configWithChallenge()]);
+
+        $token = $this->mintTokenViaSolution($firewall, '10.0.0.50');
+        // Flip a character in the signature portion.
+        [$payload, $signature] = explode('.', $token, 2);
+        $tampered = $payload . '.' . strtr($signature, ['A' => 'B', 'a' => 'b', '0' => '1']);
+
+        $request = Request::create(
+            '/protected',
+            'GET',
+            [],
+            ['fw_challenge_pass' => $tampered],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.50']
+        );
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($request);
+    }
+
+    public function testUnrelatedIpIsNotChallenged(): void
+    {
+        $firewall = Firewall::create([$this->configWithChallenge()]);
+
+        $request = Request::create(
+            '/protected',
+            'GET',
+            [],
+            [],
+            [],
+            ['REMOTE_ADDR' => '8.8.8.8']
+        );
+
+        $this->assertTrue($firewall->evaluate($request));
+    }
+
+    public function testMissingSecretWithChallengePluginsThrowsAtStartup(): void
+    {
+        $configFile = $this->writeConfig([
+            'global' => ['mode' => 'exception'],
+            'challenge' => [
+                'provider' => 'math',
+                'secret' => '',
+            ],
+            'plugins' => [
+                [
+                    'plugin' => 'Kanopi\Firewall\Plugins\IpAddress',
+                    'response' => 'challenge',
+                    'weight' => 0,
+                    'enable' => true,
+                    'config' => ['10.0.0.50'],
+                ],
+            ],
+        ]);
+
+        $this->expectException(ConfigurationException::class);
+        Firewall::create([$configFile]);
+    }
+
+    public function testNoChallengeConfigSkipsFeatureEntirely(): void
+    {
+        // Config with no challenge plugins — challenge feature should be dormant,
+        // and the magic-path POST should fall through to whatever rules exist
+        // (here: nothing, so it's allowed).
+        $configFile = $this->writeConfig([
+            'global' => ['mode' => 'exception'],
+            'plugins' => [],
+        ]);
+
+        $firewall = Firewall::create([$configFile]);
+        $request = Request::create('/_firewall/challenge', 'POST', [], [], [], [
+            'REMOTE_ADDR' => '10.0.0.50',
+        ]);
+
+        $this->assertTrue($firewall->evaluate($request));
+    }
+
+    /**
+     * Build a configuration with a challenge plugin that matches a single IP.
+     */
+    private function configWithChallenge(): string
+    {
+        return $this->writeConfig([
+            'global' => ['mode' => 'exception'],
+            'challenge' => [
+                'provider' => 'math',
+                'secret' => self::SECRET,
+                'cookie_name' => 'fw_challenge_pass',
+                'header_name' => 'X-Firewall-Challenge',
+                'path' => '/_firewall/challenge',
+            ],
+            'plugins' => [
+                [
+                    'plugin' => 'Kanopi\Firewall\Plugins\IpAddress',
+                    'response' => 'challenge',
+                    'weight' => 0,
+                    'enable' => true,
+                    'metadata' => ['default_expiration_time' => 600],
+                    'config' => ['10.0.0.50'],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Build a request that the configured challenge plugin will match.
+     */
+    private function blockedRequest(string $ip, string $path = '/'): Request
+    {
+        return Request::create($path, 'GET', [], [], [], ['REMOTE_ADDR' => $ip]);
+    }
+
+    /**
+     * Drive the firewall through one full challenge cycle and return the
+     * minted pass token.
+     */
+    private function mintTokenViaSolution(Firewall $firewall, string $ip): string
+    {
+        [$state, $answer] = $this->generateSolvedState($firewall, $ip);
+
+        $request = Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [
+                MathChallengeProvider::STATE_FIELD => $state,
+                MathChallengeProvider::ANSWER_FIELD => $answer,
+                MathChallengeProvider::REDIRECT_FIELD => '/protected',
+                MathChallengeProvider::TTL_FIELD => '600',
+            ],
+            [],
+            [],
+            ['REMOTE_ADDR' => $ip]
+        );
+
+        try {
+            $firewall->evaluate($request);
+            $this->fail('Expected ChallengeSolvedException to fire on valid solution');
+        } catch (ChallengeSolvedException $e) {
+            return $e->getToken();
+        }
+
+        return ''; // Unreachable.
+    }
+
+    /**
+     * Render the interstitial via reflection into the provider and pull out
+     * the signed state + correct answer. Avoids parsing the HTML twice.
+     *
+     * @return array{0: string, 1: string}
+     */
+    private function generateSolvedState(Firewall $firewall, string $ip): array
+    {
+        $providerRef = new \ReflectionProperty($firewall, 'challengeProvider');
+        $provider = $providerRef->getValue($firewall);
+        $this->assertInstanceOf(MathChallengeProvider::class, $provider);
+
+        $html = $provider->renderInterstitial(
+            Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => $ip]),
+            [
+                'submit_url' => '/_firewall/challenge',
+                'redirect_to' => '/protected',
+                'ttl' => '600',
+                'cookie_name' => 'fw_challenge_pass',
+                'header_name' => 'X-Firewall-Challenge',
+            ]
+        );
+
+        $stateField = MathChallengeProvider::STATE_FIELD;
+        preg_match('/name="' . preg_quote($stateField, '/') . '" value="([^"]+)"/', $html, $stateMatch);
+        $this->assertNotEmpty($stateMatch, 'state hidden input missing');
+        $state = $stateMatch[1];
+
+        [$data, ] = explode('.', $state, 2);
+        [$answer, ] = explode('|', $data, 2);
+
+        return [$state, $answer];
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function writeConfig(array $config, string $filename = 'challenge_config.yml'): string
+    {
+        $file = $this->tempDir . '/' . $filename;
+        if (file_put_contents($file, Yaml::dump($config, 6, 2)) === false) {
+            throw new \RuntimeException('Failed to write config: ' . $file);
+        }
+        return $file;
+    }
+
+    private function recursiveRemoveDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+        $files = array_diff(scandir($directory), ['.', '..']);
+        foreach ($files as $file) {
+            $path = $directory . '/' . $file;
+            if (is_dir($path)) {
+                $this->recursiveRemoveDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($directory);
+    }
+}

--- a/tests/Integration/ChallengeFlowTest.php
+++ b/tests/Integration/ChallengeFlowTest.php
@@ -197,9 +197,12 @@ class ChallengeFlowTest extends TestCase
         $firewall = Firewall::create([$this->configWithChallenge()]);
 
         $token = $this->mintTokenViaSolution($firewall, '10.0.0.50');
-        // Flip a character in the signature portion.
+        // Replace the first signature character with a guaranteed-different
+        // one; using strtr() would be flaky when the random base64url
+        // signature happens to contain none of the target characters.
         [$payload, $signature] = explode('.', $token, 2);
-        $tampered = $payload . '.' . strtr($signature, ['A' => 'B', 'a' => 'b', '0' => '1']);
+        $replacement = $signature[0] === 'A' ? 'B' : 'A';
+        $tampered = $payload . '.' . $replacement . substr($signature, 1);
 
         $request = Request::create(
             '/protected',

--- a/tests/Unit/Challenge/ChallengeProviderFactoryTest.php
+++ b/tests/Unit/Challenge/ChallengeProviderFactoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Challenge;
+
+use Kanopi\Firewall\Challenge\ChallengeProviderFactory;
+use Kanopi\Firewall\Challenge\ChallengeProviderInterface;
+use Kanopi\Firewall\Challenge\MathChallengeProvider;
+use Kanopi\Firewall\Challenge\TokenManager;
+use Kanopi\Firewall\Exception\ConfigurationException;
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ChallengeProviderFactoryTest extends AbstractTestCase
+{
+    public function testResolvesMathShortName(): void
+    {
+        $provider = ChallengeProviderFactory::create('math', new TokenManager('secret-value'));
+
+        $this->assertInstanceOf(MathChallengeProvider::class, $provider);
+        $this->assertSame('math', $provider->getName());
+    }
+
+    public function testResolvesFqcn(): void
+    {
+        $provider = ChallengeProviderFactory::create(
+            MathChallengeProvider::class,
+            new TokenManager('secret-value')
+        );
+
+        $this->assertInstanceOf(MathChallengeProvider::class, $provider);
+    }
+
+    public function testThrowsOnUnknownClass(): void
+    {
+        $this->expectException(ConfigurationException::class);
+        ChallengeProviderFactory::create('NotARealClass', new TokenManager('secret-value'));
+    }
+
+    public function testThrowsOnClassThatDoesNotImplementInterface(): void
+    {
+        $this->expectException(ConfigurationException::class);
+        // Use any existing class that isn't a provider.
+        ChallengeProviderFactory::create(TokenManager::class, new TokenManager('secret-value'));
+    }
+}

--- a/tests/Unit/Challenge/MathChallengeProviderTest.php
+++ b/tests/Unit/Challenge/MathChallengeProviderTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Challenge;
+
+use Kanopi\Firewall\Challenge\MathChallengeProvider;
+use Kanopi\Firewall\Challenge\TokenManager;
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class MathChallengeProviderTest extends AbstractTestCase
+{
+    private const SECRET = 'math-test-secret-value';
+
+    public function testRenderProducesExpectedFields(): void
+    {
+        $provider = new MathChallengeProvider(new TokenManager(self::SECRET));
+        $request = $this->getRequest('10.0.0.5');
+
+        $html = $provider->renderInterstitial($request, [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => '/wanted-page',
+            'ttl' => '900',
+            'cookie_name' => 'fw_pass',
+            'header_name' => 'X-FW',
+        ]);
+
+        $this->assertStringContainsString('<form', $html);
+        $this->assertStringContainsString('action="/_firewall/challenge"', $html);
+        $this->assertStringContainsString('name="' . MathChallengeProvider::ANSWER_FIELD . '"', $html);
+        $this->assertStringContainsString('name="' . MathChallengeProvider::STATE_FIELD . '"', $html);
+        $this->assertStringContainsString('name="' . MathChallengeProvider::REDIRECT_FIELD . '"', $html);
+        $this->assertStringContainsString('name="' . MathChallengeProvider::TTL_FIELD . '"', $html);
+        $this->assertStringContainsString('value="/wanted-page"', $html);
+        $this->assertStringContainsString('value="900"', $html);
+        // Posed question must reach the body so a visitor can read it.
+        $this->assertMatchesRegularExpression('/What is \d \+ \d\?/', $html);
+    }
+
+    public function testRenderEscapesContextValues(): void
+    {
+        $provider = new MathChallengeProvider(new TokenManager(self::SECRET));
+        $request = $this->getRequest('10.0.0.5');
+
+        $html = $provider->renderInterstitial($request, [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => '/"><script>alert(1)</script>',
+            'ttl' => '60',
+            'cookie_name' => 'fw_pass',
+            'header_name' => 'X-FW',
+        ]);
+
+        $this->assertStringNotContainsString('<script>alert(1)</script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testVerifyAcceptsCorrectAnswer(): void
+    {
+        $tokenManager = new TokenManager(self::SECRET);
+        $provider = new MathChallengeProvider($tokenManager);
+
+        // Extract the signed state + the expected answer from rendered HTML.
+        [$state, $answer] = $this->renderAndExtractSolution($provider);
+
+        $request = $this->makeSubmissionRequest($state, $answer);
+
+        $this->assertTrue($provider->verifySolution($request));
+    }
+
+    public function testVerifyRejectsWrongAnswer(): void
+    {
+        $tokenManager = new TokenManager(self::SECRET);
+        $provider = new MathChallengeProvider($tokenManager);
+
+        [$state, $answer] = $this->renderAndExtractSolution($provider);
+        $wrong = (string) ((int) $answer + 1);
+
+        $this->assertFalse($provider->verifySolution($this->makeSubmissionRequest($state, $wrong)));
+    }
+
+    public function testVerifyRejectsMissingFields(): void
+    {
+        $provider = new MathChallengeProvider(new TokenManager(self::SECRET));
+
+        $this->assertFalse($provider->verifySolution($this->makeSubmissionRequest('', '5')));
+        $this->assertFalse($provider->verifySolution($this->makeSubmissionRequest('a.b', '')));
+        $this->assertFalse($provider->verifySolution($this->makeSubmissionRequest('no-dot', '5')));
+    }
+
+    public function testVerifyRejectsTamperedState(): void
+    {
+        $tokenManager = new TokenManager(self::SECRET);
+        $provider = new MathChallengeProvider($tokenManager);
+
+        [$state, $answer] = $this->renderAndExtractSolution($provider);
+        [$data, $signature] = explode('.', $state, 2);
+
+        // Bump the answer in the data half — signature should no longer match.
+        $tampered = ((string) ((int) $answer + 1)) . substr($data, strlen($answer)) . '.' . $signature;
+
+        $this->assertFalse($provider->verifySolution($this->makeSubmissionRequest($tampered, (string) ((int) $answer + 1))));
+    }
+
+    public function testVerifyRejectsExpiredState(): void
+    {
+        $tokenManager = new TokenManager(self::SECRET);
+        $provider = new MathChallengeProvider($tokenManager);
+
+        // Hand-craft an expired (but properly signed) state.
+        $data = '5|' . (time() - 60);
+        $expired = $data . '.' . $tokenManager->sign($data);
+
+        $this->assertFalse($provider->verifySolution($this->makeSubmissionRequest($expired, '5')));
+    }
+
+    public function testGetNameReturnsMath(): void
+    {
+        $provider = new MathChallengeProvider(new TokenManager(self::SECRET));
+        $this->assertSame('math', $provider->getName());
+    }
+
+    /**
+     * @return array{0: string, 1: string} [signed state, correct answer]
+     */
+    private function renderAndExtractSolution(MathChallengeProvider $provider): array
+    {
+        $request = $this->getRequest('10.0.0.5');
+        $html = $provider->renderInterstitial($request, [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => '/x',
+            'ttl' => '60',
+            'cookie_name' => 'c',
+            'header_name' => 'h',
+        ]);
+
+        // Extract the signed state from the hidden input.
+        $stateField = MathChallengeProvider::STATE_FIELD;
+        preg_match('/name="' . preg_quote($stateField, '/') . '" value="([^"]+)"/', $html, $stateMatch);
+        $this->assertNotEmpty($stateMatch, 'Hidden state field missing from rendered HTML');
+        $state = $stateMatch[1];
+
+        // The state encodes "answer|exp.signature" — split it back out so
+        // the test knows the right answer without parsing the question.
+        [$data, ] = explode('.', $state, 2);
+        [$answer, ] = explode('|', $data, 2);
+
+        return [$state, $answer];
+    }
+
+    private function makeSubmissionRequest(string $state, string $answer): Request
+    {
+        return Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [
+                MathChallengeProvider::STATE_FIELD => $state,
+                MathChallengeProvider::ANSWER_FIELD => $answer,
+            ],
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.5']
+        );
+    }
+}

--- a/tests/Unit/Challenge/TokenManagerTest.php
+++ b/tests/Unit/Challenge/TokenManagerTest.php
@@ -49,7 +49,7 @@ final class TokenManagerTest extends AbstractTestCase
 
         $token = $manager->mint($request, 3600);
         [$payload, $signature] = explode('.', $token, 2);
-        $tampered = strtr($payload, ['A' => 'B', 'a' => 'b']) . '.' . $signature;
+        $tampered = self::flipFirstChar($payload) . '.' . $signature;
 
         $this->assertFalse($manager->verify($tampered, $request));
     }
@@ -61,9 +61,24 @@ final class TokenManagerTest extends AbstractTestCase
 
         $token = $manager->mint($request, 3600);
         [$payload, $signature] = explode('.', $token, 2);
-        $tamperedSig = $payload . '.' . strtr($signature, ['A' => 'B', 'a' => 'b']);
+        $tamperedSig = $payload . '.' . self::flipFirstChar($signature);
 
         $this->assertFalse($manager->verify($tamperedSig, $request));
+    }
+
+    /**
+     * Replace the first character of $s with a different one, so the
+     * resulting string is always distinct from the input — even when the
+     * input is random base64url and may not contain any chosen target
+     * character.
+     */
+    private static function flipFirstChar(string $s): string
+    {
+        if ($s === '') {
+            return 'A';
+        }
+        $replacement = $s[0] === 'A' ? 'B' : 'A';
+        return $replacement . substr($s, 1);
     }
 
     public function testVerifyFailsForExpiredToken(): void

--- a/tests/Unit/Challenge/TokenManagerTest.php
+++ b/tests/Unit/Challenge/TokenManagerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Challenge;
+
+use Kanopi\Firewall\Challenge\TokenManager;
+use Kanopi\Firewall\Exception\ConfigurationException;
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class TokenManagerTest extends AbstractTestCase
+{
+    private const SECRET = 'test-secret-value-do-not-reuse-in-prod';
+
+    public function testEmptySecretThrows(): void
+    {
+        $this->expectException(ConfigurationException::class);
+        new TokenManager('');
+    }
+
+    public function testMintAndVerifyRoundTrip(): void
+    {
+        $manager = new TokenManager(self::SECRET);
+        $request = $this->getRequest('10.0.0.5');
+
+        $token = $manager->mint($request, 3600);
+
+        $this->assertNotEmpty($token);
+        $this->assertStringContainsString('.', $token);
+        $this->assertTrue($manager->verify($token, $request));
+    }
+
+    public function testVerifyFailsForDifferentIp(): void
+    {
+        $manager = new TokenManager(self::SECRET);
+        $original = $this->getRequest('10.0.0.5');
+        $other = $this->getRequest('10.0.0.6');
+
+        $token = $manager->mint($original, 3600);
+
+        $this->assertFalse($manager->verify($token, $other));
+    }
+
+    public function testVerifyFailsForTamperedPayload(): void
+    {
+        $manager = new TokenManager(self::SECRET);
+        $request = $this->getRequest('10.0.0.5');
+
+        $token = $manager->mint($request, 3600);
+        [$payload, $signature] = explode('.', $token, 2);
+        $tampered = strtr($payload, ['A' => 'B', 'a' => 'b']) . '.' . $signature;
+
+        $this->assertFalse($manager->verify($tampered, $request));
+    }
+
+    public function testVerifyFailsForTamperedSignature(): void
+    {
+        $manager = new TokenManager(self::SECRET);
+        $request = $this->getRequest('10.0.0.5');
+
+        $token = $manager->mint($request, 3600);
+        [$payload, $signature] = explode('.', $token, 2);
+        $tamperedSig = $payload . '.' . strtr($signature, ['A' => 'B', 'a' => 'b']);
+
+        $this->assertFalse($manager->verify($tamperedSig, $request));
+    }
+
+    public function testVerifyFailsForExpiredToken(): void
+    {
+        $manager = new TokenManager(self::SECRET);
+        $request = $this->getRequest('10.0.0.5');
+
+        // Mint a token with negative TTL — TokenManager floors that to 3600,
+        // so instead we construct an expired payload directly by signing
+        // hand-rolled JSON with `sign()`.
+        $expiredPayload = json_encode(['ip' => '10.0.0.5', 'exp' => time() - 60, 'nonce' => 'abc']);
+        $encoded = rtrim(strtr(base64_encode((string) $expiredPayload), '+/', '-_'), '=');
+        $expiredToken = $encoded . '.' . $manager->sign($encoded);
+
+        $this->assertFalse($manager->verify($expiredToken, $request));
+    }
+
+    public function testVerifyFailsForGarbageInput(): void
+    {
+        $manager = new TokenManager(self::SECRET);
+        $request = $this->getRequest('10.0.0.5');
+
+        $this->assertFalse($manager->verify('', $request));
+        $this->assertFalse($manager->verify('no-dot', $request));
+        $this->assertFalse($manager->verify('.', $request));
+        $this->assertFalse($manager->verify('a.', $request));
+        $this->assertFalse($manager->verify('.b', $request));
+        $this->assertFalse($manager->verify('a.b.c', $request));
+        $this->assertFalse($manager->verify('!!.!!', $request));
+    }
+
+    public function testSignAndVerifySignature(): void
+    {
+        $manager = new TokenManager(self::SECRET);
+
+        $data = '8|' . (time() + 300);
+        $sig = $manager->sign($data);
+
+        $this->assertNotEmpty($sig);
+        $this->assertTrue($manager->verifySignature($data, $sig));
+        $this->assertFalse($manager->verifySignature($data . 'x', $sig));
+        $this->assertFalse($manager->verifySignature($data, $sig . 'x'));
+    }
+
+    public function testTtlFallsBackTo3600WhenNonPositive(): void
+    {
+        $manager = new TokenManager(self::SECRET);
+        $request = $this->getRequest('10.0.0.5');
+
+        // Negative TTL should still mint a verifiable token (TokenManager
+        // floors to 3600), and that token should verify cleanly.
+        $token = $manager->mint($request, -1);
+        $this->assertTrue($manager->verify($token, $request));
+    }
+}

--- a/tests/Unit/FirewallModeTest.php
+++ b/tests/Unit/FirewallModeTest.php
@@ -18,6 +18,7 @@ class FirewallModeTest extends AbstractTestCase
     private StorageInterface&MockObject $storage;
     private PluginManager&MockObject $blockManager;
     private PluginManager&MockObject $bypassManager;
+    private PluginManager&MockObject $challengeManager;
 
     protected function setUp(): void
     {
@@ -25,6 +26,7 @@ class FirewallModeTest extends AbstractTestCase
         $this->storage = $this->createMock(StorageInterface::class);
         $this->blockManager = $this->createMock(PluginManager::class);
         $this->bypassManager = $this->createMock(PluginManager::class);
+        $this->challengeManager = $this->createMock(PluginManager::class);
     }
 
     private function createFirewall(array $config = []): Firewall
@@ -33,7 +35,14 @@ class FirewallModeTest extends AbstractTestCase
         $firewall = $ref->newInstanceWithoutConstructor();
         $constructor = $ref->getConstructor();
         $constructor->setAccessible(true);
-        $constructor->invoke($firewall, $this->storage, $this->blockManager, $this->bypassManager, $config);
+        $constructor->invoke(
+            $firewall,
+            $this->storage,
+            $this->blockManager,
+            $this->bypassManager,
+            $this->challengeManager,
+            $config
+        );
         return $firewall;
     }
 

--- a/tests/Unit/FirewallTest.php
+++ b/tests/Unit/FirewallTest.php
@@ -22,12 +22,14 @@ class FirewallTest extends AbstractTestCase
     private StorageInterface&MockObject $storage;
     private PluginManager&MockObject $blockManager;
     private PluginManager&MockObject $bypassManager;
+    private PluginManager&MockObject $challengeManager;
 
     protected function setUp(): void {
         parent::setUp();
         $this->storage = $this->createMock(StorageInterface::class);
         $this->blockManager = $this->createMock(PluginManager::class);
         $this->bypassManager = $this->createMock(PluginManager::class);
+        $this->challengeManager = $this->createMock(PluginManager::class);
     }
 
     /**
@@ -38,7 +40,14 @@ class FirewallTest extends AbstractTestCase
         $firewall = $ref->newInstanceWithoutConstructor();
         $constructor = $ref->getConstructor();
         $constructor->setAccessible(true);
-        $constructor->invoke($firewall, $storage ?? $this->storage, $this->blockManager, $this->bypassManager, $config);
+        $constructor->invoke(
+            $firewall,
+            $storage ?? $this->storage,
+            $this->blockManager,
+            $this->bypassManager,
+            $this->challengeManager,
+            $config
+        );
         return $firewall;
     }
 

--- a/tests/Unit/Utility/PluginConfigNormalizerTest.php
+++ b/tests/Unit/Utility/PluginConfigNormalizerTest.php
@@ -457,6 +457,89 @@ final class PluginConfigNormalizerTest extends AbstractTestCase
     }
 
     /**
+     * Test: partitionAndSort routes response: challenge to challenge bucket.
+     */
+    public function testPartitionAndSortRoutesChallenge(): void
+    {
+        $plugins = [
+            [
+                'plugin' => 'Kanopi\Firewall\Plugins\IpAddress',
+                'response' => 'challenge',
+                'weight' => 0,
+                'enable' => true,
+            ],
+            [
+                'plugin' => 'Kanopi\Firewall\Plugins\Url',
+                'response' => 'block',
+                'weight' => 0,
+                'enable' => true,
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::partitionAndSort($plugins);
+
+        $this->assertArrayHasKey('challenge', $result);
+        $this->assertCount(1, $result['challenge']);
+        $this->assertCount(0, $result['allow']);
+        $this->assertCount(1, $result['block']);
+        $this->assertEquals('Kanopi\Firewall\Plugins\IpAddress', $result['challenge'][0]['plugin']);
+    }
+
+    /**
+     * Test: challenge bucket sorts by weight.
+     */
+    public function testPartitionAndSortSortsChallengeByWeight(): void
+    {
+        $plugins = [
+            [
+                'plugin' => 'C',
+                'response' => 'challenge',
+                'weight' => 100,
+                'enable' => true,
+            ],
+            [
+                'plugin' => 'A',
+                'response' => 'challenge',
+                'weight' => -100,
+                'enable' => true,
+            ],
+            [
+                'plugin' => 'B',
+                'response' => 'challenge',
+                'weight' => 0,
+                'enable' => true,
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::partitionAndSort($plugins);
+
+        $this->assertEquals('A', $result['challenge'][0]['plugin']);
+        $this->assertEquals('B', $result['challenge'][1]['plugin']);
+        $this->assertEquals('C', $result['challenge'][2]['plugin']);
+    }
+
+    /**
+     * Test: unknown response value falls back to block, not challenge.
+     */
+    public function testPartitionAndSortUnknownResponseDefaultsToBlock(): void
+    {
+        $plugins = [
+            [
+                'plugin' => 'Kanopi\Firewall\Plugins\IpAddress',
+                'response' => 'bogus',
+                'weight' => 0,
+                'enable' => true,
+            ],
+        ];
+
+        $result = PluginConfigNormalizer::partitionAndSort($plugins);
+
+        $this->assertCount(0, $result['allow']);
+        $this->assertCount(0, $result['challenge']);
+        $this->assertCount(1, $result['block']);
+    }
+
+    /**
      * Test: full workflow from legacy format to partitioned plugins.
      */
     public function testFullWorkflow(): void


### PR DESCRIPTION
## Summary

- Adds a third plugin response mode — `challenge` — alongside `allow` and `block`. Matched requests are served a CAPTCHA-style interstitial; solving it mints an HMAC-signed pass token (IP-bound, per-plugin TTL) delivered as cookie + custom header. Subsequent requests bearing the token skip the challenge bucket; block plugins still apply.
- Ships built-in `MathChallengeProvider` ("What is A + B?") plus a `ChallengeProviderInterface` extension point. ALTCHA / Turnstile / hCaptcha adapters can land as separate PRs against the same interface (ALTCHA tracked in #72).
- Includes a general-purpose firewall demo under `example/demo/` with three stacks (PHP built-in, multi-worker, nginx + php-fpm) and `composer demo*` shortcuts for each.

## What changed

**Architecture (`src/`)**
- `Challenge/ChallengeProviderInterface.php` — `renderInterstitial()` / `verifySolution()` / `getName()`.
- `Challenge/MathChallengeProvider.php` — built-in provider; stateless via an HMAC-signed `answer|exp.signature` hidden field. Inline HTML+JS interstitial (no static assets).
- `Challenge/TokenManager.php` — HMAC-SHA256 mint/verify over `base64url(JSON{ip, exp, nonce}).base64url(hmac)`. Constant-time signature check; fails fast on empty secret.
- `Challenge/ChallengeProviderFactory.php` — resolves `'math'` short name or FQCN, parallel to `StorageFactory`.
- `Firewall::evaluate()` — new dispatch order: challenge-submission intercept → bypass → repeat-offender check → valid-token short-circuit → challenge plugins → block plugins.
- `Exception/ChallengeRequiredException.php`, `ChallengeSolvedException.php` — parallel `FirewallBlockedException` for `FirewallMode::Exception` tests; `ChallengeSolvedException` carries the minted token + redirect target so integration tests can assert both.
- `Utility/PluginConfigNormalizer.php` — `partitionAndSort()` now returns a third `challenge` bucket; unknown response values still default to `block`.

**Config**
- New optional top-level `challenge:` section (`provider`, `secret`, `cookie_name`, `header_name`, `path`). Only required when a plugin uses `response: challenge`; `Firewall::create()` throws `ConfigurationException` if `challenge.secret` is empty in that case.
- Defaults added to `config/config.yml`.

**Tests (`tests/`)**
- `Unit/Challenge/TokenManagerTest.php`, `MathChallengeProviderTest.php`, `ChallengeProviderFactoryTest.php` — 21 unit tests covering mint/verify, IP mismatch, expiry, tampering, render escaping, provider resolution.
- `Unit/Utility/PluginConfigNormalizerTest.php` — 3 new tests for the challenge partition.
- `Integration/ChallengeFlowTest.php` — 10 end-to-end tests covering the full render → solve → mint → cookie+header re-presentation loop, IP-binding rejection, tampered-token rejection, missing-secret startup failure.
- `Unit/FirewallTest.php`, `Unit/FirewallModeTest.php` — reflection-constructor helpers updated for the new 4th `PluginManager` argument.

**Demo (`example/demo/`)**
- Three response modes wired up via URL-based rules (`/admin` blocked, `/secure` challenged, `/` allowed) so the demo behaves identically regardless of how Docker mangles the source IP.
- Stacks: PHP built-in server (`composer demo`), multi-worker built-in (`composer demo:workers`), nginx + php-fpm via Docker for production-shaped perf testing (`composer demo:perf`).
- `FileStorage` at `/tmp/firewall-demo.data`; every start path wipes the file on boot so each `up` is a clean slate. `composer demo:reset` for on-the-fly resets between runs.
- README documents perf-testing the token-verification hot path with `wrk`.

**Docs**
- Main `README.md` → new "Challenge Response Type" section (config shape, dispatch table, when to use it, when not to); Configuration Overview table updated.
- `presets/README.md` → `response:` field doc updated.
- `example/config.notes.yml` → new `challenge:` block + commented `response: challenge` example.

## Test plan

- [x] `vendor/bin/phpunit` — 740 tests pass; only the 6 pre-existing Redis errors remain on local envs without `ext-redis` (same set noted in #71).
- [x] `composer demo` smoke test — `/admin/foo/bar` → 400 with banning message echoing the deep path; `/secure/bar` → math interstitial; `composer demo:reset` clears storage and allows the challenge to re-fire.
- [x] `composer demo:perf` (nginx + php-fpm) smoke test — identical behavior to built-in server; full challenge → POST → cookie → reload cycle verified.
- [x] Storage persistence verified — `/admin` hit then `/secure` returns 400 (repeat-offender path) with the original `request_id` reused.
- [x] `composer validate` — clean.
- [ ] CI on this PR is green.
- [ ] Spot-check rendered README "Challenge Response Type" section on GitHub.

Follow-up: ALTCHA provider tracked in #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)