### PR TITLE
Add ALTCHA challenge provider (Fixes #72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,7 +875,19 @@ If any plugin uses `response: challenge`, `challenge.secret` is **required**. St
 Two providers ship with the firewall — set `challenge.provider` to either short name:
 
 - **`math`** — asks "What is A + B?" with single-digit operands. Low-friction proof-of-effort, no JS bundle, no external script load. Defeats the laziest bots; trivial for a human.
-- **`altcha`** — embeds the [ALTCHA](https://altcha.org/docs/v2/) v2 widget with a pre-computed challenge (no server round-trip to fetch one). The visitor's browser brute-forces `SHA-256(salt + N) == challenge`; the salt embeds an expiry and the challenge is HMAC-signed with `challenge.secret`, so the server stays stateless. Self-hostable, privacy-respecting, and imposes a measurable per-solve CPU cost on bots. The widget script loads from `cdn.jsdelivr.net/npm/altcha`; allow it in your CSP if you have one.
+- **`altcha`** — embeds the [ALTCHA](https://altcha.org/docs/v2/) v2 widget with a pre-computed challenge (no server round-trip to fetch one). The visitor's browser brute-forces `SHA-256(salt + N) == challenge`; the salt embeds an expiry and the challenge is HMAC-signed with `challenge.secret`, so the server stays stateless. Privacy-respecting, and imposes a per-solve CPU cost on bots.
+
+  The widget script is pinned to an exact version and served with a Subresource Integrity digest. To self-host it, or to serve it from a host your CSP already allows, set both options — supplying `widget_src` without `widget_integrity` emits no `integrity` attribute, since a digest that does not match the bytes would block the script entirely:
+
+  ```yaml
+  challenge:
+    provider: altcha
+    provider_options:
+      widget_src: /assets/altcha.min.js
+      widget_integrity: 'sha384-…'   # openssl dgst -sha384 -binary altcha.min.js | openssl base64 -A
+  ```
+
+  The bundle is an ES module, so it is loaded with `<script type="module">`. If you host it yourself, keep that in mind: a classic script tag fails with `Unexpected token 'export'`.
 
 For stronger bot resistance (Turnstile, hCaptcha, reCAPTCHA, etc.), implement `Kanopi\Firewall\Challenge\ChallengeProviderInterface` and set `challenge.provider` to its FQCN.
 

--- a/README.md
+++ b/README.md
@@ -688,9 +688,14 @@ plugins:
 
 If any plugin uses `response: challenge`, `challenge.secret` is **required**. Startup fails fast with `ConfigurationException` when it is empty — the firewall will not silently fall back to plaintext tokens.
 
-#### Built-in provider
+#### Built-in providers
 
-The `math` provider asks "What is A + B?" with single-digit operands. It's a low-friction proof-of-effort, not a CAPTCHA. For stronger bot resistance, implement `Kanopi\Firewall\Challenge\ChallengeProviderInterface` (Turnstile, hCaptcha, reCAPTCHA, etc.) and set `challenge.provider` to its FQCN.
+Two providers ship with the firewall — set `challenge.provider` to either short name:
+
+- **`math`** — asks "What is A + B?" with single-digit operands. Low-friction proof-of-effort, no JS bundle, no external script load. Defeats the laziest bots; trivial for a human.
+- **`altcha`** — embeds the [ALTCHA](https://altcha.org/docs/v2/) v2 widget with a pre-computed challenge (no server round-trip to fetch one). The visitor's browser brute-forces `SHA-256(salt + N) == challenge`; the salt embeds an expiry and the challenge is HMAC-signed with `challenge.secret`, so the server stays stateless. Self-hostable, privacy-respecting, and imposes a measurable per-solve CPU cost on bots. The widget script loads from `cdn.jsdelivr.net/npm/altcha`; allow it in your CSP if you have one.
+
+For stronger bot resistance (Turnstile, hCaptcha, reCAPTCHA, etc.), implement `Kanopi\Firewall\Challenge\ChallengeProviderInterface` and set `challenge.provider` to its FQCN.
 
 #### How dispatch interacts with allow / block
 

--- a/README.md
+++ b/README.md
@@ -871,6 +871,19 @@ plugins:
 
 If any plugin uses `response: challenge`, `challenge.secret` is **required**. Startup fails fast with `ConfigurationException` when it is empty — the firewall will not silently fall back to plaintext tokens.
 
+#### Single-use solutions
+
+A stateless provider verifies a solution purely from the posted payload, so the same payload keeps verifying until it expires. For a proof-of-work challenge that quietly defeats the point: an attacker solves one challenge and hands the payload to as many clients as they like, each minting its own IP-bound pass token, and the per-solve cost is amortised to nothing.
+
+Providers can opt out of that by implementing `Kanopi\Firewall\Challenge\SingleUseSolutionInterface`, which hands the firewall an identifier for the solution in the current request. The firewall records it in the configured storage backend and refuses any later submission carrying the same identifier. `altcha` implements this; a solved payload is accepted exactly once.
+
+Two consequences worth knowing:
+
+- **The challenge flow now writes to storage.** Records are small (one per solved challenge) and expire on their own when the underlying challenge would have gone stale. With `InMemoryStorage` they do not survive the process, so use a shared backend if you serve challenges from more than one worker.
+- **The check is read-then-write, not atomic.** Two submissions of the same solution arriving in the same instant can both succeed. This shrinks the reuse window from the full challenge lifetime to microseconds, which is the part that matters — the attack being closed is redistribution over seconds or minutes, not winning a race.
+
+`math` deliberately does **not** implement it: its signed state is `answer|expiry`, and with only nine possible answers two visitors served in the same second routinely share one, so treating that value as single-use would reject legitimate solvers.
+
 #### Scoping tokens across instances
 
 A pass token attests "this client solved *a* challenge" — so if two Firewall instances share a `challenge.secret`, they would accept each other's tokens without further scoping. That matters when the challenges differ in strength: a token earned on the trivial `math` challenge could otherwise be replayed against a route protected by `altcha`, and the weakest challenge in your deployment would set the effective security of every route that shares the secret.
@@ -895,7 +908,7 @@ The alternative is to give each instance its own `challenge.secret`, which isola
 Two providers ship with the firewall — set `challenge.provider` to either short name:
 
 - **`math`** — asks "What is A + B?" with single-digit operands. Low-friction proof-of-effort, no JS bundle, no external script load. Defeats the laziest bots; trivial for a human.
-- **`altcha`** — embeds the [ALTCHA](https://altcha.org/docs/v2/) v2 widget with a pre-computed challenge (no server round-trip to fetch one). The visitor's browser brute-forces `SHA-256(salt + N) == challenge`; the salt embeds an expiry and the challenge is HMAC-signed with `challenge.secret`, so the server stays stateless. Privacy-respecting, and imposes a per-solve CPU cost on bots.
+- **`altcha`** — embeds the [ALTCHA](https://altcha.org/docs/v2/) v2 widget with a pre-computed challenge (no server round-trip to fetch one). The visitor's browser brute-forces `SHA-256(salt + N) == challenge`; the salt embeds an expiry and the challenge is HMAC-signed with `challenge.secret`, so the server stays stateless. Privacy-respecting, and imposes a per-solve CPU cost on bots. Solved challenges are single-use — see [Single-use solutions](#single-use-solutions).
 
   The widget script is pinned to an exact version and served with a Subresource Integrity digest. To self-host it, or to serve it from a host your CSP already allows, set both options — supplying `widget_src` without `widget_integrity` emits no `integrity` attribute, since a digest that does not match the bytes would block the script entirely:
 

--- a/README.md
+++ b/README.md
@@ -844,6 +844,7 @@ The pass token is:
 
 - **Signed** with the configured `challenge.secret` (HMAC-SHA256) so it cannot be forged.
 - **IP-bound** — the token only verifies for the same client IP that solved the challenge.
+- **Audience-bound** — the token carries an `aud` claim and only verifies against the instance that issued it. See [Scoping tokens across instances](#scoping-tokens-across-instances).
 - **Delivered two ways** — as an `HttpOnly; Secure; SameSite=Strict` cookie *and* as a value the interstitial JS writes to `localStorage` so SPA callers can attach it to XHRs via a custom header (defaults to `X-Firewall-Challenge`).
 - **Expires** after `metadata.default_expiration_time` seconds for the matched plugin (default `3600`).
 
@@ -869,6 +870,25 @@ plugins:
 ```
 
 If any plugin uses `response: challenge`, `challenge.secret` is **required**. Startup fails fast with `ConfigurationException` when it is empty — the firewall will not silently fall back to plaintext tokens.
+
+#### Scoping tokens across instances
+
+A pass token attests "this client solved *a* challenge" — so if two Firewall instances share a `challenge.secret`, they would accept each other's tokens without further scoping. That matters when the challenges differ in strength: a token earned on the trivial `math` challenge could otherwise be replayed against a route protected by `altcha`, and the weakest challenge in your deployment would set the effective security of every route that shares the secret.
+
+Tokens therefore carry an `aud` claim, which defaults to the configured provider name and is covered by the signature. A `math` token will not verify against an `altcha` instance.
+
+If you run **the same provider** in several places with the same secret — say a low-value public route and a sensitive admin area — the default audiences are identical, so set them apart explicitly:
+
+```yaml
+challenge:
+  provider: altcha
+  secret: "${FIREWALL_SECRET}"
+  audience: admin-portal   # defaults to the provider name
+```
+
+The alternative is to give each instance its own `challenge.secret`, which isolates them just as effectively.
+
+> **Upgrade note.** Pass tokens minted before the `aud` claim existed are rejected, because verification fails closed rather than treating a missing audience as a match. The visible effect is that everyone holding a live pass token is challenged once more after deploying. Tokens are short-lived (default one hour), so this clears on its own.
 
 #### Built-in providers
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -15,12 +15,17 @@ plugins: []
 #   header_name: Header the interstitial JS stashes in localStorage and
 #                that SPA callers send on subsequent XHRs. Set to "" to
 #                disable the localStorage delivery path.
+#   provider_options:
+#                Optional per-provider settings forwarded to the provider
+#                constructor. `altcha` accepts `widget_src` and
+#                `widget_integrity`; see example/config.notes.yml.
 challenge:
   provider: math
   secret: ''
   path: /_firewall/challenge
   cookie_name: fw_challenge_pass
   header_name: X-Firewall-Challenge
+  provider_options: {}
 # Legacy format (deprecated, auto-converted to plugins:)
 bypass: ~
 block: ~

--- a/config/config.yml
+++ b/config/config.yml
@@ -19,6 +19,9 @@ plugins: []
 #                Optional per-provider settings forwarded to the provider
 #                constructor. `altcha` accepts `widget_src` and
 #                `widget_integrity`; see example/config.notes.yml.
+#   audience:    Scopes pass tokens to this instance so two firewalls
+#                sharing a secret do not accept each other's tokens.
+#                Defaults to the provider name when left empty.
 challenge:
   provider: math
   secret: ''
@@ -26,6 +29,7 @@ challenge:
   cookie_name: fw_challenge_pass
   header_name: X-Firewall-Challenge
   provider_options: {}
+  audience: ''
 # Legacy format (deprecated, auto-converted to plugins:)
 bypass: ~
 block: ~

--- a/example/config.notes.yml
+++ b/example/config.notes.yml
@@ -72,10 +72,15 @@ storage:
 # plugin does, `secret` is REQUIRED — startup throws ConfigurationException
 # if it is empty.
 challenge:
-  # Short name of a built-in provider ("math") or FQCN of a class that
-  # implements Kanopi\Firewall\Challenge\ChallengeProviderInterface.
-  # The built-in "math" provider asks "What is A + B?" with single-digit
-  # operands — a low-friction proof-of-effort, not a CAPTCHA.
+  # Short name of a built-in provider ("math", "altcha") or FQCN of a class
+  # that implements Kanopi\Firewall\Challenge\ChallengeProviderInterface.
+  #   math   — "What is A + B?" with single-digit operands. Low-friction
+  #            proof-of-effort, no JS bundle, no external script load.
+  #   altcha — Embeds the ALTCHA v2 widget with a pre-computed challenge.
+  #            The browser brute-forces SHA-256(salt + N) == challenge;
+  #            challenge is HMAC-signed with `secret`. Self-hostable,
+  #            privacy-respecting, measurable per-solve CPU cost on bots.
+  #            See https://altcha.org/docs/v2/.
   provider: math
   # HMAC secret used to sign pass tokens. MUST be a long, random value. The
   # `${VAR}` syntax loads it from an env var so it stays out of source control.

--- a/example/config.notes.yml
+++ b/example/config.notes.yml
@@ -78,10 +78,24 @@ challenge:
   #            proof-of-effort, no JS bundle, no external script load.
   #   altcha — Embeds the ALTCHA v2 widget with a pre-computed challenge.
   #            The browser brute-forces SHA-256(salt + N) == challenge;
-  #            challenge is HMAC-signed with `secret`. Self-hostable,
-  #            privacy-respecting, measurable per-solve CPU cost on bots.
+  #            challenge is HMAC-signed with `secret`. Privacy-respecting,
+  #            per-solve CPU cost on bots, solved challenges are single-use.
   #            See https://altcha.org/docs/v2/.
   provider: math
+  # Optional per-provider settings, forwarded to the provider constructor.
+  # Unknown keys are ignored, so this is safe to leave empty.
+  #
+  # altcha accepts:
+  #   widget_src       — URL of the ALTCHA widget bundle. Defaults to an
+  #                      exact pinned version on jsDelivr. Override to
+  #                      self-host, or to use a host your CSP allows.
+  #   widget_integrity — SRI digest matching widget_src. Defaults to the
+  #                      digest of the pinned bundle. If you set widget_src
+  #                      without this, no integrity attribute is emitted —
+  #                      a mismatched digest would block the script.
+  #                      Generate with:
+  #                        openssl dgst -sha384 -binary FILE | openssl base64 -A
+  provider_options: {}
   # HMAC secret used to sign pass tokens. MUST be a long, random value. The
   # `${VAR}` syntax loads it from an env var so it stays out of source control.
   secret: '${FIREWALL_CHALLENGE_SECRET}'

--- a/example/config.notes.yml
+++ b/example/config.notes.yml
@@ -96,6 +96,13 @@ challenge:
   #                      Generate with:
   #                        openssl dgst -sha384 -binary FILE | openssl base64 -A
   provider_options: {}
+  # Scopes pass tokens to this instance. Tokens carry the value as an `aud`
+  # claim and only verify against a firewall configured with the same one,
+  # so two instances that share `secret` but run different challenges do
+  # not accept each other's tokens. Defaults to the provider name; set it
+  # explicitly when several instances run the SAME provider and should not
+  # share passes (e.g. a public site and an admin portal).
+  audience: ''
   # HMAC secret used to sign pass tokens. MUST be a long, random value. The
   # `${VAR}` syntax loads it from an env var so it stays out of source control.
   secret: '${FIREWALL_CHALLENGE_SECRET}'

--- a/example/demo/README.md
+++ b/example/demo/README.md
@@ -1,6 +1,6 @@
 # Lite Firewall local demo
 
-A throwaway harness for poking at the firewall in a browser. Demonstrates all three response modes (`allow`, `block`, `challenge`) in one config, and ships a production-shaped nginx → php-fpm stack so you can run perf experiments against something that looks like a real deployment.
+A throwaway harness for poking at the firewall in a browser. Demonstrates all three response modes (`allow`, `block`, `challenge`) and both built-in challenge providers (`math` and `altcha`) side by side, and ships a production-shaped nginx → php-fpm stack so you can run perf experiments against something that looks like a real deployment.
 
 ## TL;DR — composer shortcuts
 
@@ -18,11 +18,14 @@ The longer-form invocations and tuning knobs are documented below.
 
 The config keys rules off the URL so behavior is identical on any networking setup:
 
-| Path     | Result                                                                                          |
-|----------|-------------------------------------------------------------------------------------------------|
-| `/`      | Allowed — nothing matches.                                                                      |
-| `/admin` | Blocked — a `response: block` URL plugin returns 400 with the configured banning message.       |
-| `/secure`| Challenged — `response: challenge` serves a math interstitial. Solve it once, get a 60s pass cookie. |
+| Path              | Result                                                                                          |
+|-------------------|-------------------------------------------------------------------------------------------------|
+| `/`               | Allowed — nothing matches.                                                                      |
+| `/admin`          | Blocked — a `response: block` URL plugin returns 400 with the configured banning message.       |
+| `/secure`         | Challenged via the **math** provider. Solve "What is A + B?" → 60s pass cookie (`fw_challenge_pass`). |
+| `/secure-altcha`  | Challenged via the **ALTCHA** provider. The widget solves a SHA-256 proof-of-work automatically → 60s pass cookie (`fw_challenge_altcha_pass`). |
+
+Only one `challenge.provider` is configurable per Firewall instance, so the demo ships two configs (`config.yml` for math, `config.altcha.yml` for ALTCHA) and `index.php` dispatches between them based on the request path. The two pass tokens live in distinct cookies / submit paths so they coexist cleanly.
 
 ## Option 1 — PHP built-in server (quick)
 

--- a/example/demo/README.md
+++ b/example/demo/README.md
@@ -25,7 +25,9 @@ The config keys rules off the URL so behavior is identical on any networking set
 | `/secure`         | Challenged via the **math** provider. Solve "What is A + B?" → 60s pass cookie (`fw_challenge_pass`). |
 | `/secure-altcha`  | Challenged via the **ALTCHA** provider. The widget solves a SHA-256 proof-of-work automatically → 60s pass cookie (`fw_challenge_altcha_pass`). |
 
-Only one `challenge.provider` is configurable per Firewall instance, so the demo ships two configs (`config.yml` for math, `config.altcha.yml` for ALTCHA) and `index.php` dispatches between them based on the request path. The two pass tokens live in distinct cookies / submit paths so they coexist cleanly.
+Only one `challenge.provider` is configurable per Firewall instance, so the demo ships two configs (`config.yml` for math, `config.altcha.yml` for ALTCHA) and `index.php` dispatches between them based on the request path. The two pass tokens live in distinct cookies and submit paths so they coexist in one browser session.
+
+Note that the distinct cookie names are ergonomics, not a security boundary. The two instances share a `challenge.secret`, so what actually stops a token earned on the easy math challenge from opening `/secure-altcha` is the `aud` claim, which defaults to the provider name — see [Scoping tokens across instances](../../README.md#scoping-tokens-across-instances). Try it: solve `/secure`, copy `fw_challenge_pass` into `fw_challenge_altcha_pass`, and `/secure-altcha` still challenges you.
 
 ## Option 1 — PHP built-in server (quick)
 

--- a/example/demo/config.altcha.yml
+++ b/example/demo/config.altcha.yml
@@ -1,0 +1,36 @@
+# ALTCHA variant of the demo config.
+#
+# Loaded by example/demo/index.php whenever the request touches the ALTCHA
+# routes (/secure-altcha or /_firewall/challenge-altcha) — see that file
+# for the dispatch logic. Everything else falls back to config.yml.
+#
+# Each provider gets a distinct challenge submit path, cookie name, and
+# header name so a math pass token and an altcha pass token can co-exist
+# in the same browser session without overwriting each other.
+
+global:
+  banning_message: "Blocked: {{request.path}} is restricted (request {{request.id}})."
+
+# Same storage file as config.yml so a block recorded by one Firewall
+# instance is observed by the other (repeat-offender behavior).
+storage:
+  type: Kanopi\Firewall\Storage\FileStorage
+  config:
+    storage_file: /tmp/firewall-demo.data
+
+challenge:
+  provider: altcha
+  secret: 'demo-secret-do-not-reuse-in-prod'
+  cookie_name: fw_challenge_altcha_pass
+  header_name: X-Firewall-Challenge-Altcha
+  path: /_firewall/challenge-altcha
+
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: challenge
+    weight: 0
+    enable: true
+    metadata:
+      default_expiration_time: 60
+    config:
+      - "path@starts_with:/secure-altcha"

--- a/example/demo/index.php
+++ b/example/demo/index.php
@@ -5,11 +5,18 @@ declare(strict_types=1);
 /*
  * Front controller for the Lite Firewall demo.
  *
- * Three demo routes — see example/demo/config.yml for the rules:
+ * Four demo routes — see example/demo/config.yml and config.altcha.yml
+ * for the rules:
  *
- *   /            allowed
- *   /admin       blocked
- *   /secure      challenged (interstitial → solve → pass token → reload)
+ *   /                allowed
+ *   /admin           blocked
+ *   /secure          challenged via the math provider
+ *   /secure-altcha   challenged via the ALTCHA provider
+ *
+ * Only one ChallengeProviderInterface is wired per Firewall instance,
+ * so the two challenge providers live in separate config files and we
+ * dispatch by path: anything touching /secure-altcha (or its submit
+ * endpoint) loads config.altcha.yml; everything else loads config.yml.
  *
  * Run with the PHP built-in server (single-process):
  *
@@ -22,13 +29,21 @@ declare(strict_types=1);
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-\Kanopi\Firewall\Firewall::create([__DIR__ . '/config.yml'])->evaluate();
+$requestPath = strtok((string) ($_SERVER['REQUEST_URI'] ?? '/'), '?') ?: '/';
+
+$useAltcha = str_starts_with($requestPath, '/secure-altcha')
+    || $requestPath === '/_firewall/challenge-altcha';
+
+$configFile = $useAltcha ? 'config.altcha.yml' : 'config.yml';
+
+\Kanopi\Firewall\Firewall::create([__DIR__ . '/' . $configFile])->evaluate();
 
 // Anything past evaluate() means the firewall allowed the request through:
 // either nothing matched, or a pass token is held.
 $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
 $path = $_SERVER['REQUEST_URI'] ?? '/';
-$cookiePresent = isset($_COOKIE['fw_challenge_pass']);
+$mathCookie = isset($_COOKIE['fw_challenge_pass']);
+$altchaCookie = isset($_COOKIE['fw_challenge_altcha_pass']);
 
 header('Content-Type: text/html; charset=utf-8');
 
@@ -59,21 +74,23 @@ header('Content-Type: text/html; charset=utf-8');
     <tbody>
       <tr><td><a href="/">/</a></td><td>Allowed — this page.</td></tr>
       <tr><td><a href="/admin">/admin</a></td><td>Blocked — the URL plugin rejects anything under <code>/admin</code> with a 400.</td></tr>
-      <tr><td><a href="/secure">/secure</a></td><td>Challenged — math interstitial. Solve it once, then <code>/secure</code> stays accessible for 60s via the pass cookie.</td></tr>
+      <tr><td><a href="/secure">/secure</a></td><td>Challenged via the <strong>math</strong> provider — "What is A + B?" interstitial. 60s pass cookie.</td></tr>
+      <tr><td><a href="/secure-altcha">/secure-altcha</a></td><td>Challenged via the <strong>ALTCHA</strong> provider — proof-of-work widget solves automatically. 60s pass cookie.</td></tr>
     </tbody>
   </table>
 
   <h2>Re-triggering the challenge</h2>
   <p>The pass token TTL is 60s in this demo. To force the interstitial again sooner:</p>
   <ul>
-    <li>Delete the <code>fw_challenge_pass</code> cookie via browser dev tools, or</li>
-    <li>Reload <code>/secure</code> in an incognito window.</li>
+    <li>Delete the <code>fw_challenge_pass</code> / <code>fw_challenge_altcha_pass</code> cookie via browser dev tools, or</li>
+    <li>Reload the route in an incognito window.</li>
   </ul>
 
   <p class="meta">
     Request path: <code><?= htmlspecialchars($path, ENT_QUOTES, 'UTF-8') ?></code><br>
     Client IP (as the firewall sees it): <code><?= htmlspecialchars($ip, ENT_QUOTES, 'UTF-8') ?></code><br>
-    Pass cookie present: <code><?= $cookiePresent ? 'yes' : 'no' ?></code>
+    Math pass cookie present: <code><?= $mathCookie ? 'yes' : 'no' ?></code><br>
+    ALTCHA pass cookie present: <code><?= $altchaCookie ? 'yes' : 'no' ?></code>
   </p>
 </body>
 </html>

--- a/src/Challenge/AltchaChallengeProvider.php
+++ b/src/Challenge/AltchaChallengeProvider.php
@@ -54,7 +54,31 @@ final class AltchaChallengeProvider implements ChallengeProviderInterface
 
     private const CHALLENGE_LIFETIME = 300;
 
-    private const WIDGET_SRC = 'https://cdn.jsdelivr.net/npm/altcha/dist/altcha.min.js';
+    /**
+     * Default widget bundle, pinned to an exact version.
+     *
+     * @see self::DEFAULT_WIDGET_INTEGRITY for the matching SRI digest.
+     */
+    public const DEFAULT_WIDGET_SRC = 'https://cdn.jsdelivr.net/npm/altcha@2.3.0/dist/altcha.min.js';
+
+    /**
+     * Subresource Integrity digest for DEFAULT_WIDGET_SRC.
+     *
+     * Must be regenerated whenever DEFAULT_WIDGET_SRC changes:
+     *   curl -sL <url> | openssl dgst -sha384 -binary | openssl base64 -A
+     */
+    public const DEFAULT_WIDGET_INTEGRITY =
+        'sha384-8I1KL049hNSwGKuCu/6NlGM1rfkVTfw/5bVzUFNvxO3XLV3isCJR1s5pTyuE2Zuo';
+
+    /**
+     * Widget bundle URL actually emitted into the interstitial.
+     */
+    private readonly string $widgetSrc;
+
+    /**
+     * SRI digest emitted alongside the bundle, or '' to emit none.
+     */
+    private readonly string $widgetIntegrity;
 
     /**
      * Constructs a new AltchaChallengeProvider object.
@@ -63,9 +87,30 @@ final class AltchaChallengeProvider implements ChallengeProviderInterface
      *   Shared HMAC manager. Signs the per-challenge value embedded in the
      *   widget, which is what keeps this provider stateless — the expected
      *   challenge never has to be stored server-side.
+     * @param array<string, mixed> $options
+     *   Provider options from `challenge.provider_options`:
+     *     - widget_src:       URL of the ALTCHA widget bundle. Override to
+     *                         self-host the script or to serve it from a
+     *                         CDN your CSP already allows.
+     *     - widget_integrity: SRI digest for that bundle. Defaults to the
+     *                         digest of the pinned default; overriding
+     *                         `widget_src` without also supplying this
+     *                         emits no `integrity` attribute, because a
+     *                         stale digest would block the script outright.
      */
-    public function __construct(private readonly TokenManager $tokenManager)
+    public function __construct(private readonly TokenManager $tokenManager, array $options = [])
     {
+        $src = trim((string) ($options['widget_src'] ?? ''));
+        $integrity = trim((string) ($options['widget_integrity'] ?? ''));
+
+        $this->widgetSrc = $src !== '' ? $src : self::DEFAULT_WIDGET_SRC;
+
+        if ($integrity !== '') {
+            $this->widgetIntegrity = $integrity;
+        } else {
+            // Only the pinned default has a digest we can vouch for.
+            $this->widgetIntegrity = $src === '' ? self::DEFAULT_WIDGET_INTEGRITY : '';
+        }
     }
 
     /**
@@ -96,7 +141,17 @@ final class AltchaChallengeProvider implements ChallengeProviderInterface
 
         $challengeAttr = InterstitialRenderer::escapeHtml($challengeJson);
         $payloadField = InterstitialRenderer::escapeHtml(self::PAYLOAD_FIELD);
-        $widgetSrc = InterstitialRenderer::escapeHtml(self::WIDGET_SRC);
+        $widgetSrc = InterstitialRenderer::escapeHtml($this->widgetSrc);
+
+        // SRI only means anything alongside a CORS request, hence
+        // crossorigin — without it the browser cannot verify the digest.
+        $integrityAttr = '';
+        if ($this->widgetIntegrity !== '') {
+            $integrityAttr = sprintf(
+                ' integrity="%s" crossorigin="anonymous"',
+                InterstitialRenderer::escapeHtml($this->widgetIntegrity)
+            );
+        }
 
         return InterstitialRenderer::render([
             'intro' => 'Please complete the check below to continue.',
@@ -104,7 +159,7 @@ final class AltchaChallengeProvider implements ChallengeProviderInterface
                 . "\n" . '    button:disabled { background: #9bb8e6; cursor: not-allowed; }',
             // The official ALTCHA distribution is an ES module — a classic
             // <script> tag fails with "Unexpected token 'export'".
-            'extra_head' => "  <script type=\"module\" src=\"{$widgetSrc}\" async defer></script>",
+            'extra_head' => "  <script type=\"module\" src=\"{$widgetSrc}\"{$integrityAttr} async defer></script>",
             'form_fields' => <<<FIELDS
       <altcha-widget challengejson="{$challengeAttr}" auto="onload" hidefooter></altcha-widget>
 FIELDS,

--- a/src/Challenge/AltchaChallengeProvider.php
+++ b/src/Challenge/AltchaChallengeProvider.php
@@ -159,7 +159,7 @@ final class AltchaChallengeProvider implements ChallengeProviderInterface
                 . "\n" . '    button:disabled { background: #9bb8e6; cursor: not-allowed; }',
             // The official ALTCHA distribution is an ES module — a classic
             // <script> tag fails with "Unexpected token 'export'".
-            'extra_head' => "  <script type=\"module\" src=\"{$widgetSrc}\"{$integrityAttr} async defer></script>",
+            'extra_head' => sprintf('  <script type="module" src="%s"%s async defer></script>', $widgetSrc, $integrityAttr),
             'form_fields' => <<<FIELDS
       <altcha-widget challengejson="{$challengeAttr}" auto="onload" hidefooter></altcha-widget>
 FIELDS,

--- a/src/Challenge/AltchaChallengeProvider.php
+++ b/src/Challenge/AltchaChallengeProvider.php
@@ -56,15 +56,29 @@ final class AltchaChallengeProvider implements ChallengeProviderInterface
 
     private const WIDGET_SRC = 'https://cdn.jsdelivr.net/npm/altcha/dist/altcha.min.js';
 
+    /**
+     * Constructs a new AltchaChallengeProvider object.
+     *
+     * @param TokenManager $tokenManager
+     *   Shared HMAC manager. Signs the per-challenge value embedded in the
+     *   widget, which is what keeps this provider stateless — the expected
+     *   challenge never has to be stored server-side.
+     */
     public function __construct(private readonly TokenManager $tokenManager)
     {
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getName(): string
     {
         return 'altcha';
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function renderInterstitial(Request $request, array $context): string
     {
         $salt = bin2hex(random_bytes(12)) . '?expires=' . (time() + self::CHALLENGE_LIFETIME);
@@ -85,7 +99,6 @@ final class AltchaChallengeProvider implements ChallengeProviderInterface
             'submit_url' => $context['submit_url'] ?? '',
             'redirect_to' => $context['redirect_to'] ?? '/',
             'ttl' => $context['ttl'] ?? '3600',
-            'cookie_name' => $context['cookie_name'] ?? '',
             'header_name' => $context['header_name'] ?? '',
             'payload_field' => self::PAYLOAD_FIELD,
             'redirect_field' => self::REDIRECT_FIELD,
@@ -225,7 +238,6 @@ final class AltchaChallengeProvider implements ChallengeProviderInterface
       var err = document.getElementById('error');
       var submit = document.getElementById('submit');
       var widget = document.querySelector('altcha-widget');
-      var cookieName = "{$e['cookie_name']}";
       var headerName = "{$e['header_name']}";
       var redirectTo = "{$e['redirect_to']}";
 

--- a/src/Challenge/AltchaChallengeProvider.php
+++ b/src/Challenge/AltchaChallengeProvider.php
@@ -30,17 +30,25 @@ use Symfony\Component\HttpFoundation\Request;
  *   client → server (base64-encoded JSON in the `altcha` field):
  *     {algorithm, challenge, number, salt, signature}
  *
- * The salt embeds an `?expires=<unix>` query string so a precomputed
- * solution goes stale before it can be replayed at scale. The signature
- * is an HMAC over the challenge value via TokenManager::sign(), so a
- * tampered challenge or salt fails verification even with a valid PoW.
+ * The salt embeds an `?expires=<unix>` query string so a solution goes
+ * stale shortly after it is issued. The signature is an HMAC over the
+ * challenge value via TokenManager::sign(), so a tampered challenge or
+ * salt fails verification even with a valid PoW.
+ *
+ * Expiry alone does not make the work non-reusable, though: within the
+ * challenge lifetime the same solved payload verifies every time it is
+ * submitted. This provider therefore implements SingleUseSolutionInterface
+ * so `Firewall` records each solved challenge and rejects the second
+ * submission — without that, one solve could be redistributed to any
+ * number of clients, each minting its own pass token, and the per-solve
+ * cost below would be amortised to nothing.
  *
  * Compared to MathChallengeProvider this trades a tiny bit of CPU on the
  * visitor's device (50-150 ms typical at the default maxnumber) for a
- * fully automated flow — no typing required — and a measurable cost per
- * solve, which makes mass single-shot bot attacks less attractive.
+ * fully automated flow — no typing required — and a per-solve cost that,
+ * because solutions are single-use, actually has to be paid per client.
  */
-final class AltchaChallengeProvider implements ChallengeProviderInterface
+final class AltchaChallengeProvider implements ChallengeProviderInterface, SingleUseSolutionInterface
 {
     /**
      * Form field that carries the base64-encoded solution payload posted
@@ -191,31 +199,69 @@ SCRIPT,
         ]);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function verifySolution(Request $request): bool
+    {
+        return $this->validate($request) !== null;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * The `challenge` value is the identifier: it is a SHA-256 over the
+     * per-render salt, so it is unique to one issued challenge, and it is
+     * the exact value covered by the HMAC signature — an attacker cannot
+     * vary it to dodge the consumed-solution record without invalidating
+     * the signature.
+     */
+    public function getSolutionReceipt(Request $request): ?array
+    {
+        $validated = $this->validate($request);
+        if ($validated === null) {
+            return null;
+        }
+
+        return ['id' => $validated['challenge'], 'expires' => $validated['expires']];
+    }
+
+    /**
+     * Decode and fully validate the posted solution.
+     *
+     * Shared by verifySolution() and getSolutionReceipt() so the two can
+     * never disagree about whether a payload is acceptable.
+     *
+     * @return array{challenge: string, expires: int}|null
+     *   The verified challenge value and its expiry, or NULL if the
+     *   payload is malformed, stale, unsigned, or does not solve the
+     *   proof of work.
+     */
+    private function validate(Request $request): ?array
     {
         $encoded = trim((string) $request->request->get(self::PAYLOAD_FIELD, ''));
         if ($encoded === '') {
-            return false;
+            return null;
         }
 
         $json = base64_decode($encoded, true);
         if ($json === false) {
-            return false;
+            return null;
         }
 
         $payload = json_decode($json, true);
         if (!is_array($payload)) {
-            return false;
+            return null;
         }
 
         foreach (['algorithm', 'challenge', 'number', 'salt', 'signature'] as $key) {
             if (!isset($payload[$key]) || !is_scalar($payload[$key])) {
-                return false;
+                return null;
             }
         }
 
         if ($payload['algorithm'] !== self::ALGORITHM) {
-            return false;
+            return null;
         }
 
         $salt = (string) $payload['salt'];
@@ -228,19 +274,23 @@ SCRIPT,
         } elseif (is_string($rawNumber) && ctype_digit($rawNumber)) {
             $number = (int) $rawNumber;
         } else {
-            return false;
+            return null;
         }
 
         $expires = $this->parseExpires($salt);
         if ($expires === null || $expires <= time()) {
-            return false;
+            return null;
         }
 
         if (!hash_equals($challenge, hash('sha256', $salt . $number))) {
-            return false;
+            return null;
         }
 
-        return $this->tokenManager->verifySignature($challenge, $signature);
+        if (!$this->tokenManager->verifySignature($challenge, $signature)) {
+            return null;
+        }
+
+        return ['challenge' => $challenge, 'expires' => $expires];
     }
 
     /**

--- a/src/Challenge/AltchaChallengeProvider.php
+++ b/src/Challenge/AltchaChallengeProvider.php
@@ -94,16 +94,45 @@ final class AltchaChallengeProvider implements ChallengeProviderInterface
             'signature' => $signature,
         ]);
 
-        return $this->renderTemplate([
-            'challenge_json' => $challengeJson,
+        $challengeAttr = InterstitialRenderer::escapeHtml($challengeJson);
+        $payloadField = InterstitialRenderer::escapeHtml(self::PAYLOAD_FIELD);
+        $widgetSrc = InterstitialRenderer::escapeHtml(self::WIDGET_SRC);
+
+        return InterstitialRenderer::render([
+            'intro' => 'Please complete the check below to continue.',
+            'extra_styles' => '    altcha-widget { display: block; margin-bottom: 1rem; }'
+                . "\n" . '    button:disabled { background: #9bb8e6; cursor: not-allowed; }',
+            // The official ALTCHA distribution is an ES module — a classic
+            // <script> tag fails with "Unexpected token 'export'".
+            'extra_head' => "  <script type=\"module\" src=\"{$widgetSrc}\" async defer></script>",
+            'form_fields' => <<<FIELDS
+      <altcha-widget challengejson="{$challengeAttr}" auto="onload" hidefooter></altcha-widget>
+FIELDS,
+            // The widget enables the button once it has solved the proof of
+            // work, so the visitor cannot submit an empty payload.
+            'submit_disabled' => true,
+            'error_message' => 'Verification failed. Please try again.',
+            'submit_guard' => <<<GUARD
+        if (!data.get('{$payloadField}')) {
+          err.classList.add('visible');
+          return;
+        }
+
+GUARD,
+            'extra_script' => <<<'SCRIPT'
+      var widget = document.querySelector('altcha-widget');
+      if (widget) {
+        widget.addEventListener('verified', function () { submit.disabled = false; });
+        widget.addEventListener('expired', function () { submit.disabled = true; });
+      }
+
+SCRIPT,
             'submit_url' => $context['submit_url'] ?? '',
             'redirect_to' => $context['redirect_to'] ?? '/',
             'ttl' => $context['ttl'] ?? '3600',
             'header_name' => $context['header_name'] ?? '',
-            'payload_field' => self::PAYLOAD_FIELD,
             'redirect_field' => self::REDIRECT_FIELD,
             'ttl_field' => self::TTL_FIELD,
-            'widget_src' => self::WIDGET_SRC,
         ]);
     }
 
@@ -176,112 +205,5 @@ final class AltchaChallengeProvider implements ChallengeProviderInterface
         }
 
         return (int) $params['expires'];
-    }
-
-    /**
-     * Inline HTML + JS template.
-     *
-     * Every {{key}} substitution is HTML-escaped. The widget script is
-     * loaded from the official CDN; if that's blocked by your CSP you can
-     * subclass and override WIDGET_SRC, or implement
-     * ChallengeProviderInterface directly against a self-hosted bundle.
-     *
-     * @param array<string, string|int> $vars
-     */
-    private function renderTemplate(array $vars): string
-    {
-        $escape = static fn(string|int $v): string => htmlspecialchars(
-            (string) $v,
-            ENT_QUOTES | ENT_SUBSTITUTE,
-            'UTF-8'
-        );
-
-        $e = array_map($escape, $vars);
-
-        return <<<HTML
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content="noindex, nofollow">
-  <title>Verification required</title>
-  <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #f5f6f8; color: #1a1a1a; margin: 0; display: flex; min-height: 100vh; align-items: center; justify-content: center; }
-    .card { background: #fff; padding: 2rem 2.5rem; border-radius: 8px; box-shadow: 0 4px 24px rgba(0,0,0,0.08); max-width: 28rem; width: 90%; }
-    h1 { font-size: 1.25rem; margin: 0 0 0.75rem; }
-    p { margin: 0 0 1.25rem; color: #555; }
-    altcha-widget { display: block; margin-bottom: 1rem; }
-    button { width: 100%; padding: 0.65rem 1rem; font-size: 1rem; background: #1f6feb; color: #fff; border: 0; border-radius: 4px; cursor: pointer; }
-    button:disabled { background: #9bb8e6; cursor: not-allowed; }
-    button:not(:disabled):hover { background: #1858c4; }
-    .error { color: #b42318; margin-top: 0.75rem; font-size: 0.9rem; display: none; }
-    .error.visible { display: block; }
-  </style>
-</head>
-<body>
-  <main class="card">
-    <h1>Quick verification</h1>
-    <p>Please complete the check below to continue.</p>
-    <form id="challenge-form" method="post" action="{$e['submit_url']}">
-      <altcha-widget challengejson="{$e['challenge_json']}" auto="onload" hidefooter></altcha-widget>
-      <input type="hidden" name="{$e['redirect_field']}" value="{$e['redirect_to']}">
-      <input type="hidden" name="{$e['ttl_field']}" value="{$e['ttl']}">
-      <button type="submit" id="submit" disabled>Continue</button>
-      <div id="error" class="error" role="alert">Verification failed. Please try again.</div>
-    </form>
-  </main>
-  <script type="module" src="{$e['widget_src']}" async defer></script>
-  <script>
-    (function () {
-      var form = document.getElementById('challenge-form');
-      var err = document.getElementById('error');
-      var submit = document.getElementById('submit');
-      var widget = document.querySelector('altcha-widget');
-      var headerName = "{$e['header_name']}";
-      var redirectTo = "{$e['redirect_to']}";
-
-      if (widget) {
-        widget.addEventListener('verified', function () { submit.disabled = false; });
-        widget.addEventListener('expired', function () { submit.disabled = true; });
-      }
-
-      form.addEventListener('submit', function (event) {
-        event.preventDefault();
-        err.classList.remove('visible');
-
-        var data = new FormData(form);
-        if (!data.get('{$e['payload_field']}')) {
-          err.classList.add('visible');
-          return;
-        }
-
-        fetch(form.action, {
-          method: 'POST',
-          body: data,
-          headers: { 'Accept': 'application/json' },
-          credentials: 'same-origin'
-        }).then(function (resp) {
-          return resp.json().then(function (body) { return { ok: resp.ok, body: body }; });
-        }).then(function (result) {
-          if (!result.ok || !result.body || !result.body.token) {
-            err.classList.add('visible');
-            return;
-          }
-          try {
-            if (headerName) {
-              localStorage.setItem('firewall.' + headerName, result.body.token);
-            }
-          } catch (e) { /* localStorage blocked — cookie still works */ }
-          window.location.href = result.body.redirect || redirectTo;
-        }).catch(function () {
-          err.classList.add('visible');
-        });
-      });
-    })();
-  </script>
-</body>
-</html>
-HTML;
     }
 }

--- a/src/Challenge/AltchaChallengeProvider.php
+++ b/src/Challenge/AltchaChallengeProvider.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kanopi\Firewall\Challenge;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Built-in ALTCHA proof-of-work challenge.
+ *
+ * Embeds the ALTCHA widget pre-loaded with a server-issued challenge so
+ * the page never round-trips back for a challenge JSON — the server stays
+ * stateless between render and verify. The visitor's browser brute-forces
+ * `number` such that `SHA-256(salt + number) == challenge`, the widget
+ * posts the base64-encoded solution back as the `altcha` field, and
+ * verifySolution() re-runs the hash plus an HMAC check on the challenge
+ * value.
+ *
+ * Wire format (per https://altcha.org/docs/v2/):
+ *   server → client (rendered into the widget):
+ *     {algorithm, challenge, maxnumber, salt, signature}
+ *   client → server (base64-encoded JSON in the `altcha` field):
+ *     {algorithm, challenge, number, salt, signature}
+ *
+ * The salt embeds an `?expires=<unix>` query string so a precomputed
+ * solution goes stale before it can be replayed at scale. The signature
+ * is an HMAC over the challenge value via TokenManager::sign(), so a
+ * tampered challenge or salt fails verification even with a valid PoW.
+ *
+ * Compared to MathChallengeProvider this trades a tiny bit of CPU on the
+ * visitor's device (50-150 ms typical at the default maxnumber) for a
+ * fully automated flow — no typing required — and a measurable cost per
+ * solve, which makes mass single-shot bot attacks less attractive.
+ */
+final class AltchaChallengeProvider implements ChallengeProviderInterface
+{
+    /**
+     * Form field that carries the base64-encoded solution payload posted
+     * back from the widget. Name is fixed by the ALTCHA widget itself.
+     */
+    public const PAYLOAD_FIELD = 'altcha';
+
+    /**
+     * Form field carrying the post-success redirect target. Same name as
+     * MathChallengeProvider — `Firewall::handleChallengeSubmission` reads
+     * a shared field name regardless of which provider is wired up.
+     */
+    public const REDIRECT_FIELD = 'redirect_to';
+
+    /**
+     * Form field carrying the per-plugin TTL.
+     */
+    public const TTL_FIELD = 'ttl';
+
+    private const ALGORITHM = 'SHA-256';
+    private const MAXNUMBER = 100000;
+    private const CHALLENGE_LIFETIME = 300;
+    private const WIDGET_SRC = 'https://cdn.jsdelivr.net/npm/altcha/dist/altcha.min.js';
+
+    public function __construct(private readonly TokenManager $tokenManager)
+    {
+    }
+
+    public function getName(): string
+    {
+        return 'altcha';
+    }
+
+    public function renderInterstitial(Request $request, array $context): string
+    {
+        $salt = bin2hex(random_bytes(12)) . '?expires=' . (time() + self::CHALLENGE_LIFETIME);
+        $number = random_int(1, self::MAXNUMBER);
+        $challenge = hash('sha256', $salt . $number);
+        $signature = $this->tokenManager->sign($challenge);
+
+        $challengeJson = (string) json_encode([
+            'algorithm' => self::ALGORITHM,
+            'challenge' => $challenge,
+            'maxnumber' => self::MAXNUMBER,
+            'salt' => $salt,
+            'signature' => $signature,
+        ]);
+
+        return $this->renderTemplate([
+            'challenge_json' => $challengeJson,
+            'submit_url' => $context['submit_url'] ?? '',
+            'redirect_to' => $context['redirect_to'] ?? '/',
+            'ttl' => $context['ttl'] ?? '3600',
+            'cookie_name' => $context['cookie_name'] ?? '',
+            'header_name' => $context['header_name'] ?? '',
+            'payload_field' => self::PAYLOAD_FIELD,
+            'redirect_field' => self::REDIRECT_FIELD,
+            'ttl_field' => self::TTL_FIELD,
+            'widget_src' => self::WIDGET_SRC,
+        ]);
+    }
+
+    public function verifySolution(Request $request): bool
+    {
+        $encoded = trim((string) $request->request->get(self::PAYLOAD_FIELD, ''));
+        if ($encoded === '') {
+            return false;
+        }
+
+        $json = base64_decode($encoded, true);
+        if ($json === false) {
+            return false;
+        }
+
+        $payload = json_decode($json, true);
+        if (!is_array($payload)) {
+            return false;
+        }
+
+        foreach (['algorithm', 'challenge', 'number', 'salt', 'signature'] as $key) {
+            if (!isset($payload[$key]) || !is_scalar($payload[$key])) {
+                return false;
+            }
+        }
+
+        if ($payload['algorithm'] !== self::ALGORITHM) {
+            return false;
+        }
+
+        $salt = (string) $payload['salt'];
+        $challenge = (string) $payload['challenge'];
+        $signature = (string) $payload['signature'];
+        $rawNumber = $payload['number'];
+
+        if (is_int($rawNumber)) {
+            $number = $rawNumber;
+        } elseif (is_string($rawNumber) && ctype_digit($rawNumber)) {
+            $number = (int) $rawNumber;
+        } else {
+            return false;
+        }
+
+        $expires = $this->parseExpires($salt);
+        if ($expires === null || $expires <= time()) {
+            return false;
+        }
+
+        if (!hash_equals($challenge, hash('sha256', $salt . $number))) {
+            return false;
+        }
+
+        return $this->tokenManager->verifySignature($challenge, $signature);
+    }
+
+    /**
+     * Pull the `expires` value out of the salt's query string. Returns
+     * null if absent or not a valid unix timestamp.
+     */
+    private function parseExpires(string $salt): ?int
+    {
+        $pos = strpos($salt, '?');
+        if ($pos === false) {
+            return null;
+        }
+
+        parse_str(substr($salt, $pos + 1), $params);
+        if (!isset($params['expires']) || !is_string($params['expires']) || !ctype_digit($params['expires'])) {
+            return null;
+        }
+
+        return (int) $params['expires'];
+    }
+
+    /**
+     * Inline HTML + JS template.
+     *
+     * Every {{key}} substitution is HTML-escaped. The widget script is
+     * loaded from the official CDN; if that's blocked by your CSP you can
+     * subclass and override WIDGET_SRC, or implement
+     * ChallengeProviderInterface directly against a self-hosted bundle.
+     *
+     * @param array<string, string|int> $vars
+     */
+    private function renderTemplate(array $vars): string
+    {
+        $escape = static fn(string|int $v): string => htmlspecialchars(
+            (string) $v,
+            ENT_QUOTES | ENT_SUBSTITUTE,
+            'UTF-8'
+        );
+
+        $e = array_map($escape, $vars);
+
+        return <<<HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Verification required</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #f5f6f8; color: #1a1a1a; margin: 0; display: flex; min-height: 100vh; align-items: center; justify-content: center; }
+    .card { background: #fff; padding: 2rem 2.5rem; border-radius: 8px; box-shadow: 0 4px 24px rgba(0,0,0,0.08); max-width: 28rem; width: 90%; }
+    h1 { font-size: 1.25rem; margin: 0 0 0.75rem; }
+    p { margin: 0 0 1.25rem; color: #555; }
+    altcha-widget { display: block; margin-bottom: 1rem; }
+    button { width: 100%; padding: 0.65rem 1rem; font-size: 1rem; background: #1f6feb; color: #fff; border: 0; border-radius: 4px; cursor: pointer; }
+    button:disabled { background: #9bb8e6; cursor: not-allowed; }
+    button:not(:disabled):hover { background: #1858c4; }
+    .error { color: #b42318; margin-top: 0.75rem; font-size: 0.9rem; display: none; }
+    .error.visible { display: block; }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <h1>Quick verification</h1>
+    <p>Please complete the check below to continue.</p>
+    <form id="challenge-form" method="post" action="{$e['submit_url']}">
+      <altcha-widget challengejson="{$e['challenge_json']}" auto="onload" hidefooter></altcha-widget>
+      <input type="hidden" name="{$e['redirect_field']}" value="{$e['redirect_to']}">
+      <input type="hidden" name="{$e['ttl_field']}" value="{$e['ttl']}">
+      <button type="submit" id="submit" disabled>Continue</button>
+      <div id="error" class="error" role="alert">Verification failed. Please try again.</div>
+    </form>
+  </main>
+  <script type="module" src="{$e['widget_src']}" async defer></script>
+  <script>
+    (function () {
+      var form = document.getElementById('challenge-form');
+      var err = document.getElementById('error');
+      var submit = document.getElementById('submit');
+      var widget = document.querySelector('altcha-widget');
+      var cookieName = "{$e['cookie_name']}";
+      var headerName = "{$e['header_name']}";
+      var redirectTo = "{$e['redirect_to']}";
+
+      if (widget) {
+        widget.addEventListener('verified', function () { submit.disabled = false; });
+        widget.addEventListener('expired', function () { submit.disabled = true; });
+      }
+
+      form.addEventListener('submit', function (event) {
+        event.preventDefault();
+        err.classList.remove('visible');
+
+        var data = new FormData(form);
+        if (!data.get('{$e['payload_field']}')) {
+          err.classList.add('visible');
+          return;
+        }
+
+        fetch(form.action, {
+          method: 'POST',
+          body: data,
+          headers: { 'Accept': 'application/json' },
+          credentials: 'same-origin'
+        }).then(function (resp) {
+          return resp.json().then(function (body) { return { ok: resp.ok, body: body }; });
+        }).then(function (result) {
+          if (!result.ok || !result.body || !result.body.token) {
+            err.classList.add('visible');
+            return;
+          }
+          try {
+            if (headerName) {
+              localStorage.setItem('firewall.' + headerName, result.body.token);
+            }
+          } catch (e) { /* localStorage blocked — cookie still works */ }
+          window.location.href = result.body.redirect || redirectTo;
+        }).catch(function () {
+          err.classList.add('visible');
+        });
+      });
+    })();
+  </script>
+</body>
+</html>
+HTML;
+    }
+}

--- a/src/Challenge/AltchaChallengeProvider.php
+++ b/src/Challenge/AltchaChallengeProvider.php
@@ -48,18 +48,6 @@ final class AltchaChallengeProvider implements ChallengeProviderInterface
      */
     public const PAYLOAD_FIELD = 'altcha';
 
-    /**
-     * Form field carrying the post-success redirect target. Same name as
-     * MathChallengeProvider — `Firewall::handleChallengeSubmission` reads
-     * a shared field name regardless of which provider is wired up.
-     */
-    public const REDIRECT_FIELD = 'redirect_to';
-
-    /**
-     * Form field carrying the per-plugin TTL.
-     */
-    public const TTL_FIELD = 'ttl';
-
     private const ALGORITHM = 'SHA-256';
 
     private const MAXNUMBER = 100000;

--- a/src/Challenge/AltchaChallengeProvider.php
+++ b/src/Challenge/AltchaChallengeProvider.php
@@ -61,8 +61,11 @@ final class AltchaChallengeProvider implements ChallengeProviderInterface
     public const TTL_FIELD = 'ttl';
 
     private const ALGORITHM = 'SHA-256';
+
     private const MAXNUMBER = 100000;
+
     private const CHALLENGE_LIFETIME = 300;
+
     private const WIDGET_SRC = 'https://cdn.jsdelivr.net/npm/altcha/dist/altcha.min.js';
 
     public function __construct(private readonly TokenManager $tokenManager)

--- a/src/Challenge/ChallengeProviderFactory.php
+++ b/src/Challenge/ChallengeProviderFactory.php
@@ -29,6 +29,7 @@ final class ChallengeProviderFactory
      */
     private const BUILTINS = [
         'math' => MathChallengeProvider::class,
+        'altcha' => AltchaChallengeProvider::class,
     ];
 
     /**

--- a/src/Challenge/ChallengeProviderFactory.php
+++ b/src/Challenge/ChallengeProviderFactory.php
@@ -73,14 +73,14 @@ final class ChallengeProviderFactory
             ));
         }
 
-        $instance = self::instantiate($class, $tokenManager, $options);
+        $challengeProvider = self::instantiate($class, $tokenManager, $options);
 
         LoggingFactory::logMessage('debug', 'Challenge provider created', [
-            'provider' => $instance->getName(),
+            'provider' => $challengeProvider->getName(),
             'class' => $class,
         ]);
 
-        return $instance;
+        return $challengeProvider;
     }
 
     /**

--- a/src/Challenge/ChallengeProviderFactory.php
+++ b/src/Challenge/ChallengeProviderFactory.php
@@ -40,13 +40,22 @@ final class ChallengeProviderFactory
      * @param TokenManager $tokenManager
      *   Shared HMAC manager. Providers that need to sign per-challenge
      *   state (like MathChallengeProvider) receive it via constructor.
+     * @param array<string, mixed> $options
+     *   Contents of `challenge.provider_options`, passed as a second
+     *   constructor argument to providers that declare one. Providers
+     *   taking only a TokenManager — including every custom provider
+     *   written against the original single-argument signature — are
+     *   constructed unchanged, so this stays backward compatible.
      *
      * @throws ConfigurationException
      *   When the provider name resolves to nothing or to a class that
      *   does not implement ChallengeProviderInterface.
      */
-    public static function create(string $provider, TokenManager $tokenManager): ChallengeProviderInterface
-    {
+    public static function create(
+        string $provider,
+        TokenManager $tokenManager,
+        array $options = []
+    ): ChallengeProviderInterface {
         $class = self::BUILTINS[$provider] ?? $provider;
 
         if (!class_exists($class)) {
@@ -64,7 +73,7 @@ final class ChallengeProviderFactory
             ));
         }
 
-        $instance = new $class($tokenManager);
+        $instance = self::instantiate($class, $tokenManager, $options);
 
         LoggingFactory::logMessage('debug', 'Challenge provider created', [
             'provider' => $instance->getName(),
@@ -72,5 +81,32 @@ final class ChallengeProviderFactory
         ]);
 
         return $instance;
+    }
+
+    /**
+     * Construct the provider, passing options only when it accepts them.
+     *
+     * `ChallengeProviderInterface` cannot describe a constructor, so the
+     * arity is checked directly rather than assumed. A provider written
+     * against the original `__construct(TokenManager $tm)` signature keeps
+     * working; one that declares a second parameter receives the options.
+     *
+     * @param class-string<ChallengeProviderInterface> $class
+     *   Resolved provider class.
+     * @param array<string, mixed> $options
+     *   Provider options to forward when supported.
+     */
+    private static function instantiate(
+        string $class,
+        TokenManager $tokenManager,
+        array $options
+    ): ChallengeProviderInterface {
+        $constructor = (new \ReflectionClass($class))->getConstructor();
+
+        if ($constructor instanceof \ReflectionMethod && $constructor->getNumberOfParameters() >= 2) {
+            return new $class($tokenManager, $options);
+        }
+
+        return new $class($tokenManager);
     }
 }

--- a/src/Challenge/ChallengeProviderInterface.php
+++ b/src/Challenge/ChallengeProviderInterface.php
@@ -29,6 +29,23 @@ use Symfony\Component\HttpFoundation\Request;
 interface ChallengeProviderInterface
 {
     /**
+     * Form field carrying the post-success redirect target.
+     *
+     * Part of the contract rather than each provider's own constant:
+     * `Firewall::handleChallengeSubmission()` reads the posted solution
+     * without knowing which provider rendered it, so the field name has
+     * to be fixed across every implementation.
+     */
+    public const REDIRECT_FIELD = 'redirect_to';
+
+    /**
+     * Form field carrying the per-plugin pass-token TTL in seconds.
+     *
+     * Fixed across implementations for the same reason as REDIRECT_FIELD.
+     */
+    public const TTL_FIELD = 'ttl';
+
+    /**
      * Short identifier used in `challenge.provider` config (e.g. "math").
      */
     public function getName(): string;

--- a/src/Challenge/InterstitialRenderer.php
+++ b/src/Challenge/InterstitialRenderer.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kanopi\Firewall\Challenge;
+
+/**
+ * Renders the shared challenge interstitial document.
+ *
+ * Both built-in providers serve the same page: a centered card, a form
+ * that POSTs to the challenge endpoint, hidden `redirect_to` / `ttl`
+ * fields, a submit button, and an error region. Only the challenge
+ * control itself differs — a text input for the math provider, a widget
+ * element for ALTCHA.
+ *
+ * Keeping one copy of the document means the submit JS (and the escaping
+ * rules it depends on) live in exactly one place. Providers supply the
+ * pieces that are genuinely theirs via the `$parts` array.
+ */
+final class InterstitialRenderer
+{
+    /**
+     * Escape a value for interpolation into HTML text or an attribute.
+     */
+    public static function escapeHtml(string|int $value): string
+    {
+        return htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+
+    /**
+     * Build the interstitial document.
+     *
+     * `form_fields`, `extra_script`, `extra_head`, `extra_styles` and
+     * `submit_guard` are injected verbatim — the calling provider owns
+     * escaping anything it interpolates into them. Every other value is
+     * escaped here.
+     *
+     * @param array{
+     *   intro: string,
+     *   extra_styles: string,
+     *   extra_head: string,
+     *   form_fields: string,
+     *   submit_disabled: bool,
+     *   error_message: string,
+     *   submit_guard: string,
+     *   extra_script: string,
+     *   submit_url: string|int,
+     *   redirect_to: string|int,
+     *   ttl: string|int,
+     *   header_name: string|int,
+     *   redirect_field: string|int,
+     *   ttl_field: string|int
+     * } $parts
+     *   Provider-supplied document pieces.
+     */
+    public static function render(array $parts): string
+    {
+        $submitUrl = self::escapeHtml($parts['submit_url']);
+        $redirectTo = self::escapeHtml($parts['redirect_to']);
+        $ttl = self::escapeHtml($parts['ttl']);
+        $headerName = self::escapeHtml($parts['header_name']);
+        $redirectField = self::escapeHtml($parts['redirect_field']);
+        $ttlField = self::escapeHtml($parts['ttl_field']);
+
+        $intro = $parts['intro'];
+        $extraStyles = $parts['extra_styles'];
+        $extraHead = $parts['extra_head'];
+        $formFields = $parts['form_fields'];
+        $errorMessage = $parts['error_message'];
+        $submitGuard = $parts['submit_guard'];
+        $extraScript = $parts['extra_script'];
+        $disabled = $parts['submit_disabled'] ? ' disabled' : '';
+
+        return <<<HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Verification required</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #f5f6f8; color: #1a1a1a; margin: 0; display: flex; min-height: 100vh; align-items: center; justify-content: center; }
+    .card { background: #fff; padding: 2rem 2.5rem; border-radius: 8px; box-shadow: 0 4px 24px rgba(0,0,0,0.08); max-width: 28rem; width: 90%; }
+    h1 { font-size: 1.25rem; margin: 0 0 0.75rem; }
+    p { margin: 0 0 1.25rem; color: #555; }
+    button { width: 100%; padding: 0.65rem 1rem; font-size: 1rem; background: #1f6feb; color: #fff; border: 0; border-radius: 4px; cursor: pointer; }
+    button:not(:disabled):hover { background: #1858c4; }
+    .error { color: #b42318; margin-top: 0.75rem; font-size: 0.9rem; display: none; }
+    .error.visible { display: block; }
+{$extraStyles}
+  </style>
+{$extraHead}
+</head>
+<body>
+  <main class="card">
+    <h1>Quick verification</h1>
+    <p>{$intro}</p>
+    <form id="challenge-form" method="post" action="{$submitUrl}">
+{$formFields}
+      <input type="hidden" name="{$redirectField}" value="{$redirectTo}">
+      <input type="hidden" name="{$ttlField}" value="{$ttl}">
+      <button type="submit" id="submit"{$disabled}>Continue</button>
+      <div id="error" class="error" role="alert">{$errorMessage}</div>
+    </form>
+  </main>
+  <script>
+    (function () {
+      var form = document.getElementById('challenge-form');
+      var err = document.getElementById('error');
+      var submit = document.getElementById('submit');
+      var headerName = "{$headerName}";
+      var redirectTo = "{$redirectTo}";
+{$extraScript}
+      form.addEventListener('submit', function (event) {
+        event.preventDefault();
+        err.classList.remove('visible');
+
+        var data = new FormData(form);
+{$submitGuard}
+        fetch(form.action, {
+          method: 'POST',
+          body: data,
+          headers: { 'Accept': 'application/json' },
+          credentials: 'same-origin'
+        }).then(function (resp) {
+          return resp.json().then(function (body) { return { ok: resp.ok, body: body }; });
+        }).then(function (result) {
+          if (!result.ok || !result.body || !result.body.token) {
+            err.classList.add('visible');
+            return;
+          }
+          try {
+            if (headerName) {
+              localStorage.setItem('firewall.' + headerName, result.body.token);
+            }
+          } catch (e) { /* localStorage blocked — cookie still works */ }
+          window.location.href = result.body.redirect || redirectTo;
+        }).catch(function () {
+          err.classList.add('visible');
+        });
+      });
+    })();
+  </script>
+</body>
+</html>
+HTML;
+    }
+}

--- a/src/Challenge/InterstitialRenderer.php
+++ b/src/Challenge/InterstitialRenderer.php
@@ -35,6 +35,34 @@ final class InterstitialRenderer
     }
 
     /**
+     * Encode a value as a complete JavaScript string literal, quotes included.
+     *
+     * HTML entity escaping is NOT valid inside a `<script>` block — the
+     * browser does not decode entities there, and `htmlspecialchars()`
+     * leaves backslashes untouched, so a value ending in `\` escapes the
+     * closing quote and produces a SyntaxError that kills the whole
+     * script. That matters: the ALTCHA submit button ships disabled and
+     * is only enabled by this script, so a parse error locks the visitor
+     * out of the page with no fallback.
+     *
+     * `json_encode()` with the HEX flags is the correct tool — it escapes
+     * backslashes, quotes and `<` / `>` / `&`, so neither the string
+     * literal nor the enclosing `</script>` can be broken out of.
+     */
+    public static function escapeJs(string|int $value): string
+    {
+        $encoded = json_encode(
+            (string) $value,
+            JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+
+        // Defensive: never emit an empty expression, which would itself be
+        // a syntax error. json_encode() should not fail given the
+        // substitution flag, but the fallback costs nothing.
+        return $encoded === false ? '""' : $encoded;
+    }
+
+    /**
      * Build the interstitial document.
      *
      * `form_fields`, `extra_script`, `extra_head`, `extra_styles` and
@@ -65,9 +93,12 @@ final class InterstitialRenderer
         $submitUrl = self::escapeHtml($parts['submit_url']);
         $redirectTo = self::escapeHtml($parts['redirect_to']);
         $ttl = self::escapeHtml($parts['ttl']);
-        $headerName = self::escapeHtml($parts['header_name']);
         $redirectField = self::escapeHtml($parts['redirect_field']);
         $ttlField = self::escapeHtml($parts['ttl_field']);
+
+        // Script-context values need JS literal encoding, not HTML escaping.
+        $headerNameJs = self::escapeJs($parts['header_name']);
+        $redirectToJs = self::escapeJs($parts['redirect_to']);
 
         $intro = $parts['intro'];
         $extraStyles = $parts['extra_styles'];
@@ -116,8 +147,8 @@ final class InterstitialRenderer
       var form = document.getElementById('challenge-form');
       var err = document.getElementById('error');
       var submit = document.getElementById('submit');
-      var headerName = "{$headerName}";
-      var redirectTo = "{$redirectTo}";
+      var headerName = {$headerNameJs};
+      var redirectTo = {$redirectToJs};
 {$extraScript}
       form.addEventListener('submit', function (event) {
         event.preventDefault();

--- a/src/Challenge/MathChallengeProvider.php
+++ b/src/Challenge/MathChallengeProvider.php
@@ -84,15 +84,31 @@ final class MathChallengeProvider implements ChallengeProviderInterface
         $stateData = $expected . '|' . $exp;
         $signedState = $stateData . '.' . $this->tokenManager->sign($stateData);
 
-        return $this->renderTemplate([
-            'question' => sprintf('What is %d + %d?', $a, $b),
+        $question = InterstitialRenderer::escapeHtml(sprintf('What is %d + %d?', $a, $b));
+        $answerField = InterstitialRenderer::escapeHtml(self::ANSWER_FIELD);
+        $stateField = InterstitialRenderer::escapeHtml(self::STATE_FIELD);
+        $state = InterstitialRenderer::escapeHtml($signedState);
+
+        return InterstitialRenderer::render([
+            'intro' => 'Please answer the question below to continue.',
+            'extra_styles' => '    label { display: block; font-weight: 600; margin-bottom: 0.5rem; }'
+                . "\n" . '    input[type="text"] { width: 100%; padding: 0.6rem 0.75rem; font-size: 1rem; '
+                . 'border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; }'
+                . "\n" . '    button { margin-top: 1rem; }',
+            'extra_head' => '',
+            'form_fields' => <<<FIELDS
+      <label for="answer">{$question}</label>
+      <input type="text" id="answer" name="{$answerField}" inputmode="numeric" autocomplete="off" autofocus required>
+      <input type="hidden" name="{$stateField}" value="{$state}">
+FIELDS,
+            'submit_disabled' => false,
+            'error_message' => 'Incorrect answer. Please try again.',
+            'submit_guard' => '',
+            'extra_script' => '',
             'submit_url' => $context['submit_url'] ?? '',
             'redirect_to' => $context['redirect_to'] ?? '/',
             'ttl' => $context['ttl'] ?? '3600',
             'header_name' => $context['header_name'] ?? '',
-            'state' => $signedState,
-            'state_field' => self::STATE_FIELD,
-            'answer_field' => self::ANSWER_FIELD,
             'redirect_field' => self::REDIRECT_FIELD,
             'ttl_field' => self::TTL_FIELD,
         ]);
@@ -132,100 +148,5 @@ final class MathChallengeProvider implements ChallengeProviderInterface
         }
 
         return hash_equals($expected, $answer);
-    }
-
-    /**
-     * Inline HTML + JS template.
-     *
-     * Every {{key}} substitution is HTML-escaped — `question` is the only
-     * server-generated text, but we treat the rest defensively in case a
-     * future caller passes a user-controlled `redirect_to`.
-     *
-     * @param array<string, string|int> $vars
-     */
-    private function renderTemplate(array $vars): string
-    {
-        $escape = static fn(string|int $v): string => htmlspecialchars(
-            (string) $v,
-            ENT_QUOTES | ENT_SUBSTITUTE,
-            'UTF-8'
-        );
-
-        $e = array_map($escape, $vars);
-
-        return <<<HTML
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content="noindex, nofollow">
-  <title>Verification required</title>
-  <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #f5f6f8; color: #1a1a1a; margin: 0; display: flex; min-height: 100vh; align-items: center; justify-content: center; }
-    .card { background: #fff; padding: 2rem 2.5rem; border-radius: 8px; box-shadow: 0 4px 24px rgba(0,0,0,0.08); max-width: 28rem; width: 90%; }
-    h1 { font-size: 1.25rem; margin: 0 0 0.75rem; }
-    p { margin: 0 0 1.25rem; color: #555; }
-    label { display: block; font-weight: 600; margin-bottom: 0.5rem; }
-    input[type="text"] { width: 100%; padding: 0.6rem 0.75rem; font-size: 1rem; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; }
-    button { margin-top: 1rem; width: 100%; padding: 0.65rem 1rem; font-size: 1rem; background: #1f6feb; color: #fff; border: 0; border-radius: 4px; cursor: pointer; }
-    button:hover { background: #1858c4; }
-    .error { color: #b42318; margin-top: 0.75rem; font-size: 0.9rem; display: none; }
-    .error.visible { display: block; }
-  </style>
-</head>
-<body>
-  <main class="card">
-    <h1>Quick verification</h1>
-    <p>Please answer the question below to continue.</p>
-    <form id="challenge-form" method="post" action="{$e['submit_url']}">
-      <label for="answer">{$e['question']}</label>
-      <input type="text" id="answer" name="{$e['answer_field']}" inputmode="numeric" autocomplete="off" autofocus required>
-      <input type="hidden" name="{$e['state_field']}" value="{$e['state']}">
-      <input type="hidden" name="{$e['redirect_field']}" value="{$e['redirect_to']}">
-      <input type="hidden" name="{$e['ttl_field']}" value="{$e['ttl']}">
-      <button type="submit">Continue</button>
-      <div id="error" class="error" role="alert">Incorrect answer. Please try again.</div>
-    </form>
-  </main>
-  <script>
-    (function () {
-      var form = document.getElementById('challenge-form');
-      var err = document.getElementById('error');
-      var headerName = "{$e['header_name']}";
-      var redirectTo = "{$e['redirect_to']}";
-
-      form.addEventListener('submit', function (event) {
-        event.preventDefault();
-        err.classList.remove('visible');
-
-        var data = new FormData(form);
-        fetch(form.action, {
-          method: 'POST',
-          body: data,
-          headers: { 'Accept': 'application/json' },
-          credentials: 'same-origin'
-        }).then(function (resp) {
-          return resp.json().then(function (body) { return { ok: resp.ok, body: body }; });
-        }).then(function (result) {
-          if (!result.ok || !result.body || !result.body.token) {
-            err.classList.add('visible');
-            return;
-          }
-          try {
-            if (headerName) {
-              localStorage.setItem('firewall.' + headerName, result.body.token);
-            }
-          } catch (e) { /* localStorage blocked — cookie still works */ }
-          window.location.href = result.body.redirect || redirectTo;
-        }).catch(function () {
-          err.classList.add('visible');
-        });
-      });
-    })();
-  </script>
-</body>
-</html>
-HTML;
     }
 }

--- a/src/Challenge/MathChallengeProvider.php
+++ b/src/Challenge/MathChallengeProvider.php
@@ -49,17 +49,6 @@ final class MathChallengeProvider implements ChallengeProviderInterface
      */
     public const ANSWER_FIELD = 'challenge_answer';
 
-    /**
-     * Form field carrying the post-success redirect target.
-     */
-    public const REDIRECT_FIELD = 'redirect_to';
-
-    /**
-     * Form field carrying the per-plugin TTL (so the Firewall knows how
-     * long to mint the resulting pass token for).
-     */
-    public const TTL_FIELD = 'ttl';
-
     private const STATE_LIFETIME = 300;
 
     /**

--- a/src/Challenge/MathChallengeProvider.php
+++ b/src/Challenge/MathChallengeProvider.php
@@ -89,7 +89,6 @@ final class MathChallengeProvider implements ChallengeProviderInterface
             'submit_url' => $context['submit_url'] ?? '',
             'redirect_to' => $context['redirect_to'] ?? '/',
             'ttl' => $context['ttl'] ?? '3600',
-            'cookie_name' => $context['cookie_name'] ?? '',
             'header_name' => $context['header_name'] ?? '',
             'state' => $signedState,
             'state_field' => self::STATE_FIELD,
@@ -193,7 +192,6 @@ final class MathChallengeProvider implements ChallengeProviderInterface
     (function () {
       var form = document.getElementById('challenge-form');
       var err = document.getElementById('error');
-      var cookieName = "{$e['cookie_name']}";
       var headerName = "{$e['header_name']}";
       var redirectTo = "{$e['redirect_to']}";
 

--- a/src/Challenge/SingleUseSolutionInterface.php
+++ b/src/Challenge/SingleUseSolutionInterface.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kanopi\Firewall\Challenge;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Opt-in contract for providers whose solutions must not be replayed.
+ *
+ * A stateless provider verifies a solution purely from the posted payload,
+ * which means the same payload verifies every time it is submitted until
+ * it expires. For a proof-of-work challenge that is a real weakness: the
+ * cost is paid once and the result can be redistributed, so an attacker
+ * solves a single challenge and hands the payload to as many clients as
+ * they like, each minting its own pass token.
+ *
+ * Providers that implement this interface hand `Firewall` an identifier
+ * for the solution in the current request. `Firewall` — which owns the
+ * storage backend — records it and refuses any later submission carrying
+ * the same identifier.
+ *
+ * This is deliberately separate from `ChallengeProviderInterface` so that
+ * existing custom providers keep working untouched, and because it is not
+ * universally applicable: a provider whose solutions are not unique per
+ * render cannot use it. `MathChallengeProvider` is exactly that case —
+ * its signed state is `answer|expiry`, and with only nine possible answers
+ * two visitors served in the same second routinely share one, so treating
+ * that value as single-use would reject legitimate solvers.
+ */
+interface SingleUseSolutionInterface
+{
+    /**
+     * Identify the solution carried by this request.
+     *
+     * Called only after `verifySolution()` has already returned TRUE, so
+     * implementations may assume the payload is well-formed and authentic
+     * and do not need to re-validate it.
+     *
+     * The identifier must be unique per issued challenge and derived from
+     * signed material, otherwise an attacker could vary it to sidestep the
+     * consumed-solution record.
+     *
+     * @param Request $request
+     *   The POST request carrying the visitor's solution.
+     *
+     * @return array{id: string, expires: int}|null
+     *   `id` uniquely identifies the solved challenge; `expires` is the
+     *   unix timestamp after which the solution would be rejected anyway,
+     *   used to bound how long the consumed-solution record is kept.
+     *   NULL opts this particular request out of replay tracking.
+     */
+    public function getSolutionReceipt(Request $request): ?array;
+}

--- a/src/Challenge/TokenManager.php
+++ b/src/Challenge/TokenManager.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
  * it expires (rotating the secret invalidates everything).
  *
  * Wire format: `base64url(payload).base64url(hmac)`
- *   payload = JSON{ip, exp, nonce}
+ *   payload = JSON{ip, exp, nonce, aud}
  *   hmac    = HMAC-SHA256(payload, secret)
  *
  * Token binding (verified on every request):
@@ -32,6 +32,11 @@ use Symfony\Component\HttpFoundation\Request;
  *   - `exp`   is a unix timestamp; tokens past it are rejected.
  *   - `nonce` is 128 random bits to keep two same-second mints distinct in
  *             downstream logs and to prevent precomputed-token attacks.
+ *   - `aud`   scopes the token to one challenge configuration. Without it,
+ *             any two Firewall instances sharing a secret would accept
+ *             each other's tokens, so a token earned on a weak challenge
+ *             could be spent on a route protected by a stronger one — the
+ *             weakest challenge would set the security of all of them.
  *
  * The signature is verified with `hash_equals` so a wrong token reveals
  * nothing through timing. Payload parsing errors return FALSE rather than
@@ -44,11 +49,17 @@ final class TokenManager
      *   HMAC key. Must be non-empty when challenge plugins are active —
      *   `Firewall::create()` fails fast if a challenge plugin is configured
      *   without a secret.
+     * @param string $audience
+     *   Scope this manager mints and accepts tokens for. `Firewall`
+     *   defaults it to the configured provider name, so a `math` token is
+     *   not accepted by an `altcha`-protected instance. Operators running
+     *   several instances with the same provider and the same secret can
+     *   set `challenge.audience` explicitly to keep them separate.
      *
      * @throws ConfigurationException
      *   When the secret is empty.
      */
-    public function __construct(private readonly string $secret)
+    public function __construct(private readonly string $secret, private readonly string $audience = '')
     {
         if ($this->secret === '') {
             throw new ConfigurationException(
@@ -78,6 +89,7 @@ final class TokenManager
             'ip' => (string) $request->getClientIp(),
             'exp' => time() + $ttl,
             'nonce' => bin2hex(random_bytes(16)),
+            'aud' => $this->audience,
         ];
 
         $payloadEncoded = $this->base64UrlEncode((string) json_encode($payload));
@@ -129,6 +141,13 @@ final class TokenManager
         }
 
         if ($payload['exp'] <= time()) {
+            return false;
+        }
+
+        // Fail closed on a missing `aud`: tokens minted before this claim
+        // existed are rejected, costing their holders one extra challenge
+        // rather than leaving the cross-instance hole open.
+        if (!isset($payload['aud']) || !is_string($payload['aud']) || $payload['aud'] !== $this->audience) {
             return false;
         }
 

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -456,7 +456,9 @@ final class Firewall
      *   In Exception mode when the solution is valid. Carries the minted
      *   token and the redirect target so tests can assert both.
      * @throws ChallengeRequiredException
-     *   In Exception mode when the solution is invalid.
+     *   In Exception mode when the solution does not verify, or when it
+     *   verifies but has already been spent (see
+     *   `consumeSingleUseSolution()`).
      */
     protected function handleChallengeSubmission(Request $request): void
     {

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -13,7 +13,6 @@ namespace Kanopi\Firewall;
 
 use Kanopi\Firewall\Challenge\ChallengeProviderFactory;
 use Kanopi\Firewall\Challenge\ChallengeProviderInterface;
-use Kanopi\Firewall\Challenge\MathChallengeProvider;
 use Kanopi\Firewall\Challenge\TokenManager;
 use Kanopi\Firewall\Exception\ChallengeRequiredException;
 use Kanopi\Firewall\Exception\ChallengeSolvedException;
@@ -447,9 +446,11 @@ final class Firewall
             // @codeCoverageIgnoreEnd
         }
 
-        $ttl = max(0, (int) $request->request->get(MathChallengeProvider::TTL_FIELD, 3600));
+        $ttl = max(0, (int) $request->request->get(ChallengeProviderInterface::TTL_FIELD, 3600));
         $token = $this->tokenManager->mint($request, $ttl);
-        $redirect = $this->sanitizeRedirect((string) $request->request->get(MathChallengeProvider::REDIRECT_FIELD, '/'));
+        $redirect = $this->sanitizeRedirect(
+            (string) $request->request->get(ChallengeProviderInterface::REDIRECT_FIELD, '/')
+        );
 
         $this->getLogger()->info('Challenge solution accepted', $this->getContext($request, [
             'provider' => $this->challengeProvider->getName(),

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -215,6 +215,7 @@ final class Firewall
             'header_name' => 'X-Firewall-Challenge',
             'path' => '/_firewall/challenge',
             'provider_options' => [],
+            'audience' => '',
         ];
 
         $challengeConfig = array_replace($defaults, $challengeConfig);
@@ -234,7 +235,16 @@ final class Firewall
 
         $providerOptions = $challengeConfig['provider_options'] ?? [];
 
-        $tokenManager = new TokenManager($secret);
+        // Scope pass tokens so two instances sharing a secret but running
+        // different challenges cannot accept each other's tokens. Defaults
+        // to the provider name, which is what distinguishes them; operators
+        // running the same provider in several places can override it.
+        $audience = trim((string) ($challengeConfig['audience'] ?? ''));
+        if ($audience === '') {
+            $audience = (string) $challengeConfig['provider'];
+        }
+
+        $tokenManager = new TokenManager($secret, $audience);
         $challengeProvider = ChallengeProviderFactory::create(
             (string) $challengeConfig['provider'],
             $tokenManager,

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -440,10 +440,20 @@ final class Firewall
         }
 
         $valid = $this->challengeProvider->verifySolution($request);
+        $replayed = false;
+
+        // A stateless verify accepts the same payload every time it is
+        // posted. For providers that opt in, burn the solution here so the
+        // work behind it cannot be redistributed and reused.
+        if ($valid && !$this->consumeSingleUseSolution($request)) {
+            $valid = false;
+            $replayed = true;
+        }
 
         if (!$valid) {
             $this->getLogger()->info('Challenge solution rejected', $this->getContext($request, [
                 'provider' => $this->challengeProvider->getName(),
+                'reason' => $replayed ? 'solution_already_used' : 'invalid_solution',
             ]));
 
             if ($this->firewallMode === FirewallMode::Exception) {
@@ -484,6 +494,50 @@ final class Firewall
 
         exit((string) json_encode(['token' => $token, 'redirect' => $redirect]));
         // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Record a single-use solution, refusing one that was already spent.
+     *
+     * Only applies to providers implementing SingleUseSolutionInterface;
+     * everything else is waved through, so custom providers and the math
+     * provider are unaffected.
+     *
+     * Note this is a read-then-write against the storage backend, which
+     * exposes no atomic add. Two submissions of the same solution racing
+     * within the same instant can therefore both succeed. That narrows the
+     * window from the full challenge lifetime to microseconds, which is
+     * what matters here — the attack this closes is redistributing one
+     * solve to many clients over seconds or minutes, not winning a race.
+     *
+     * @return bool
+     *   TRUE when the solution had not been used before (or the provider
+     *   does not track reuse), FALSE when this is a replay.
+     */
+    protected function consumeSingleUseSolution(Request $request): bool
+    {
+        if (!$this->challengeProvider instanceof \Kanopi\Firewall\Challenge\SingleUseSolutionInterface) {
+            return true;
+        }
+
+        $receipt = $this->challengeProvider->getSolutionReceipt($request);
+        if ($receipt === null) {
+            return true;
+        }
+
+        // Hashed so the raw challenge value never lands in the store.
+        $key = 'fw_challenge_solution:' . hash('sha256', $receipt['id']);
+
+        if ($this->storage->get($key) !== null) {
+            return false;
+        }
+
+        // Storage treats the third argument as a lifetime in seconds. Keep
+        // the record only until the solution would expire on its own.
+        $ttl = max(1, $receipt['expires'] - time());
+        $this->storage->set($key, ['consumed_at' => time()], $ttl);
+
+        return true;
     }
 
     /**

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -214,6 +214,7 @@ final class Firewall
             'cookie_name' => 'fw_challenge_pass',
             'header_name' => 'X-Firewall-Challenge',
             'path' => '/_firewall/challenge',
+            'provider_options' => [],
         ];
 
         $challengeConfig = array_replace($defaults, $challengeConfig);
@@ -231,10 +232,13 @@ final class Firewall
             );
         }
 
+        $providerOptions = $challengeConfig['provider_options'] ?? [];
+
         $tokenManager = new TokenManager($secret);
         $challengeProvider = ChallengeProviderFactory::create(
             (string) $challengeConfig['provider'],
-            $tokenManager
+            $tokenManager,
+            is_array($providerOptions) ? $providerOptions : []
         );
 
         return [$challengeProvider, $tokenManager, $challengeConfig];

--- a/tests/Integration/ChallengeFlowTest.php
+++ b/tests/Integration/ChallengeFlowTest.php
@@ -127,6 +127,112 @@ class ChallengeFlowTest extends TestCase
         $this->assertTrue($firewall->evaluate($request));
     }
 
+    public function testCustomCookieNameIsHonoured(): void
+    {
+        // `challenge.cookie_name` is operator-configurable; the firewall
+        // must both write and read the pass token under that name, and
+        // must not silently fall back to the default.
+        $configFile = $this->writeConfig([
+            'global' => ['mode' => 'exception'],
+            'challenge' => [
+                'provider' => 'math',
+                'secret' => self::SECRET,
+                'cookie_name' => 'my_custom_pass_cookie',
+                'header_name' => 'X-Firewall-Challenge',
+                'path' => '/_firewall/challenge',
+            ],
+            'plugins' => [
+                [
+                    'plugin' => 'Kanopi\Firewall\Plugins\IpAddress',
+                    'response' => 'challenge',
+                    'weight' => 0,
+                    'enable' => true,
+                    'metadata' => ['default_expiration_time' => 600],
+                    'config' => ['10.0.0.50'],
+                ],
+            ],
+        ], 'custom_cookie.yml');
+
+        $firewall = Firewall::create([$configFile]);
+        $token = $this->mintTokenViaSolution($firewall, '10.0.0.50');
+
+        $underCustomName = Request::create(
+            '/protected',
+            'GET',
+            [],
+            ['my_custom_pass_cookie' => $token],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.50']
+        );
+        $this->assertTrue($firewall->evaluate($underCustomName));
+
+        // The default name must carry no weight once one is configured.
+        $underDefaultName = Request::create(
+            '/protected',
+            'GET',
+            [],
+            ['fw_challenge_pass' => $token],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.50']
+        );
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($underDefaultName);
+    }
+
+    public function testEmptyCookieNameDisablesTheCookiePath(): void
+    {
+        // Documented as the way to turn off cookie delivery and rely on
+        // the localStorage/header path only.
+        $configFile = $this->writeConfig([
+            'global' => ['mode' => 'exception'],
+            'challenge' => [
+                'provider' => 'math',
+                'secret' => self::SECRET,
+                'cookie_name' => '',
+                'header_name' => 'X-Firewall-Challenge',
+                'path' => '/_firewall/challenge',
+            ],
+            'plugins' => [
+                [
+                    'plugin' => 'Kanopi\Firewall\Plugins\IpAddress',
+                    'response' => 'challenge',
+                    'weight' => 0,
+                    'enable' => true,
+                    'metadata' => ['default_expiration_time' => 600],
+                    'config' => ['10.0.0.50'],
+                ],
+            ],
+        ], 'no_cookie.yml');
+
+        $firewall = Firewall::create([$configFile]);
+        $token = $this->mintTokenViaSolution($firewall, '10.0.0.50');
+
+        // No cookie name configured, so no cookie is consulted...
+        $viaCookie = Request::create(
+            '/protected',
+            'GET',
+            [],
+            ['fw_challenge_pass' => $token],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.50']
+        );
+
+        // ...but the header delivery path still works.
+        $viaHeader = Request::create(
+            '/protected',
+            'GET',
+            [],
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.50', 'HTTP_X_FIREWALL_CHALLENGE' => $token]
+        );
+        $this->assertTrue($firewall->evaluate($viaHeader));
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($viaCookie);
+    }
+
     public function testValidTokenInHeaderAllowsRequest(): void
     {
         $firewall = Firewall::create([$this->configWithChallenge()]);

--- a/tests/Integration/ChallengeFlowTest.php
+++ b/tests/Integration/ChallengeFlowTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanopi\Firewall\Tests\Integration;
 
+use Kanopi\Firewall\Challenge\AltchaChallengeProvider;
 use Kanopi\Firewall\Challenge\MathChallengeProvider;
 use Kanopi\Firewall\Exception\ChallengeRequiredException;
 use Kanopi\Firewall\Exception\ChallengeSolvedException;
@@ -402,5 +403,174 @@ class ChallengeFlowTest extends TestCase
             }
         }
         rmdir($directory);
+    }
+
+    // -------------------------------------------------------------------
+    // ALTCHA single-use solutions
+    // -------------------------------------------------------------------
+
+    public function testAltchaSolutionMintsATokenOnFirstSubmission(): void
+    {
+        $firewall = Firewall::create([$this->configWithAltchaChallenge()]);
+        $payload = $this->solveAltcha($firewall, '10.0.0.50');
+
+        try {
+            $firewall->evaluate($this->altchaSubmission($payload, '10.0.0.50'));
+            $this->fail('Expected ChallengeSolvedException');
+        } catch (ChallengeSolvedException $e) {
+            $this->assertNotEmpty($e->getToken());
+        }
+    }
+
+    public function testAltchaSolutionCannotBeReplayed(): void
+    {
+        $config = $this->configWithAltchaChallenge();
+        $firewall = Firewall::create([$config]);
+        $payload = $this->solveAltcha($firewall, '10.0.0.50');
+
+        // First submission spends the solution.
+        try {
+            $firewall->evaluate($this->altchaSubmission($payload, '10.0.0.50'));
+            $this->fail('Expected ChallengeSolvedException on first submission');
+        } catch (ChallengeSolvedException) {
+            // Expected.
+        }
+
+        // Re-posting the identical payload must now be refused.
+        $this->expectException(ChallengeRequiredException::class);
+        Firewall::create([$config])->evaluate($this->altchaSubmission($payload, '10.0.0.50'));
+    }
+
+    public function testAltchaSolutionCannotBeRedistributedToOtherClients(): void
+    {
+        // The attack this closes: solve once, hand the payload to a fleet,
+        // each client mints a pass token bound to its own IP.
+        $config = $this->configWithAltchaChallenge();
+        $payload = $this->solveAltcha(Firewall::create([$config]), '10.0.0.50');
+
+        try {
+            Firewall::create([$config])->evaluate($this->altchaSubmission($payload, '10.0.0.50'));
+            $this->fail('Expected ChallengeSolvedException on first submission');
+        } catch (ChallengeSolvedException) {
+            // Expected.
+        }
+
+        foreach (['203.0.113.5', '198.51.100.9', '192.0.2.44'] as $ip) {
+            try {
+                Firewall::create([$config])->evaluate($this->altchaSubmission($payload, $ip));
+                $this->fail('Replay from ' . $ip . ' was accepted');
+            } catch (ChallengeRequiredException) {
+                $this->addToAssertionCount(1);
+            }
+        }
+    }
+
+    public function testDistinctAltchaSolutionsAreEachAccepted(): void
+    {
+        // Burning one solution must not lock out unrelated visitors.
+        $config = $this->configWithAltchaChallenge();
+
+        foreach (['10.0.0.50', '10.0.0.50', '10.0.0.50'] as $ip) {
+            $firewall = Firewall::create([$config]);
+            $payload = $this->solveAltcha($firewall, $ip);
+
+            try {
+                $firewall->evaluate($this->altchaSubmission($payload, $ip));
+                $this->fail('Expected ChallengeSolvedException');
+            } catch (ChallengeSolvedException $e) {
+                $this->assertNotEmpty($e->getToken());
+            }
+        }
+    }
+
+    /**
+     * Config using the ALTCHA provider and a file-backed store, so
+     * consumed-solution records survive across Firewall instances the way
+     * they do across requests in production.
+     */
+    private function configWithAltchaChallenge(): string
+    {
+        return $this->writeConfig([
+            'global' => ['mode' => 'exception'],
+            'storage' => [
+                'type' => 'Kanopi\Firewall\Storage\FileStorage',
+                'config' => ['storage_file' => $this->tempDir . '/altcha-storage.data'],
+            ],
+            'challenge' => [
+                'provider' => 'altcha',
+                'secret' => self::SECRET,
+                'cookie_name' => 'fw_challenge_altcha_pass',
+                'header_name' => 'X-Firewall-Challenge-Altcha',
+                'path' => '/_firewall/challenge',
+            ],
+            'plugins' => [
+                [
+                    'plugin' => 'Kanopi\Firewall\Plugins\Url',
+                    'response' => 'challenge',
+                    'weight' => 0,
+                    'enable' => true,
+                    'metadata' => ['default_expiration_time' => 600],
+                    'config' => ['path@starts_with:/protected'],
+                ],
+            ],
+        ], 'altcha_config.yml');
+    }
+
+    /**
+     * Render an ALTCHA interstitial, brute-force the embedded challenge,
+     * and return the base64 payload the widget would post back.
+     */
+    private function solveAltcha(Firewall $firewall, string $ip): string
+    {
+        $providerRef = new \ReflectionProperty($firewall, 'challengeProvider');
+        $provider = $providerRef->getValue($firewall);
+        $this->assertInstanceOf(AltchaChallengeProvider::class, $provider);
+
+        $html = $provider->renderInterstitial(
+            Request::create('/protected', 'GET', [], [], [], ['REMOTE_ADDR' => $ip]),
+            [
+                'submit_url' => '/_firewall/challenge',
+                'redirect_to' => '/protected',
+                'ttl' => '600',
+                'header_name' => 'X-Firewall-Challenge-Altcha',
+            ]
+        );
+
+        $this->assertSame(1, preg_match('/challengejson="([^"]+)"/', $html, $m));
+        $challenge = json_decode(html_entity_decode($m[1], ENT_QUOTES, 'UTF-8'), true);
+        $this->assertIsArray($challenge);
+
+        $number = null;
+        for ($i = 0; $i <= (int) $challenge['maxnumber']; $i++) {
+            if (hash('sha256', $challenge['salt'] . $i) === $challenge['challenge']) {
+                $number = $i;
+                break;
+            }
+        }
+        $this->assertNotNull($number, 'Could not solve the ALTCHA challenge');
+
+        return base64_encode((string) json_encode([
+            'algorithm' => $challenge['algorithm'],
+            'challenge' => $challenge['challenge'],
+            'number' => $number,
+            'salt' => $challenge['salt'],
+            'signature' => $challenge['signature'],
+        ]));
+    }
+
+    private function altchaSubmission(string $payload, string $ip): Request
+    {
+        return Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [
+                AltchaChallengeProvider::PAYLOAD_FIELD => $payload,
+                AltchaChallengeProvider::REDIRECT_FIELD => '/protected',
+                AltchaChallengeProvider::TTL_FIELD => '600',
+            ],
+            [],
+            [],
+            ['REMOTE_ADDR' => $ip]
+        );
     }
 }

--- a/tests/Unit/Challenge/AltchaChallengeProviderTest.php
+++ b/tests/Unit/Challenge/AltchaChallengeProviderTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Challenge;
+
+use Kanopi\Firewall\Challenge\AltchaChallengeProvider;
+use Kanopi\Firewall\Challenge\TokenManager;
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class AltchaChallengeProviderTest extends AbstractTestCase
+{
+    private const SECRET = 'altcha-test-secret-value';
+
+    public function testGetNameReturnsAltcha(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+        $this->assertSame('altcha', $provider->getName());
+    }
+
+    public function testRenderProducesExpectedFields(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+        $html = $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => '/wanted-page',
+            'ttl' => '900',
+            'cookie_name' => 'fw_pass',
+            'header_name' => 'X-FW',
+        ]);
+
+        $this->assertStringContainsString('<form', $html);
+        $this->assertStringContainsString('action="/_firewall/challenge"', $html);
+        $this->assertStringContainsString('<altcha-widget', $html);
+        $this->assertStringContainsString('challengejson=', $html);
+        $this->assertStringContainsString('name="' . AltchaChallengeProvider::REDIRECT_FIELD . '"', $html);
+        $this->assertStringContainsString('name="' . AltchaChallengeProvider::TTL_FIELD . '"', $html);
+        $this->assertStringContainsString('value="/wanted-page"', $html);
+        $this->assertStringContainsString('value="900"', $html);
+    }
+
+    public function testRenderEmbedsChallengeJsonWithExpectedShape(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+        $html = $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => '/',
+            'ttl' => '60',
+            'cookie_name' => 'c',
+            'header_name' => 'h',
+        ]);
+
+        $challenge = $this->extractChallenge($html);
+        $this->assertSame('SHA-256', $challenge['algorithm']);
+        $this->assertArrayHasKey('challenge', $challenge);
+        $this->assertArrayHasKey('salt', $challenge);
+        $this->assertArrayHasKey('signature', $challenge);
+        $this->assertArrayHasKey('maxnumber', $challenge);
+        $this->assertIsString($challenge['salt']);
+        $this->assertStringContainsString('?expires=', $challenge['salt']);
+    }
+
+    public function testRenderEscapesContextValues(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+        $html = $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => '/"><script>alert(1)</script>',
+            'ttl' => '60',
+            'cookie_name' => 'fw_pass',
+            'header_name' => 'X-FW',
+        ]);
+
+        $this->assertStringNotContainsString('<script>alert(1)</script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testVerifyAcceptsValidSolution(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+
+        [$challenge, $number] = $this->renderAndSolve($provider);
+
+        $request = $this->makeSubmissionRequest($this->encodeSolution($challenge, $number));
+        $this->assertTrue($provider->verifySolution($request));
+    }
+
+    public function testVerifyRejectsMissingPayload(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+        $this->assertFalse($provider->verifySolution($this->makeSubmissionRequest('')));
+    }
+
+    public function testVerifyRejectsNonBase64Payload(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+        $this->assertFalse($provider->verifySolution($this->makeSubmissionRequest('!!!not-base64!!!')));
+    }
+
+    public function testVerifyRejectsNonJsonPayload(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+        $this->assertFalse($provider->verifySolution(
+            $this->makeSubmissionRequest(base64_encode('totally not json'))
+        ));
+    }
+
+    public function testVerifyRejectsTamperedChallenge(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+
+        [$challenge, $number] = $this->renderAndSolve($provider);
+        $challenge['challenge'] = str_repeat('0', strlen((string) $challenge['challenge']));
+
+        $request = $this->makeSubmissionRequest($this->encodeSolution($challenge, $number));
+        $this->assertFalse($provider->verifySolution($request));
+    }
+
+    public function testVerifyRejectsWrongNumber(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+
+        [$challenge, $number] = $this->renderAndSolve($provider);
+        $request = $this->makeSubmissionRequest($this->encodeSolution($challenge, $number + 1));
+        $this->assertFalse($provider->verifySolution($request));
+    }
+
+    public function testVerifyRejectsBadSignature(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+
+        [$challenge, $number] = $this->renderAndSolve($provider);
+        $challenge['signature'] = 'forged-signature';
+        $request = $this->makeSubmissionRequest($this->encodeSolution($challenge, $number));
+        $this->assertFalse($provider->verifySolution($request));
+    }
+
+    public function testVerifyRejectsExpiredChallenge(): void
+    {
+        $tokenManager = new TokenManager(self::SECRET);
+        $provider = new AltchaChallengeProvider($tokenManager);
+
+        $salt = bin2hex(random_bytes(8)) . '?expires=' . (time() - 60);
+        $number = 42;
+        $challenge = hash('sha256', $salt . $number);
+        $signature = $tokenManager->sign($challenge);
+
+        $payload = base64_encode((string) json_encode([
+            'algorithm' => 'SHA-256',
+            'challenge' => $challenge,
+            'number' => $number,
+            'salt' => $salt,
+            'signature' => $signature,
+        ]));
+
+        $this->assertFalse($provider->verifySolution($this->makeSubmissionRequest($payload)));
+    }
+
+    public function testVerifyRejectsSaltWithoutExpiry(): void
+    {
+        $tokenManager = new TokenManager(self::SECRET);
+        $provider = new AltchaChallengeProvider($tokenManager);
+
+        // Properly signed, properly hashed — but the salt has no `?expires`.
+        $salt = bin2hex(random_bytes(8));
+        $number = 7;
+        $challenge = hash('sha256', $salt . $number);
+        $signature = $tokenManager->sign($challenge);
+
+        $payload = base64_encode((string) json_encode([
+            'algorithm' => 'SHA-256',
+            'challenge' => $challenge,
+            'number' => $number,
+            'salt' => $salt,
+            'signature' => $signature,
+        ]));
+
+        $this->assertFalse($provider->verifySolution($this->makeSubmissionRequest($payload)));
+    }
+
+    public function testVerifyRejectsWrongAlgorithm(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+
+        [$challenge, $number] = $this->renderAndSolve($provider);
+        $challenge['algorithm'] = 'SHA-1';
+
+        $this->assertFalse($provider->verifySolution(
+            $this->makeSubmissionRequest($this->encodeSolution($challenge, $number))
+        ));
+    }
+
+    /**
+     * Render the interstitial and brute-force the embedded challenge so
+     * the test ends up holding a payload that would actually verify.
+     *
+     * @return array{0: array<string, mixed>, 1: int}
+     */
+    private function renderAndSolve(AltchaChallengeProvider $provider): array
+    {
+        $html = $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => '/',
+            'ttl' => '60',
+            'cookie_name' => 'c',
+            'header_name' => 'h',
+        ]);
+
+        $challenge = $this->extractChallenge($html);
+        $number = $this->solve($challenge);
+
+        return [$challenge, $number];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function extractChallenge(string $html): array
+    {
+        $this->assertSame(1, preg_match('/challengejson="([^"]+)"/', $html, $m), 'challengejson attribute missing');
+        $decoded = html_entity_decode($m[1], ENT_QUOTES, 'UTF-8');
+        /** @var array<string, mixed>|null $data */
+        $data = json_decode($decoded, true);
+        $this->assertIsArray($data);
+        return $data;
+    }
+
+    /**
+     * Brute-force find N such that SHA-256(salt + N) == challenge — fast
+     * enough at the default maxnumber to keep the suite snappy.
+     *
+     * @param array<string, mixed> $challenge
+     */
+    private function solve(array $challenge): int
+    {
+        $max = (int) $challenge['maxnumber'];
+        $salt = (string) $challenge['salt'];
+        $target = (string) $challenge['challenge'];
+
+        for ($i = 0; $i <= $max; $i++) {
+            if (hash_equals($target, hash('sha256', $salt . $i))) {
+                return $i;
+            }
+        }
+
+        $this->fail('Could not solve challenge within maxnumber');
+    }
+
+    /**
+     * @param array<string, mixed> $challenge
+     */
+    private function encodeSolution(array $challenge, int $number): string
+    {
+        return base64_encode((string) json_encode([
+            'algorithm' => $challenge['algorithm'],
+            'challenge' => $challenge['challenge'],
+            'number' => $number,
+            'salt' => $challenge['salt'],
+            'signature' => $challenge['signature'],
+        ]));
+    }
+
+    private function makeSubmissionRequest(string $payload): Request
+    {
+        return Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [AltchaChallengeProvider::PAYLOAD_FIELD => $payload],
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.5']
+        );
+    }
+}

--- a/tests/Unit/Challenge/AltchaChallengeProviderTest.php
+++ b/tests/Unit/Challenge/AltchaChallengeProviderTest.php
@@ -76,6 +76,86 @@ final class AltchaChallengeProviderTest extends AbstractTestCase
         $this->assertStringContainsString('&lt;script&gt;', $html);
     }
 
+    public function testRenderPinsWidgetAndEmitsIntegrityByDefault(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+        $html = $this->render($provider);
+
+        $this->assertStringContainsString(
+            'src="' . AltchaChallengeProvider::DEFAULT_WIDGET_SRC . '"',
+            $html
+        );
+        $this->assertStringContainsString(
+            'integrity="' . AltchaChallengeProvider::DEFAULT_WIDGET_INTEGRITY . '"',
+            $html
+        );
+        $this->assertStringContainsString('crossorigin="anonymous"', $html);
+        // The bundle is an ES module; a classic script tag cannot load it.
+        $this->assertStringContainsString('type="module"', $html);
+    }
+
+    public function testDefaultWidgetSrcIsPinnedToAnExactVersion(): void
+    {
+        // An unpinned URL silently changes what every challenge page loads.
+        $this->assertMatchesRegularExpression(
+            '#/altcha@\d+\.\d+\.\d+/#',
+            AltchaChallengeProvider::DEFAULT_WIDGET_SRC
+        );
+        $this->assertStringStartsWith('sha384-', AltchaChallengeProvider::DEFAULT_WIDGET_INTEGRITY);
+    }
+
+    public function testCustomWidgetSrcIsHonoured(): void
+    {
+        $provider = new AltchaChallengeProvider(
+            new TokenManager(self::SECRET),
+            ['widget_src' => '/assets/altcha.min.js', 'widget_integrity' => 'sha384-custom']
+        );
+        $html = $this->render($provider);
+
+        $this->assertStringContainsString('src="/assets/altcha.min.js"', $html);
+        $this->assertStringContainsString('integrity="sha384-custom"', $html);
+        $this->assertStringNotContainsString(AltchaChallengeProvider::DEFAULT_WIDGET_SRC, $html);
+    }
+
+    public function testCustomWidgetSrcWithoutIntegrityEmitsNoDigest(): void
+    {
+        // Carrying the default digest over to a different bundle would
+        // block the script outright, so no attribute is emitted at all.
+        $provider = new AltchaChallengeProvider(
+            new TokenManager(self::SECRET),
+            ['widget_src' => '/assets/altcha.min.js']
+        );
+        $html = $this->render($provider);
+
+        $this->assertStringContainsString('src="/assets/altcha.min.js"', $html);
+        $this->assertStringNotContainsString('integrity=', $html);
+        $this->assertStringNotContainsString(AltchaChallengeProvider::DEFAULT_WIDGET_INTEGRITY, $html);
+    }
+
+    public function testBlankWidgetOptionsFallBackToTheDefaults(): void
+    {
+        $provider = new AltchaChallengeProvider(
+            new TokenManager(self::SECRET),
+            ['widget_src' => '   ', 'widget_integrity' => '']
+        );
+        $html = $this->render($provider);
+
+        $this->assertStringContainsString(AltchaChallengeProvider::DEFAULT_WIDGET_SRC, $html);
+        $this->assertStringContainsString(AltchaChallengeProvider::DEFAULT_WIDGET_INTEGRITY, $html);
+    }
+
+    public function testWidgetSrcIsEscapedIntoTheAttribute(): void
+    {
+        $provider = new AltchaChallengeProvider(
+            new TokenManager(self::SECRET),
+            ['widget_src' => '/a.js" onload="alert(1)']
+        );
+        $html = $this->render($provider);
+
+        $this->assertStringNotContainsString('onload="alert(1)"', $html);
+        $this->assertStringContainsString('&quot;', $html);
+    }
+
     public function testVerifyAcceptsValidSolution(): void
     {
         $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
@@ -189,6 +269,19 @@ final class AltchaChallengeProviderTest extends AbstractTestCase
         $this->assertFalse($provider->verifySolution(
             $this->makeSubmissionRequest($this->encodeSolution($challenge, $number))
         ));
+    }
+
+    /**
+     * Render an interstitial with a stock context.
+     */
+    private function render(AltchaChallengeProvider $provider): string
+    {
+        return $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => '/',
+            'ttl' => '60',
+            'header_name' => 'X-FW',
+        ]);
     }
 
     /**

--- a/tests/Unit/Challenge/AltchaChallengeProviderTest.php
+++ b/tests/Unit/Challenge/AltchaChallengeProviderTest.php
@@ -166,6 +166,48 @@ final class AltchaChallengeProviderTest extends AbstractTestCase
         $this->assertTrue($provider->verifySolution($request));
     }
 
+    public function testSolutionReceiptIdentifiesTheSolvedChallenge(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+
+        [$challenge, $number] = $this->renderAndSolve($provider);
+        $request = $this->makeSubmissionRequest($this->encodeSolution($challenge, $number));
+
+        $receipt = $provider->getSolutionReceipt($request);
+
+        $this->assertIsArray($receipt);
+        $this->assertSame($challenge['challenge'], $receipt['id']);
+        $this->assertGreaterThan(time(), $receipt['expires']);
+    }
+
+    public function testSolutionReceiptIsNullForAnInvalidPayload(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+
+        [$challenge, $number] = $this->renderAndSolve($provider);
+        $challenge['signature'] = 'forged-signature';
+        $request = $this->makeSubmissionRequest($this->encodeSolution($challenge, $number));
+
+        $this->assertNull($provider->getSolutionReceipt($request));
+    }
+
+    public function testTwoRendersProduceDistinctReceiptIds(): void
+    {
+        // A shared id would make one visitor's solve invalidate another's.
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+
+        $ids = [];
+        for ($i = 0; $i < 3; $i++) {
+            [$challenge, $number] = $this->renderAndSolve($provider);
+            $request = $this->makeSubmissionRequest($this->encodeSolution($challenge, $number));
+            $receipt = $provider->getSolutionReceipt($request);
+            $this->assertIsArray($receipt);
+            $ids[] = $receipt['id'];
+        }
+
+        $this->assertCount(3, array_unique($ids));
+    }
+
     public function testVerifyRejectsMissingPayload(): void
     {
         $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));

--- a/tests/Unit/Challenge/ChallengeProviderFactoryTest.php
+++ b/tests/Unit/Challenge/ChallengeProviderFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanopi\Firewall\Tests\Unit\Challenge;
 
+use Kanopi\Firewall\Challenge\AltchaChallengeProvider;
 use Kanopi\Firewall\Challenge\ChallengeProviderFactory;
 use Kanopi\Firewall\Challenge\ChallengeProviderInterface;
 use Kanopi\Firewall\Challenge\MathChallengeProvider;
@@ -20,6 +21,14 @@ final class ChallengeProviderFactoryTest extends AbstractTestCase
 
         $this->assertInstanceOf(MathChallengeProvider::class, $provider);
         $this->assertSame('math', $provider->getName());
+    }
+
+    public function testResolvesAltchaShortName(): void
+    {
+        $provider = ChallengeProviderFactory::create('altcha', new TokenManager('secret-value'));
+
+        $this->assertInstanceOf(AltchaChallengeProvider::class, $provider);
+        $this->assertSame('altcha', $provider->getName());
     }
 
     public function testResolvesFqcn(): void

--- a/tests/Unit/Challenge/ChallengeProviderFactoryTest.php
+++ b/tests/Unit/Challenge/ChallengeProviderFactoryTest.php
@@ -53,4 +53,36 @@ final class ChallengeProviderFactoryTest extends AbstractTestCase
         // Use any existing class that isn't a provider.
         ChallengeProviderFactory::create(TokenManager::class, new TokenManager('secret-value'));
     }
+
+    public function testForwardsOptionsToProvidersThatAcceptThem(): void
+    {
+        $provider = ChallengeProviderFactory::create(
+            'altcha',
+            new TokenManager('secret-value'),
+            ['widget_src' => 'https://example.test/altcha.js', 'widget_integrity' => 'sha384-abc']
+        );
+
+        $html = $provider->renderInterstitial(
+            Request::create('/secure'),
+            ['submit_url' => '/_fw', 'redirect_to' => '/', 'ttl' => '60', 'header_name' => 'X-FW']
+        );
+
+        $this->assertStringContainsString('src="https://example.test/altcha.js"', $html);
+        $this->assertStringContainsString('integrity="sha384-abc"', $html);
+    }
+
+    public function testSingleArgumentProvidersAreStillConstructable(): void
+    {
+        // MathChallengeProvider keeps the original one-parameter constructor,
+        // standing in for any custom provider written against it. Passing
+        // options must not break it.
+        $provider = ChallengeProviderFactory::create(
+            'math',
+            new TokenManager('secret-value'),
+            ['widget_src' => 'ignored']
+        );
+
+        $this->assertInstanceOf(MathChallengeProvider::class, $provider);
+        $this->assertInstanceOf(ChallengeProviderInterface::class, $provider);
+    }
 }

--- a/tests/Unit/Challenge/InterstitialRendererTest.php
+++ b/tests/Unit/Challenge/InterstitialRendererTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Challenge;
+
+use Kanopi\Firewall\Challenge\AltchaChallengeProvider;
+use Kanopi\Firewall\Challenge\InterstitialRenderer;
+use Kanopi\Firewall\Challenge\MathChallengeProvider;
+use Kanopi\Firewall\Challenge\TokenManager;
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Escaping rules for the shared interstitial document.
+ *
+ * The regression these guard is a real lockout: the ALTCHA submit button
+ * renders disabled and is only enabled by the inline script, so a value
+ * that breaks that script's syntax leaves the visitor with no way to
+ * complete the challenge.
+ */
+final class InterstitialRendererTest extends AbstractTestCase
+{
+    private const SECRET = 'interstitial-test-secret';
+
+    /**
+     * Values that broke, or could break, the inline script when they were
+     * escaped with htmlspecialchars() instead of encoded as JS literals.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function hostileRedirectProvider(): array
+    {
+        return [
+            'trailing backslash' => ['/secure\\'],
+            'escaped quote attempt' => ['/secure\\"'],
+            'double quote' => ['/secure"onerror="alert(1)'],
+            'single quote' => ["/secure'+alert(1)+'"],
+            'script close tag' => ['/secure</script><script>alert(1)</script>'],
+            'newline attempt' => ["/secure\\n+alert(1)"],
+            'backslash run' => ['/secure\\\\\\'],
+            'invalid utf8' => ["/secure\xC3\x28"],
+        ];
+    }
+
+    #[DataProvider('hostileRedirectProvider')]
+    public function testMathInterstitialStaysSyntacticallyValid(string $redirect): void
+    {
+        $provider = new MathChallengeProvider(new TokenManager(self::SECRET));
+        $html = $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => $redirect,
+            'ttl' => '60',
+            'header_name' => 'X-FW',
+        ]);
+
+        $this->assertInlineScriptParses($html);
+    }
+
+    #[DataProvider('hostileRedirectProvider')]
+    public function testAltchaInterstitialStaysSyntacticallyValid(string $redirect): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+        $html = $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => $redirect,
+            'ttl' => '60',
+            'header_name' => 'X-FW',
+        ]);
+
+        $this->assertInlineScriptParses($html);
+    }
+
+    #[DataProvider('hostileRedirectProvider')]
+    public function testHeaderNameIsAlsoJsEncoded(string $headerName): void
+    {
+        $provider = new MathChallengeProvider(new TokenManager(self::SECRET));
+        $html = $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => '/',
+            'ttl' => '60',
+            'header_name' => $headerName,
+        ]);
+
+        $this->assertInlineScriptParses($html);
+    }
+
+    public function testEscapeJsNeutralisesScriptClose(): void
+    {
+        $encoded = InterstitialRenderer::escapeJs('</script><script>alert(1)</script>');
+
+        $this->assertStringNotContainsString('</script>', $encoded);
+        $this->assertStringNotContainsString('<', $encoded);
+        $this->assertStringNotContainsString('>', $encoded);
+    }
+
+    public function testEscapeJsEmitsAQuotedLiteral(): void
+    {
+        // The template interpolates the result bare, so the quotes must
+        // come from the encoder itself.
+        $encoded = InterstitialRenderer::escapeJs('/plain');
+
+        $this->assertSame('"\/plain"', $encoded);
+    }
+
+    public function testEscapeJsNeverEmitsAnEmptyExpression(): void
+    {
+        $this->assertNotSame('', InterstitialRenderer::escapeJs("\xC3\x28"));
+        $this->assertNotSame('', InterstitialRenderer::escapeJs(''));
+    }
+
+    public function testHtmlContextStillEscapesTheRedirectField(): void
+    {
+        $provider = new MathChallengeProvider(new TokenManager(self::SECRET));
+        $html = $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => '/"><script>alert(1)</script>',
+            'ttl' => '60',
+            'header_name' => 'X-FW',
+        ]);
+
+        // The hidden input must not be breakable out of.
+        $this->assertStringNotContainsString('"><script>alert(1)', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    /**
+     * Assert every inline (non-module) script in the document parses.
+     *
+     * Uses node when available so this is a real parse rather than a
+     * regex approximation; skips rather than silently passing when node
+     * is absent.
+     */
+    private function assertInlineScriptParses(string $html): void
+    {
+        $this->assertSame(
+            1,
+            preg_match('#<script>\s*(\(function.*?)</script>#s', $html, $matches),
+            'inline script block not found'
+        );
+
+        $script = $matches[1];
+
+        // A bare `</script>` anywhere in the block would have ended the
+        // element early in a real browser, regardless of JS validity.
+        $this->assertStringNotContainsString('</script>', $script);
+
+        $node = trim((string) shell_exec('command -v node 2>/dev/null'));
+        if ($node === '') {
+            $this->markTestSkipped('node is not available to parse-check the inline script');
+        }
+
+        $file = tempnam(sys_get_temp_dir(), 'fw-inline-') . '.js';
+        file_put_contents($file, $script);
+
+        $output = [];
+        $status = 0;
+        exec(escapeshellarg($node) . ' --check ' . escapeshellarg($file) . ' 2>&1', $output, $status);
+        unlink($file);
+
+        $this->assertSame(0, $status, "inline script failed to parse:\n" . implode("\n", $output));
+    }
+}

--- a/tests/Unit/Challenge/TokenManagerTest.php
+++ b/tests/Unit/Challenge/TokenManagerTest.php
@@ -133,4 +133,75 @@ final class TokenManagerTest extends AbstractTestCase
         $token = $manager->mint($request, -1);
         $this->assertTrue($manager->verify($token, $request));
     }
+
+    public function testTokenIsNotAcceptedByADifferentAudience(): void
+    {
+        // The exact deployment the demo now ships: two instances, one
+        // secret, different challenge providers. A token earned on the
+        // trivial math challenge must not open an ALTCHA-protected route.
+        $math = new TokenManager(self::SECRET, 'math');
+        $altcha = new TokenManager(self::SECRET, 'altcha');
+        $request = $this->getRequest('10.1.2.3');
+
+        $token = $math->mint($request, 3600);
+
+        $this->assertTrue($math->verify($token, $request));
+        $this->assertFalse($altcha->verify($token, $request));
+    }
+
+    public function testSameAudienceStillInteroperates(): void
+    {
+        // Two processes of the same deployment must still share tokens.
+        $minter = new TokenManager(self::SECRET, 'altcha');
+        $verifier = new TokenManager(self::SECRET, 'altcha');
+        $request = $this->getRequest('10.1.2.3');
+
+        $this->assertTrue($verifier->verify($minter->mint($request, 3600), $request));
+    }
+
+    public function testCustomAudienceSeparatesSameProviderInstances(): void
+    {
+        $public = new TokenManager(self::SECRET, 'public-site');
+        $admin = new TokenManager(self::SECRET, 'admin-portal');
+        $request = $this->getRequest('10.1.2.3');
+
+        $this->assertFalse($admin->verify($public->mint($request, 3600), $request));
+    }
+
+    public function testTokenWithoutAudienceClaimIsRejected(): void
+    {
+        // Forge a pre-upgrade token: correctly signed, but no `aud`.
+        // Verification must fail closed rather than accept it.
+        $manager = new TokenManager(self::SECRET, 'math');
+        $request = $this->getRequest('10.1.2.3');
+
+        $payload = ['ip' => '10.1.2.3', 'exp' => time() + 3600, 'nonce' => str_repeat('a', 32)];
+        $encoded = rtrim(strtr(base64_encode((string) json_encode($payload)), '+/', '-_'), '=');
+        $signature = rtrim(
+            strtr(base64_encode(hash_hmac('sha256', $encoded, self::SECRET, true)), '+/', '-_'),
+            '='
+        );
+
+        $this->assertFalse($manager->verify($encoded . '.' . $signature, $request));
+    }
+
+    public function testAudienceIsCoveredByTheSignature(): void
+    {
+        // Swapping `aud` in the payload must invalidate the HMAC, so an
+        // attacker cannot re-scope a token they already hold.
+        $manager = new TokenManager(self::SECRET, 'math');
+        $request = $this->getRequest('10.1.2.3');
+
+        [$payloadPart, $signature] = explode('.', $manager->mint($request, 3600), 2);
+        $padded = $payloadPart . str_repeat('=', (4 - strlen($payloadPart) % 4) % 4);
+        $json = base64_decode(strtr($padded, '-_', '+/'), true);
+        $payload = json_decode((string) $json, true);
+        $this->assertIsArray($payload);
+
+        $payload['aud'] = 'altcha';
+        $tampered = rtrim(strtr(base64_encode((string) json_encode($payload)), '+/', '-_'), '=');
+
+        $altcha = new TokenManager(self::SECRET, 'altcha');
+        $this->assertFalse($altcha->verify($tampered . '.' . $signature, $request));
+    }
 }


### PR DESCRIPTION
## Summary

- New `Kanopi\Firewall\Challenge\AltchaChallengeProvider` — stateless ALTCHA v2 provider. Server pre-computes `{algorithm, challenge, maxnumber, salt, signature}` and embeds it in the widget via `challengejson=`; salt carries `?expires=<unix>`; signature is `TokenManager::sign(challenge)`. Verify decodes the base64 `altcha` payload, re-hashes `salt + number`, checks the HMAC, and rejects expired salts.
- Registered as `'altcha'` in `ChallengeProviderFactory::BUILTINS` — same shape as the existing math builtin.
- `example/demo/` grows a fourth route (`/secure-altcha`) via path-based dispatch in `index.php` to a second config (`config.altcha.yml`). Only one `challenge.provider` is configurable per Firewall instance, so the demo runs two instances in sequence based on which path is being requested. Distinct submit path / cookie / header per provider so the two pass tokens coexist.
- Docs: README "Built-in providers" subsection now covers both math and altcha; `example/config.notes.yml` lists altcha alongside math.

## Test plan

- [x] `tests/Unit/Challenge/AltchaChallengeProviderTest.php` — 13 cases: render shape + escaping, accepts solved payload, rejects tampered challenge / wrong number / bad signature / expired salt / no-expiry salt / wrong algorithm / non-base64 / non-JSON / empty payload.
- [x] `ChallengeProviderFactoryTest::testResolvesAltchaShortName` — short-name resolution.
- [x] Full suite still passes (the pre-existing 6 Redis-extension errors are unrelated to this branch).
- [x] PHPStan and PHPCS clean on touched files.
- [x] Manual end-to-end: GET `/secure-altcha` → 200 with widget; POST garbage to `/_firewall/challenge-altcha` → 400 `invalid_solution`; POST solved payload → 200 + `fw_challenge_altcha_pass` cookie; reload with that cookie → success page.

## Notes for the reviewer

- `script type="module"` on the widget bundle is required — the official ALTCHA `altcha.min.js` distribution ships as an ES module; a classic `<script>` tag fails with `Unexpected token 'export'`.
- The widget bundle is loaded from `cdn.jsdelivr.net/npm/altcha/dist/altcha.min.js`. If a self-hosted bundle is preferred down the line, that string is a class constant and can be extracted to config without API changes.
- Both providers' `REDIRECT_FIELD` / `TTL_FIELD` constants are named identically (`redirect_to` / `ttl`) so `Firewall::handleChallengeSubmission()` doesn't need to know which provider is wired up — it reads a shared field name regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)