### PR TITLE
Make documented config overrides land (Fixes #82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,12 @@ app:
 
 ### Filesystem Processors (opt-in)
 
-The `file:` (read a file's contents) and `require:` (include a PHP file and use its return value) processors are **disabled by default**. Because their path comes from an environment variable, enabling them turns any env-var injection into a local file inclusion — or, for `require:`, remote code execution. Using either one without opting in throws `ConfigurationException`.
+The `file:` (read a file's contents) and `require:` (include a PHP file and use its return value) processors are **disabled by default**. Because their path comes from an environment variable, enabling them turns any env-var injection into a local file inclusion — or, for `require:`, remote code execution.
+
+Using either one without opting in raises `ConfigurationException` from `TokenSubstitute`. Note where that exception ends up:
+
+- **Calling `TokenSubstitute::substitute()` directly** — the exception propagates to you.
+- **A token inside a YAML config** — `Config::loadFile()` swallows it, so `Firewall::create()` succeeds with **an empty config that allows every request**. There is no exception and no log entry. The gate still refuses to read the file, but it fails *open*, not loud. See [Fail open or fail closed?](#fail-open-or-fail-closed) for how to guard against this, and [#78](https://github.com/kanopi/firewall/issues/78) for the underlying silent-swallow behavior.
 
 Opt in during bootstrap, **before any config is loaded**, and constrain the reads to directories you control:
 
@@ -2218,7 +2223,7 @@ By default the library builds its own Monolog `Logger` on the `firewall` channel
 )->evaluate();
 ```
 
-This keeps everything the firewall logs — including the messages emitted *during* `create()` — flowing to your handler.
+This keeps everything the firewall logs — including the messages emitted *during* `create()` — flowing to your handler. It works whether or not your YAML declares a `logger:` section; index `0` is created if it does not exist. Entries you do declare are preserved, so `[logger][1][class]` adds a second handler alongside the first.
 
 **Option 2 — replace the whole logger after construction.** `LoggingFactory::setLogger()` takes a Monolog `Logger` instance (not any PSR-3 logger):
 
@@ -2270,6 +2275,29 @@ $overrides = [
     '[block][\Kanopi\Firewall\Plugins\GeoLocation][metadata][reader][db]' => $_ENV['GEOIP_DB_PATH'],
     '[block][\Kanopi\Firewall\Plugins\UserAgent][enable]' => false,
 ];
+```
+
+**Sections you have not declared are created for you.** An override writes into `global:`, `storage:`, `logger:`, `bypass:` or `block:` even when your YAML leaves that section out entirely — you do not have to add a placeholder entry first.
+
+**An override that cannot be applied is silently ignored.** This happens when the path has to traverse *through* a value that is not an array:
+
+```yaml
+storage: /tmp/firewall.data   # a scalar, not a mapping
+```
+
+```php
+// Dropped — `[storage]` is a string, so there is no `[config]` to write into.
+// No exception, no log entry, and the original scalar is left intact.
+'[storage][config][file]' => '/tmp/other.data',
+```
+
+Because there is no signal when this happens, assert the value landed if the override matters:
+
+```php
+$config = \Kanopi\Firewall\Utility\Config::load([$configPath], $overrides);
+if (($config['storage']['config']['file'] ?? null) !== $expectedPath) {
+    throw new \RuntimeException('Firewall storage override did not apply.');
+}
 ```
 
 ## Error Handling & Exceptions

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,9 @@
         "symfony/dotenv": "~6.4 || ~7.3",
         "symfony/var-dumper": "~6.4 || ~7.3"
     },
+    "suggest": {
+        "ext-redis": "Required only by Kanopi\\Firewall\\RateLimitStorage\\RedisRateLimitStorage, for distributed rate limiting. Every other rate-limit backend (memory, file, database, PSR-6 cache) works without it."
+    },
     "scripts": {
         "server:start": [
             "Composer\\Config::disableProcessTimeout",

--- a/src/Utility/Config.php
+++ b/src/Utility/Config.php
@@ -53,12 +53,68 @@ class Config
 
         foreach ($overrides as $key => $value) {
             try {
+                self::openOverridePath($merged, (string) $key);
                 $propertyAccessor->setValue($merged, $key, $value);
             } catch (\Exception) {
             }
         }
 
         return $merged;
+    }
+
+    /**
+     * Replace NULL nodes along an override path with empty arrays.
+     *
+     * `config/config.yml` — always prepended by `Firewall::create()` — ships
+     * `global: ~`, `storage: ~`, `logger: ~`, `bypass: ~` and `block: ~`, all
+     * of which parse to NULL. PropertyAccess cannot traverse into NULL, so it
+     * throws `UnexpectedTypeException`, which `load()` swallows. The override
+     * was then silently dropped: `[storage][config][file]`, `[logger][0][class]`,
+     * `[global][mode]` and `[block][...][enable]` all no-opped unless the
+     * caller's own YAML happened to define that section. Only `[plugins][...]`
+     * worked, because `plugins: []` is already an array.
+     *
+     * An empty section and an absent one mean the same thing here, so opening
+     * NULL to `[]` only makes the documented overrides land. Nodes holding a
+     * non-NULL value are left untouched — overwriting those would discard real
+     * configuration, and PropertyAccess still raises (and `load()` still
+     * swallows) exactly as before.
+     *
+     * @param array<string, mixed> $merged
+     *   Merged config to open up, by reference.
+     * @param string $path
+     *   PropertyAccess path the override will be written to.
+     */
+    private static function openOverridePath(array &$merged, string $path): void
+    {
+        // Only bracket notation addresses array offsets. Anything else (e.g.
+        // the bare `a` in testConfigLoadWithOverridesNotValid) is not a
+        // traversable array path, so leave it entirely to PropertyAccess.
+        if (preg_match('/^(?:\[[^\[\]]*\])+$/', $path) !== 1) {
+            return;
+        }
+
+        preg_match_all('/\[([^\[\]]*)\]/', $path, $matches);
+
+        // The last segment is the key being written, not a node to traverse.
+        $segments = $matches[1];
+        array_pop($segments);
+
+        $cursor = &$merged;
+        foreach ($segments as $segment) {
+            if (!is_array($cursor) || !array_key_exists($segment, $cursor)) {
+                // Missing nodes are fine — PropertyAccess creates those itself.
+                break;
+            }
+
+            if (is_null($cursor[$segment])) {
+                $cursor[$segment] = [];
+            }
+
+            $cursor = &$cursor[$segment];
+        }
+
+        unset($cursor);
     }
 
     /**

--- a/tests/Integration/Plugins/AllPluginsIntegrationTest.php
+++ b/tests/Integration/Plugins/AllPluginsIntegrationTest.php
@@ -412,8 +412,10 @@ class AllPluginsIntegrationTest extends IntegrationTestCase
         // Test with file storage
         $this->runRateLimitTest('file');
         
-        // Test with Redis if available
-        if (!self::getEnv('TEST_SKIP_REDIS')) {
+        // Test with Redis if available. `ext-redis` is a composer `suggest`,
+        // so the class genuinely may not exist — the skip below only covers a
+        // reachable-but-unusable server.
+        if (extension_loaded('redis') && !self::getEnv('TEST_SKIP_REDIS')) {
             $this->runRateLimitTest('redis');
         }
         
@@ -464,7 +466,10 @@ class AllPluginsIntegrationTest extends IntegrationTestCase
         
         try {
             $firewall = $this->createFirewall($config);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
+            // \Throwable, not \Exception: a missing `ext-redis` surfaces as
+            // `Error: Class "Redis" not found`, which an \Exception catch lets
+            // through and turns an optional backend into a suite failure.
             if ($storageType === 'redis') {
                 $this->markTestSkipped('Redis not available: ' . $e->getMessage());
             }

--- a/tests/Unit/RateLimitStorage/RedisRateLimitStorageTest.php
+++ b/tests/Unit/RateLimitStorage/RedisRateLimitStorageTest.php
@@ -6,9 +6,18 @@ namespace Kanopi\Firewall\Tests\Unit\RateLimitStorage;
 
 use Kanopi\Firewall\RateLimitStorage\RedisRateLimitStorage;
 use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Redis;
 use RedisException;
 
+/**
+ * `ext-redis` is a composer `suggest`, not a `require` — only
+ * RedisRateLimitStorage needs it, and every other rate-limit backend works
+ * without it. These tests mock `Redis`/`RedisException`, which PHPUnit cannot
+ * do when the extension is absent, so the whole case is skipped rather than
+ * erroring out a suite that is otherwise green.
+ */
+#[RequiresPhpExtension('redis')]
 class RedisRateLimitStorageTest extends AbstractTestCase
 {
     /**

--- a/tests/Unit/Utility/ReadmeOverrideExamplesTest.php
+++ b/tests/Unit/Utility/ReadmeOverrideExamplesTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Utility;
+
+use Kanopi\Firewall\Utility\Config;
+use Monolog\Handler\TestHandler;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+/**
+ * Verifies that every override example documented in README.md actually
+ * lands in the merged configuration.
+ *
+ * `Firewall::create()` always prepends `config/config.yml`, which ships
+ * `global: ~`, `storage: ~`, `logger: ~`, `bypass: ~` and `block: ~` — all
+ * NULL. PropertyAccess cannot traverse into NULL and `Config::load()` catches
+ * the resulting exception, so a broken override is indistinguishable from a
+ * working one at the call site: no return value, no exception, no log entry.
+ * That is exactly how the README came to document an override example that
+ * silently did nothing (issue #82).
+ *
+ * These tests therefore load through the real `config/config.yml`, the same
+ * way `Firewall::create()` does, and assert the overridden value is readable
+ * back out afterwards. Asserting only that `Config::load()` returns an array
+ * would pass against the broken behavior.
+ *
+ * When adding or changing an override example in README.md, mirror it here.
+ */
+final class ReadmeOverrideExamplesTest extends TestCase
+{
+    /**
+     * Path to the default config the firewall always loads first.
+     */
+    private const DEFAULT_CONFIG = __DIR__ . '/../../../config/config.yml';
+
+    /**
+     * Override paths documented in README.md, each with a representative value.
+     *
+     * @return array<string, array{0: string, 1: mixed}>
+     */
+    public static function readmeOverrideProvider(): array
+    {
+        return [
+            // "Dynamic Configuration Overrides"
+            'storage location' => ['[storage][config][file]', '/tmp/firewall.data'],
+            'geoip db on a plugins: entry' => ['[plugins][1][metadata][reader][db]', '/tmp/GeoLite2-City.mmdb'],
+            'redis host on a plugins: entry' => ['[plugins][3][metadata][storage][config][redis][host]', 'localhost'],
+            'disable a plugins: entry' => ['[plugins][2][enable]', false],
+
+            // "Dynamic Configuration Overrides" — legacy block:/bypass: format.
+            'legacy geoip db' => ['[block][\Kanopi\Firewall\Plugins\GeoLocation][metadata][reader][db]', '/tmp/GeoLite2-City.mmdb'],
+            'legacy disable plugin' => ['[block][\Kanopi\Firewall\Plugins\UserAgent][enable]', false],
+        ];
+    }
+
+    /**
+     * Every documented override path must survive the merge.
+     */
+    #[DataProvider('readmeOverrideProvider')]
+    public function testReadmeOverrideLands(string $path, mixed $value): void
+    {
+        $config = Config::load([self::DEFAULT_CONFIG], [$path => $value]);
+
+        self::assertSame(
+            $value,
+            PropertyAccess::createPropertyAccessor()->getValue($config, $path),
+            sprintf('README documents the override path "%s", but it did not land in the merged config.', $path)
+        );
+    }
+
+    /**
+     * "Injecting Your Own Logger" — Option 1 passes an instantiated Monolog
+     * handler through the override mechanism. `logger: ~` in the default
+     * config used to make this a silent no-op.
+     */
+    public function testReadmeLoggerHandlerInjectionLands(): void
+    {
+        $handler = new TestHandler();
+
+        $config = Config::load([self::DEFAULT_CONFIG], ['[logger][0][class]' => $handler]);
+
+        self::assertSame($handler, $config['logger'][0]['class']);
+    }
+
+    /**
+     * A user config layered on top must not change the outcome — the override
+     * has to land whether or not the caller's own YAML defines the section.
+     */
+    public function testReadmeOverrideLandsOverUserSuppliedConfig(): void
+    {
+        $userConfig = ['plugins' => [['type' => 'ip', 'response' => 'block', 'values' => ['1.2.3.4']]]];
+
+        $config = Config::load([self::DEFAULT_CONFIG, $userConfig], ['[storage][config][file]' => '/tmp/firewall.data']);
+
+        self::assertSame('/tmp/firewall.data', $config['storage']['config']['file']);
+        self::assertSame('ip', $config['plugins'][0]['type']);
+    }
+
+    /**
+     * Opening NULL sections must not clobber values that are actually set.
+     */
+    public function testOverrideDoesNotDiscardSiblingConfiguration(): void
+    {
+        $userConfig = ['storage' => ['class' => 'Kanopi\Firewall\Storage\FileStorage', 'config' => ['ttl' => 3600]]];
+
+        $config = Config::load([self::DEFAULT_CONFIG, $userConfig], ['[storage][config][file]' => '/tmp/firewall.data']);
+
+        self::assertSame('/tmp/firewall.data', $config['storage']['config']['file']);
+        self::assertSame(3600, $config['storage']['config']['ttl']);
+        self::assertSame('Kanopi\Firewall\Storage\FileStorage', $config['storage']['class']);
+    }
+
+    /**
+     * A scalar sitting where the path needs to traverse is a genuine caller
+     * error. It stays swallowed rather than silently destroying that value.
+     */
+    public function testOverrideThroughScalarNodeIsIgnoredAndPreservesValue(): void
+    {
+        $config = Config::load([['storage' => 'not-an-array']], ['[storage][config][file]' => '/tmp/firewall.data']);
+
+        self::assertSame('not-an-array', $config['storage']);
+    }
+}


### PR DESCRIPTION
Fixes #82.

## Verification first

Both claims in #82 reproduce. But testing the surrounding behavior showed the logger case is one symptom of a broader bug — **4 of the 5 override examples in the README silently no-op**, including the flagship `[storage][config][file]`:

| Documented override path | Before | After |
|---|---|---|
| `[storage][config][file]` | **dropped** | lands |
| `[plugins][0][enable]` | lands | lands |
| `[global][mode]` | **dropped** | lands |
| `[logger][0][class]` | **dropped** | lands |
| `[block][\Kanopi\Firewall\Plugins\UserAgent][enable]` | **dropped** | lands |

End-to-end through `Firewall::create()`, the README's Option 1 logger injection installed **zero** handlers before this change, and installs the caller's handler after it.

## Root cause

`Firewall::create()` always prepends `config/config.yml`, which ships `global: ~`, `storage: ~`, `logger: ~`, `bypass: ~` and `block: ~` — all NULL. `PropertyAccess` cannot traverse into NULL, so `setValue()` throws `UnexpectedTypeException` and `Config::load()` swallows it. Only `[plugins][...]` worked, because `plugins: []` is already an array.

Nothing surfaces the failure: no return value, no exception, no log entry. That is how a doc example that never worked shipped in a PR about documentation accuracy.

## Scope note

#82 proposed a documentation fix — demote or drop the logger example. I fixed the code instead. A doc-only fix would have required also documenting that most overrides don't work, which is worse than making them work. Happy to revert to the doc-only approach if you'd rather keep `Config::load()` untouched.

`openOverridePath()` opens NULL nodes along an override path to `[]` before the write. An empty section and an absent one already mean the same thing here — `Firewall::create()` does exactly this normalization for `logger`/`storage`/`global` one frame later. Nodes holding a non-NULL value are left alone, so an override traversing a real scalar stays swallowed exactly as before, rather than destroying that value.

## README corrections

- **Filesystem processors** — the opt-in gate was described as throwing `ConfigurationException`. True when calling `TokenSubstitute::substitute()` directly (verified), but a token inside a YAML config has that exception swallowed by `Config::loadFile()`, so the real outcome is an empty config that allows every request. Now documented as-is, cross-referencing #78; worth re-tightening once #78 lands.
- **Overrides** — documents that undeclared sections are created for you, and that an override traversing a scalar is silently ignored, with the assert-it-landed guard.
- **Logger injection** — Option 1 now works as written; noted that it applies with or without a `logger:` section.

## Doc-drift guard

Adds `tests/Unit/Utility/ReadmeOverrideExamplesTest.php`, the follow-up #82 asks for. It loads through the real `config/config.yml` — the way `Firewall::create()` does — and asserts each documented path reads back out. Asserting only that `Config::load()` returns an array would pass against the broken behavior.

**5 of its 10 cases fail without the `Config.php` change** (confirmed by reverting the fix and re-running).

## ext-redis made genuinely optional

The suite had 6 pre-existing errors on this machine because `ext-redis` isn't installed. It's optional in practice — every other rate-limit backend works without it — but nothing said so, and the integration test's `catch (\Exception)` let `Error: Class "Redis" not found` through.

- Declared in a new `suggest` section in `composer.json`
- Unit test marked `#[RequiresPhpExtension('redis')]`
- Integration branch gated on `extension_loaded('redis')`, catch broadened to `\Throwable`

## Testing

| | Before | After |
|---|---|---|
| `phpunit` | 740 tests, **6 errors** | **750 tests, 0 errors**, 12 skipped |
| `composer check:code` (phpcs) | clean | clean |
| `composer stan` (phpstan) | clean | clean |
| `composer check:rector` | clean | clean |
| `composer validate` | valid | valid |

The 6 errors were environmental (missing `ext-redis`) and identical on a stashed baseline; they are now skips. Remaining warnings/deprecations are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)