### PR TITLE
Replace trait method_exists() guards with default hooks (Fixes #80)

### DIFF
--- a/src/Traits/DatabaseTrait.php
+++ b/src/Traits/DatabaseTrait.php
@@ -76,30 +76,42 @@ trait DatabaseTrait
      */
     protected function createTable(): void
     {
-        /** @phpstan-ignore-next-line */
-        if (method_exists($this, 'getStorageTables')) {
-            $tables = $this->getStorageTables();
-            /** @var Table[] $tables */
-            foreach ($tables as $table) {
-                if (!$this->schemaManager->tablesExist([$table->getName()])) {
-                    try {
-                        $this->schemaManager->createTable($table);
-                        $this->getLogger()->info('Database table created', [
-                            'table' => $table->getName(),
-                        ]);
-                    } catch (\Exception $e) {
-                        $this->getLogger()->error('Failed to create database table', [
-                            'table' => $table->getName(),
-                            'error' => $e->getMessage(),
-                        ]);
-                    }
-                } else {
-                    $this->getLogger()->debug('Database table already exists', [
-                        'table' => $this->config['storage_table'],
+        $tables = $this->getStorageTables();
+        /** @var Table[] $tables */
+        foreach ($tables as $table) {
+            if (!$this->schemaManager->tablesExist([$table->getName()])) {
+                try {
+                    $this->schemaManager->createTable($table);
+                    $this->getLogger()->info('Database table created', [
+                        'table' => $table->getName(),
+                    ]);
+                } catch (\Exception $e) {
+                    $this->getLogger()->error('Failed to create database table', [
+                        'table' => $table->getName(),
+                        'error' => $e->getMessage(),
                     ]);
                 }
+            } else {
+                $this->getLogger()->debug('Database table already exists', [
+                    'table' => $this->config['storage_table'],
+                ]);
             }
         }
+    }
+
+    /**
+     * Describe the tables this storage requires.
+     *
+     * Optional hook. Classes using this trait override this to declare their
+     * schema; the default returns no tables so the trait remains usable by
+     * classes that manage their own schema or need none.
+     *
+     * @return Table[]
+     *   Tables to create when they do not already exist.
+     */
+    protected function getStorageTables(): array
+    {
+        return [];
     }
 
     /**

--- a/src/Traits/EvaluateTrait.php
+++ b/src/Traits/EvaluateTrait.php
@@ -500,11 +500,26 @@ trait EvaluateTrait
             return null;
         }
 
-        /** @phpstan-ignore-next-line */
-        if (method_exists($this, 'getValue')) {
-            return $this->getValue($request, $variable);
-        }
+        return $this->getValue($request, $variable);
+    }
 
+    /**
+     * Resolve a request variable to its value.
+     *
+     * Optional hook. Classes using this trait override this to expose the
+     * variables they know how to resolve; the default returns null so the
+     * trait remains usable by classes that only need rule evaluation.
+     *
+     * @param Request $request
+     *   Symfony HTTP request object.
+     * @param string $variable
+     *   Variable name to extract from the request.
+     *
+     * @return mixed
+     *   The value of the variable, or null when it cannot be resolved.
+     */
+    protected function getValue(Request $request, string $variable): mixed
+    {
         return null;
     }
 }


### PR DESCRIPTION
Fixes #80

## What this does

Removes the two `method_exists($this, ...)` guards that PHPStan level max flagged, replacing them with declared optional hooks that carry no-op defaults:

- `src/Traits/EvaluateTrait.php` — `getRequestValue()` calls `$this->getValue()` directly; the trait declares `getValue()` returning `null`.
- `src/Traits/DatabaseTrait.php` — `createTable()` loops `$this->getStorageTables()` unconditionally; the trait declares it returning `[]`.

No consumer or test file is touched. The unrelated `@phpstan-ignore-next-line` on the `$schemaManager` property (`DatabaseTrait.php:30`) is left alone.

## Why

`composer check:security` failed with 6 `function.alreadyNarrowedType` errors on every PHP version, blocking CI for any PR since the last green `2.x` run on 2026-05-19.

Two things about the issue's analysis are worth correcting:

**The existing inline ignores never worked.** Both sites already had `@phpstan-ignore-next-line`. PHPStan reports these errors in the context of each *using class*, and inline comments in a trait body don't match those reports. I confirmed this — switching to the identifier form `@phpstan-ignore function.alreadyNarrowedType` produced *7* errors (the original 6 plus an unmatched-ignore). Only config-level `ignoreErrors` with a `path` would have suppressed them.

**Option 2 from the issue would have broken the test suite.** Neither dropping the guards nor declaring `abstract protected function` was viable, because the hooks are genuinely optional and tested as such:

- `EvaluateTraitTest::getPluginWithoutGetValue()` (`:52`) backs `testGetRequestValueMissingMethod` (`:203`), which asserts the `null` fallback.
- 5 of the 8 anonymous classes in `DatabaseTraitTest.php` use `DatabaseTrait` without `getStorageTables()`.

An `abstract` declaration would have made every one of those a fatal error.

The default-hook approach relies on PHP resolving a class's own method ahead of a trait's, so all 6 consumers keep their implementations while omitting consumers get the default. `getStorageTables()` returning `[]` makes the loop a no-op — byte-for-byte the old `method_exists() === false` path. The upside over a suppression is that the extension point becomes declared and documented instead of implicit.

## How to test

```bash
composer check:security   # 0 errors (was 6)
composer check:code       # passes
composer check:rector     # passes
composer test
```

Reflection confirms the resolution on the real classes — all six resolve the hook to their own declaration, so the trait default is shadowed wherever it matters:

| Class | Hook resolved from |
|---|---|
| `Asn` | `Asn.php:127` |
| `Url` | `Url.php:64` |
| `GeoLocation` | `GeoLocation.php:118` |
| `UserAgent` | `UserAgent.php:112` |
| `DatabaseStorage` | `DatabaseStorage.php:51` |
| `DatabaseRateLimitStorage` | `DatabaseRateLimitStorage.php:49` |

`GeoLocationTrait` (the second trait on `Asn`/`GeoLocation`) does not declare `getValue()`, so there is no trait-vs-trait conflict requiring `insteadof`/`as`. None of `AbstractPluginBase`, `AbstractStorageBase`, or `AbstractRateLimitStorage` declares either hook, so nothing inherited is shadowed.

Verified across the full CI matrix, PHP 8.1–8.5 (Docker, deps resolved per-version):

| Check | 8.1 | 8.2 | 8.3 | 8.4 | 8.5 |
|---|---|---|---|---|---|
| Precedence semantics | pass | pass | pass | pass | pass |
| `php -l` both traits | pass | pass | pass | pass | pass |
| PHPStan 2.2.5 level max | 6 → **0** | — | — | 6 → **0** | 6 → **0** |
| Trait tests (47) | 47/47 | — | — | 47/47 | 47/47 |
| Full suite vs. baseline | identical | — | — | identical | — |

The diff introduces no new syntax: `mixed` was already the return type of `getRequestValue()`. 8.1 at HEAD reproduces all 6 errors, so the bug and the fix both hold across the matrix.

## Breaking changes

None for anything in this repo. One BC edge worth a release note for external plugins, since a trait method *does* beat an inherited parent method:

```php
class TheirBase { protected function getValue(...) { /* real logic */ } }
class TheirPlugin extends TheirBase { use EvaluateTrait; }  // trait default now wins -> null
```

Previously `method_exists($this, 'getValue')` found the inherited method and called it. Nothing in this repo has that shape and it is an unusual way to write a plugin, but it is a real behavior change — confirmed identical on 8.1 through 8.5.

## Not addressed here

The failing `phpunit` checks the issue mentions are unrelated: `Run PHPUnit` passes and the job dies later in `Post to Github` with `API rate limit exceeded`. That still needs a token/throttling fix or a re-run, and probably its own issue if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
