### PR TITLE
Correct Firewall @throws docblocks (Fixes #79)

### DIFF
--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -19,6 +19,7 @@ use Kanopi\Firewall\Exception\ChallengeRequiredException;
 use Kanopi\Firewall\Exception\ChallengeSolvedException;
 use Kanopi\Firewall\Exception\ConfigurationException;
 use Kanopi\Firewall\Exception\FirewallBlockedException;
+use Kanopi\Firewall\Exception\StorageException;
 use Kanopi\Firewall\Logging\LoggingFactory;
 use Kanopi\Firewall\Logging\LoggingTrait;
 use Kanopi\Firewall\Plugins\PluginInterface;
@@ -99,6 +100,11 @@ final class Firewall
      * All configurations are merged in the order they are passed, layered on top of
      * the default configuration loaded from `config.yml`.
      *
+     * Configuration inputs are loaded leniently: a string that does not
+     * reference a readable file, and an argument that is neither string,
+     * array, nor null, are both skipped rather than raising. Only the
+     * wiring performed after loading can fail.
+     *
      * @param array<int, string|array<string, mixed>|null> $configs
      *   Zero or more configurations to merge.
      *   Each can be a YAML file path (string), a config array, or null.
@@ -108,9 +114,14 @@ final class Firewall
      * @return self
      *   A new instance of the class initialized with the merged config.
      *
-     * @throws FirewallBlockedException
-     *   If a string argument does not reference an existing file,
-     *   or if an argument is not string, array, or null.
+     * @throws ConfigurationException
+     *   When challenge plugins are configured without a `challenge.secret`,
+     *   when `challenge.provider` cannot be resolved to a
+     *   ChallengeProviderInterface, or when `global.require_trusted_proxies`
+     *   is enabled and no trusted proxies have been set.
+     * @throws StorageException
+     *   When the configured storage backend cannot create, read, or write
+     *   its backing file.
      */
     public static function create(array $configs = [], array $overrides = []): self
     {
@@ -295,8 +306,23 @@ final class Firewall
      *   Request to evaluate.
      *
      * @return bool
-     *   Return TRUE if allowed to pass. FALSE
+     *   Always TRUE when the request is allowed through. A blocked or
+     *   challenged request never returns — in production the response is
+     *   written and the process exits, and in `mode: exception` one of the
+     *   exceptions below is thrown instead.
+     *
      * @throws FirewallBlockedException
+     *   In `mode: exception`, when a blocking plugin matches or the request
+     *   key is already on the block list.
+     * @throws ChallengeRequiredException
+     *   In `mode: exception`, when a challenge plugin matches and no valid
+     *   pass token is held, or when a posted solution is invalid.
+     * @throws ChallengeSolvedException
+     *   In `mode: exception`, when a posted challenge solution is valid.
+     * @throws ConfigurationException
+     *   In every mode, when a challenge plugin matches but no challenge
+     *   provider is configured. `create()` normally rejects that wiring
+     *   first, so this is a defensive last resort.
      */
     public function evaluate(?Request $request = null): bool
     {
@@ -476,6 +502,10 @@ final class Firewall
      *
      * @throws ChallengeRequiredException
      *   In Exception mode.
+     * @throws ConfigurationException
+     *   When a challenge plugin matched but no provider is wired up. This
+     *   should be unreachable — `create()` fails first — but is raised in
+     *   every mode rather than serving an empty page.
      */
     protected function sendChallengeResponse(Request $request, PluginInterface $plugin): void
     {
@@ -657,7 +687,8 @@ final class Firewall
      *   Status code to return for the request.
      *
      * @throws FirewallBlockedException
-     *   When env variable is used for testing.
+     *   In `mode: exception`. Every other mode writes the status code and
+     *   message to the response and exits.
      */
     protected function sendBlockingResponse(Request $request, int $statusCode = 0): void
     {

--- a/tests/Unit/FirewallTest.php
+++ b/tests/Unit/FirewallTest.php
@@ -6,11 +6,13 @@ namespace Kanopi\Firewall\Tests\Unit;
 
 use Kanopi\Firewall\Exception\ConfigurationException;
 use Kanopi\Firewall\Exception\FirewallBlockedException;
+use Kanopi\Firewall\Exception\StorageException;
 use Kanopi\Firewall\Firewall;
 use Kanopi\Firewall\Logging\LoggingFactory;
 use Kanopi\Firewall\Plugins\IpAddress;
 use Kanopi\Firewall\Plugins\PluginInterface;
 use Kanopi\Firewall\Plugins\PluginManager;
+use Kanopi\Firewall\Storage\FileStorage;
 use Kanopi\Firewall\Storage\InMemoryStorage;
 use Kanopi\Firewall\Storage\StorageInterface;
 use Kanopi\Firewall\Tests\Logging\TestLogHandler;
@@ -862,5 +864,68 @@ class FirewallTest extends AbstractTestCase
 
         $firewall = Firewall::create([$config]);
         $this->assertInstanceOf(Firewall::class, $firewall);
+    }
+
+    /**
+     * Regression for #79: `create()` used to advertise a
+     * FirewallBlockedException for unloadable config inputs. Nothing is
+     * raised — a string that isn't a readable file, and an argument that is
+     * neither string, array, nor null, are both skipped.
+     */
+    public function testCreateSkipsUnloadableConfigInputsWithoutThrowing(): void
+    {
+        $firewall = Firewall::create([
+            sys_get_temp_dir() . '/fw79-does-not-exist.yml',
+            42,
+            null,
+        ]);
+
+        $this->assertInstanceOf(Firewall::class, $firewall);
+    }
+
+    /**
+     * Regression for #79: `StorageFactory::create()` runs inline inside
+     * `create()` and is not wrapped, so an unusable storage file surfaces
+     * as a StorageException out of `create()`.
+     */
+    public function testCreateThrowsStorageExceptionForUnusableStorageFile(): void
+    {
+        // The parent directory does not exist, so touch() fails regardless
+        // of the uid the suite runs as.
+        $unusable = sys_get_temp_dir() . '/fw79-missing-dir/storage_data.json';
+
+        $this->expectException(StorageException::class);
+        $this->expectExceptionMessage('Unable to create file');
+        Firewall::create([
+            [
+                'storage' => [
+                    'type' => FileStorage::class,
+                    'config' => ['storage_file' => $unusable],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Regression for #79: a challenge plugin without `challenge.secret`
+     * fails at startup with a ConfigurationException — one of the two
+     * exceptions `create()` now documents.
+     */
+    public function testCreateThrowsConfigurationExceptionForChallengeWithoutSecret(): void
+    {
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage('`challenge.secret`');
+        Firewall::create([
+            [
+                'plugins' => [
+                    [
+                        'plugin' => IpAddress::class,
+                        'response' => 'challenge',
+                        'enable' => true,
+                        'config' => ['1.2.3.4'],
+                    ],
+                ],
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
Fixes #79.

## Verified first

A standalone script against the current `2.x` code confirmed every claim in the issue:

| Input to `Firewall::create()` | Actual result |
|---|---|
| `['/definitely/not/here.yml']` | no exception — instance returned |
| `[42]` (non-string, non-array) | no exception — instance returned |
| `FileStorage` with an uncreatable path | `StorageException: Unable to create file at ...` |
| challenge plugin, empty `challenge.secret` | `ConfigurationException: ... `challenge.secret` is empty` |

So the documented `@throws FirewallBlockedException` on `create()` was wrong on both counts: that exception is only ever thrown from `sendBlockingResponse()` in `mode: exception`, and an unloadable config input raises nothing at all (`Config::loadFile()` swallows it — #78).

## Changes

`src/Firewall.php`, docblocks only — no behavior change:

- **`create()`** — replaced the bogus tag with `@throws ConfigurationException` (empty `challenge.secret`, unresolvable `challenge.provider`, `require_trusted_proxies` with no proxies set) and `@throws StorageException` (`StorageFactory::create()` is called unwrapped inline at `Firewall.php:166`, so `FileTrait::validateFilePath()` throws straight out). Added a note that config loading is lenient by design.
- **`evaluate()`** — listed only `FirewallBlockedException`; it can also throw `ChallengeRequiredException`, `ChallengeSolvedException`, and the defensive `ConfigurationException` from `sendChallengeResponse()`. Its `@return` also promised a `FALSE` that is never returned.
- **`sendChallengeResponse()`** — documented the `ConfigurationException` it raises when a challenge plugin matches with no provider wired up.
- **`sendBlockingResponse()`** — "When env variable is used for testing" was wrong; there is no env var involved, it is governed by `mode: exception`.

The result now matches the README exception reference corrected in #77.

## Tests

Three regression tests in `tests/Unit/FirewallTest.php` pin the documented behavior so the docblock can't drift back:

- `testCreateSkipsUnloadableConfigInputsWithoutThrowing`
- `testCreateThrowsStorageExceptionForUnusableStorageFile`
- `testCreateThrowsConfigurationExceptionForChallengeWithoutSecret`

The storage test targets a path under a nonexistent parent directory so `touch()` fails regardless of the uid CI runs as.

## Checks

- `phpunit --testsuite unit` — 711 tests, 1407 assertions, pass (2 pre-existing deprecations, 7 pre-existing skips)
- `phpunit --testsuite integration` — 42 tests, 417 assertions, pass (5 pre-existing skips)
- `phpcs --standard=phpcs_ruleset.xml src` — clean
- `phpstan analyse src --level max` — no errors
- `rector process src/ --dry-run` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)