### PR TITLE
Stop config load failures from failing open (Fixes #78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ The `file:` (read a file's contents) and `require:` (include a PHP file and use 
 Using either one without opting in raises `ConfigurationException` from `TokenSubstitute`. Note where that exception ends up:
 
 - **Calling `TokenSubstitute::substitute()` directly** — the exception propagates to you.
-- **A token inside a YAML config** — `Config::loadFile()` swallows it, so `Firewall::create()` succeeds with **an empty config that allows every request**. There is no exception and no log entry. The gate still refuses to read the file, but it fails *open*, not loud. See [Fail open or fail closed?](#fail-open-or-fail-closed) for how to guard against this, and [#78](https://github.com/kanopi/firewall/issues/78) for the underlying silent-swallow behavior.
+- **A token inside a YAML config** — `Config::loadFile()` catches it and drops that file from the merge, so with the default `require_config: false` the firewall starts with **a config missing those rules** — potentially an empty one that allows every request. The failure is logged at `error` level with the reason. Set [`global.require_config: true`](#requiring-the-config-to-load) to make it a startup failure instead.
 
 Opt in during bootstrap, **before any config is loaded**, and constrain the reads to directories you control:
 
@@ -472,6 +472,7 @@ global:
   banning_status_code: 429
   banning_message: '{{request.id}} Request Banned'
   require_trusted_proxies: false
+  require_config: false
   blocking_escalation:
     - window: 300
       offense: 0
@@ -496,6 +497,36 @@ global:
 | `true` | Throws `Kanopi\Firewall\Exception\ConfigurationException` and refuses to start. Recommended for production deployments behind a load balancer / CDN / reverse proxy. |
 
 See the trusted-proxies note in [Basic Implementation](#basic-implementation) for the `Request::setTrustedProxies(...)` call you need to add before `Firewall::create()`.
+
+### Requiring the config to load
+
+Config loading is lenient: a config file that is missing, unreadable, or malformed contributes nothing to the merge rather than raising. That is convenient for optional config paths and dangerous everywhere else — a firewall with no plugins allows every request. `require_config` decides which of those you get:
+
+| Value | Behaviour |
+|-------|-----------|
+| `false` (default) | Every config input that failed to load is logged at `error` level (`Firewall config file failed to load — its rules are NOT active`, with the path and the reason), and the firewall starts with whatever did load. |
+| `true` | Throws `Kanopi\Firewall\Exception\ConfigurationException` listing every input that failed, and refuses to start. Recommended for production. |
+
+The exception message carries the underlying reason, so a typo, a permissions problem, a YAML syntax error, a circular `configs:` include, an unresolvable `%env(...)%` token, and a disabled `file:` / `require:` processor are all distinguishable:
+
+```
+global.require_config is enabled and 1 config input(s) failed to load:
+/var/www/firewall.yml — File does not exist.
+```
+
+There is one case the YAML flag cannot cover: when the config file that *would* have carried `require_config: true` is itself the one that failed to load. Set it outside the YAML for that:
+
+```php
+// Bootstrap, before Firewall::create().
+define('KANOPI_FIREWALL_REQUIRE_CONFIG', true);
+
+// …or as an override, which is read even when no config file parsed.
+Firewall::create([__DIR__ . '/firewall.yml'], ['[global][require_config]' => true]);
+```
+
+`global.require_config` wins over the constant when both are present, including when it is explicitly `false`.
+
+Plugin-level config files (`metadata.config`) are reported the same way — an unreadable one logs `Plugin config file failed to load — its rules are NOT active` and leaves that plugin with only its inline `config:` entries. `require_config` does not escalate those to a startup failure.
 
 ### Mode
 
@@ -2325,7 +2356,7 @@ Every exception the library throws extends `Kanopi\Firewall\Exception\FirewallEx
 
 Note that the three request-time exceptions are thrown **only** in `mode: exception`. In the default `block` mode the firewall writes the response and calls `exit()` itself, so there is nothing to catch.
 
-Config *loading* problems are the notable omission from that table: a missing, unreadable, or malformed config file — including circular `configs:` includes, unresolvable `%env(...)%` tokens, and use of a disabled filesystem processor — raises **no exception**. Loading is lenient by design and those failures produce an empty or partial ruleset instead. See [Fail open or fail closed?](#fail-open-or-fail-closed) for why that matters and how to guard against it.
+Config *loading* problems are conditional: a missing, unreadable, or malformed config file — including circular `configs:` includes, unresolvable `%env(...)%` tokens, and use of a disabled filesystem processor — is logged at `error` level and produces an empty or partial ruleset, and raises `ConfigurationException` only when [`global.require_config: true`](#requiring-the-config-to-load) is set. See [Fail open or fail closed?](#fail-open-or-fail-closed) for why that matters.
 
 ### Handling blocks in a framework
 
@@ -2355,32 +2386,39 @@ try {
 |---|---|---|
 | A `block` plugin matched a request (`mode: exception`) | `FirewallBlockedException` | The request you were meant to block proceeds. |
 | Startup validation failed — empty `challenge.secret`, unresolvable `challenge.provider`, or no trusted proxies with `require_trusted_proxies: true` | `ConfigurationException` | The firewall never started. **Nothing is filtered.** |
-| Your config file is missing, unreadable, or malformed | **Nothing at all** | The firewall starts with an empty ruleset and allows every request. |
+| Your config file is missing, unreadable, or malformed, with `require_config: true` | `ConfigurationException` | The firewall never started. **Nothing is filtered.** |
+| The same, with `require_config: false` (default) | **Nothing** — logged at `error` | The firewall starts with a partial ruleset, possibly an empty one that allows every request. |
 
-**The third row is the one to design around.** Config loading is deliberately lenient: `Config::loadFile()` skips files it cannot read and swallows YAML, include, and `%env(...)%` resolution errors, so a mistyped path or a broken include yields a firewall with **no plugins and no complaint**. `Firewall::create()` succeeds, `evaluate()` returns `true` for everything, and nothing in your logs says otherwise. Catching `ConfigurationException` does not protect you here, because none is thrown.
+**The last row is the one to design around.** Config loading is lenient by default: `Config::loadFile()` skips files it cannot read and catches YAML, include, and `%env(...)%` resolution errors, so a mistyped path or a broken include yields a firewall with **no plugins**. `Firewall::create()` succeeds and `evaluate()` returns `true` for everything. Each failure is at least logged:
 
-So an exception handler alone is not enough. Assert that your rules actually loaded:
+```
+firewall.ERROR: Firewall config file failed to load — its rules are NOT active
+    {"file":"/var/www/firewall.yml","reason":"File does not exist.","require_config":false}
+```
+
+An exception handler alone still will not catch that, because none is thrown. Turn it into a startup failure instead:
+
+```yaml
+global:
+  require_config: true
+```
+
+See [Requiring the config to load](#requiring-the-config-to-load) for the constant and override forms, which cover the case where the file carrying the flag is the one that failed to load. If you would rather assert on the result yourself, `Config::getLoadErrors()` reports what a lenient load dropped:
 
 ```php
 $configPath = __DIR__ . '/firewall.yml';
 
-// A typo here would otherwise be silent.
-if (!is_readable($configPath)) {
-    throw new \RuntimeException("Firewall config unreadable: {$configPath}");
-}
-
-// Confirm the file parsed into the rules you expect before trusting the firewall.
+\Kanopi\Firewall\Utility\Config::clearLoadErrors();
 $config = \Kanopi\Firewall\Utility\Config::load([$configPath]);
-if (($config['plugins'] ?? []) === []) {
-    throw new \RuntimeException("Firewall config loaded no plugins: {$configPath}");
+
+if (\Kanopi\Firewall\Utility\Config::getLoadErrors() !== []) {
+    throw new \RuntimeException("Firewall config did not load cleanly: {$configPath}");
 }
 
 Firewall::create([$configPath])->evaluate();
 ```
 
-If your config still uses the legacy `block:` / `bypass:` format, check those keys instead — they are normalized into `plugins:` inside `Firewall::create()`, which is after `Config::load()` returns. Whichever shape you use, the point is the same: verify your rules are present rather than assuming a silent load succeeded.
-
-For the two cases that *do* throw, pick a policy deliberately:
+For the cases that *do* throw, pick a policy deliberately:
 
 - **Fail closed** — rethrow, or return a 503. Correct default for anything where serving unfiltered traffic is worse than serving an error: authenticated apps, checkout flows, admin surfaces. A startup misconfiguration is an operator error caught in deploy, not something to paper over at runtime.
 - **Fail open** — log at `critical` and continue. Reasonable only for public, low-risk content where availability outweighs filtering, and only if that alert actually pages someone.

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,3 +1,11 @@
+# Global settings. Left empty here so a caller's own YAML supplies them.
+#   require_config: when true, Firewall::create() throws
+#                   ConfigurationException if any config input failed to
+#                   load, instead of starting with a partial ruleset. The
+#                   default (false) logs each failure at `error` and starts
+#                   anyway. Define KANOPI_FIREWALL_REQUIRE_CONFIG for the
+#                   case where the file carrying this flag is the one that
+#                   failed to load.
 global: ~
 storage: ~
 plugins: []

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -100,10 +100,13 @@ final class Firewall
      * All configurations are merged in the order they are passed, layered on top of
      * the default configuration loaded from `config.yml`.
      *
-     * Configuration inputs are loaded leniently: a string that does not
-     * reference a readable file, and an argument that is neither string,
-     * array, nor null, are both skipped rather than raising. Only the
-     * wiring performed after loading can fail.
+     * Configuration inputs are loaded leniently by default: a string that
+     * does not reference a readable file, and an argument that is neither
+     * string, array, nor null, are both skipped rather than raising. Unlike
+     * before, a skipped or malformed input is no longer silent — each one is
+     * logged at `error` level, and setting `global.require_config: true` (or
+     * defining `KANOPI_FIREWALL_REQUIRE_CONFIG`) turns it into a startup
+     * failure instead.
      *
      * @param array<int, string|array<string, mixed>|null> $configs
      *   Zero or more configurations to merge.
@@ -117,16 +120,28 @@ final class Firewall
      * @throws ConfigurationException
      *   When challenge plugins are configured without a `challenge.secret`,
      *   when `challenge.provider` cannot be resolved to a
-     *   ChallengeProviderInterface, or when `global.require_trusted_proxies`
-     *   is enabled and no trusted proxies have been set.
+     *   ChallengeProviderInterface, when `global.require_trusted_proxies`
+     *   is enabled and no trusted proxies have been set, or when
+     *   `global.require_config` is enabled and any config input failed to
+     *   load.
      * @throws StorageException
      *   When the configured storage backend cannot create, read, or write
      *   its backing file.
      */
     public static function create(array $configs = [], array $overrides = []): self
     {
-        // Load default config first
+        // Load default config first. Clear first, read after: `Config::load()`
+        // never throws, so the only evidence that a config file was missing,
+        // unreadable, or malformed is the list it leaves behind.
+        Config::clearLoadErrors();
         $config = Config::load(array_merge([__DIR__ . '/../config/config.yml'], $configs), $overrides);
+        $configLoadErrors = Config::getLoadErrors();
+
+        // Read the flag before the array_filter() below strips an explicit
+        // `require_config: false` and makes it indistinguishable from unset.
+        $requireConfig = self::requireConfig(
+            isset($config['global']) && is_array($config['global']) ? $config['global'] : []
+        );
 
         // Set the default values.
         $config['logger'] = isset($config['logger']) && is_array($config['logger']) ? array_filter($config['logger']) : [];
@@ -135,6 +150,10 @@ final class Firewall
         $config['challenge'] = isset($config['challenge']) && is_array($config['challenge']) ? $config['challenge'] : [];
 
         LoggingFactory::setLogger(LoggingFactory::create($config['logger']));
+
+        // The logger only exists now, so this is the first moment a load
+        // failure recorded above can actually reach an operator.
+        self::reportConfigLoadFailures($configLoadErrors, $requireConfig);
 
         // Every plugin reads `$request->getClientIp()`. Symfony only honors
         // proxy headers (X-Forwarded-For, Forwarded, X-Real-IP, …) when the
@@ -250,6 +269,90 @@ final class Firewall
         );
 
         return [$challengeProvider, $tokenManager, $challengeConfig];
+    }
+
+    /**
+     * Is a complete config load mandatory for this firewall?
+     *
+     * Sources, in precedence order:
+     *   1. `global.require_config` in the merged config — the normal place
+     *      to set it, and reachable from an override
+     *      (`['[global][require_config]' => true]`) as well as YAML.
+     *   2. The `KANOPI_FIREWALL_REQUIRE_CONFIG` constant, following the same
+     *      pattern as the `KANOPI_FIREWALL_CACHE_*` constants. This is the
+     *      one that survives the case the flag exists for: when the *only*
+     *      config file is the one that failed to load, its YAML cannot
+     *      possibly carry the flag, so bootstrap PHP has to.
+     *   3. Off — the 2.x default, so existing setups that pass optional
+     *      config paths keep working.
+     *
+     * @param array<string, mixed> $globalConfig
+     *   The `global` config section, before `array_filter()` strips falsey
+     *   values.
+     */
+    private static function requireConfig(array $globalConfig): bool
+    {
+        if (array_key_exists('require_config', $globalConfig)) {
+            return (bool) $globalConfig['require_config'];
+        }
+
+        return defined('KANOPI_FIREWALL_REQUIRE_CONFIG') && (bool) KANOPI_FIREWALL_REQUIRE_CONFIG;
+    }
+
+    /**
+     * Surface config inputs that did not load (#78).
+     *
+     * `Config::loadFile()` returns `[]` for a missing, unreadable, or
+     * malformed file. An empty plugin registry makes `PluginManager::
+     * evaluate()` return false for every request, so a mistyped path used to
+     * produce a firewall that allowed everything, with no exception and
+     * nothing in the log to say why — a silent fail-open on a security
+     * component.
+     *
+     * Behaviour mirrors `checkTrustedProxiesPosture()`:
+     *   * default — log every failure at `error` and start anyway, because
+     *     optional config paths are an established 2.x usage.
+     *   * `global.require_config: true` — refuse to start, so a deploy that
+     *     renames or fails to ship a config file fails the deploy instead of
+     *     quietly disabling the firewall.
+     *
+     * @param array<int, array{file: string, message: string}> $errors
+     *   Failures recorded by `Config::load()`.
+     * @param bool $requireConfig
+     *   Whether a complete load is mandatory.
+     *
+     * @throws ConfigurationException
+     *   When `$requireConfig` is true and at least one input failed.
+     */
+    protected static function reportConfigLoadFailures(array $errors, bool $requireConfig): void
+    {
+        if ($errors === []) {
+            return;
+        }
+
+        foreach ($errors as $error) {
+            LoggingFactory::logger()->error(
+                'Firewall config file failed to load — its rules are NOT active',
+                [
+                    'file' => $error['file'],
+                    'reason' => $error['message'],
+                    'require_config' => $requireConfig,
+                ]
+            );
+        }
+
+        if (!$requireConfig) {
+            return;
+        }
+
+        throw new ConfigurationException(sprintf(
+            'global.require_config is enabled and %d config input(s) failed to load: %s',
+            count($errors),
+            implode('; ', array_map(
+                static fn (array $error): string => $error['file'] . ' — ' . $error['message'],
+                $errors
+            ))
+        ));
     }
 
     /**

--- a/src/Plugins/AbstractPluginBase.php
+++ b/src/Plugins/AbstractPluginBase.php
@@ -57,7 +57,11 @@ abstract class AbstractPluginBase implements PluginInterface
             $files = $metadata['config'];
             if (!is_array($files)) {
                 if (is_string($files) && !Path::looksLikeUrl($files)) {
-                    $files = [@realpath($files)];
+                    // Keep the path as written when realpath() fails. It used
+                    // to become `false`, which Config::load() skips without a
+                    // word; as a string it reaches Config::loadFile(), which
+                    // records why it could not be read (#78).
+                    $files = [@realpath($files) ?: $files];
                 } elseif (is_string($files) && Path::looksLikeUrl($files)) {
                     $files = [$files];
                 } else {
@@ -71,12 +75,30 @@ abstract class AbstractPluginBase implements PluginInterface
 
             foreach ($files as &$file) {
                 if (is_string($file) && !Path::looksLikeUrl($file)) {
-                    $file = realpath($file);
+                    $file = realpath($file) ?: $file;
                 }
             }
 
+            unset($file);
+
             $this->files = $files;
+
+            // A plugin's own config files fail open exactly like the top-level
+            // ones do: an unreadable or malformed file leaves the plugin with
+            // an empty rule list, which for a block plugin means it matches
+            // nothing. Report what did not load — the logger is already
+            // configured by the time plugins are constructed, so unlike the
+            // bootstrap load this can be logged directly (#78).
+            Config::clearLoadErrors();
             $this->config = Config::load($files);
+
+            foreach (Config::getLoadErrors() as $error) {
+                $this->getLogger()->error('Plugin config file failed to load — its rules are NOT active', [
+                    'plugin' => $this->getName(),
+                    'file' => $error['file'],
+                    'reason' => $error['message'],
+                ]);
+            }
 
             $this->getLogger()->debug('Plugin initialized with config files', [
                 'plugin' => $this->getName(),

--- a/src/Utility/Config.php
+++ b/src/Utility/Config.php
@@ -19,7 +19,27 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 class Config
 {
     /**
+     * Load failures recorded since the last `clearLoadErrors()`.
+     *
+     * Loading stays lenient — `loadFile()` still returns `[]` for a file it
+     * cannot read or parse — but the reason is no longer thrown away. Every
+     * skipped file and every swallowed `ConfigurationException` lands here so
+     * the caller can report it (or refuse to start) once a real logger
+     * exists. See `Firewall::create()`, which clears this list, loads, and
+     * then hands whatever accumulated to `reportConfigLoadFailures()`.
+     *
+     * @var array<int, array{file: string, message: string}>
+     */
+    private static array $loadErrors = [];
+
+    /**
      * Loader function used for producing the configuration files and merging.
+     *
+     * Loading is lenient: an input that cannot be read or parsed contributes
+     * nothing to the merge rather than raising. Those failures are appended
+     * to the load-error list instead of vanishing — call `clearLoadErrors()`
+     * beforehand and `getLoadErrors()` afterwards to find out whether the
+     * merged result is actually complete.
      *
      * @param array $configs
      *   Configs to process.
@@ -178,13 +198,91 @@ class Config
     }
 
     /**
+     * Failures recorded since the last `clearLoadErrors()` call.
+     *
+     * @return array<int, array{file: string, message: string}>
+     *   One entry per config input that could not be loaded, in the order
+     *   they were attempted. Empty when everything loaded.
+     */
+    public static function getLoadErrors(): array
+    {
+        return self::$loadErrors;
+    }
+
+    /**
+     * Discard recorded load failures.
+     *
+     * Call this before a `load()` you intend to inspect, so failures from an
+     * earlier load (or from another firewall instance in the same process)
+     * are not attributed to it.
+     */
+    public static function clearLoadErrors(): void
+    {
+        self::$loadErrors = [];
+    }
+
+    /**
+     * Record a config input that could not be loaded.
+     *
+     * Recording rather than logging on the spot is deliberate. The main
+     * caller — `Firewall::create()` — loads config *before*
+     * `LoggingFactory::setLogger()` runs, so a log written here would go to a
+     * handler-less bootstrap logger on a cold start and be lost, yet would
+     * duplicate the caller's report in a long-running process where a logger
+     * from a previous `create()` is still installed. Each caller reports the
+     * list it collected, exactly once, when it has a logger.
+     *
+     * @param string $file
+     *   The config input that failed.
+     * @param string $message
+     *   Why it failed, in operator-readable terms.
+     */
+    private static function recordLoadError(string $file, string $message): void
+    {
+        self::$loadErrors[] = ['file' => $file, 'message' => $message];
+    }
+
+    /**
+     * Explain why a local path was not loaded.
+     *
+     * @param string $file
+     *   Path that failed the readability gate in `loadFile()`.
+     *
+     * @return string
+     *   Operator-readable reason.
+     */
+    private static function describeUnreadablePath(string $file): string
+    {
+        if (!file_exists($file)) {
+            return 'File does not exist.';
+        }
+
+        if (is_dir($file)) {
+            return 'Path is a directory, not a config file.';
+        }
+
+        if (!is_file($file)) {
+            return 'Path is not a regular file.';
+        }
+
+        return 'File is not readable — check filesystem permissions.';
+    }
+
+    /**
      * Load the Configuration file.
+     *
+     * Never throws. A missing, unreadable, or malformed file yields `[]`, but
+     * the reason is recorded on the class (see `getLoadErrors()`) instead of
+     * being discarded. Callers report or escalate it: `Firewall::create()`
+     * logs every failure at `error` level and turns a non-empty list into a
+     * `ConfigurationException` when `global.require_config` is enabled.
      *
      * @param string $file
      *   File to load.
      *
      * @return array
-     *   Return an array of config data.
+     *   Return an array of config data, or an empty array when the file could
+     *   not be read or parsed.
      */
     public static function loadFile(string $file): array
     {
@@ -206,18 +304,30 @@ class Config
             try {
                 $contents = self::fileGetContents($file);
                 if ($contents === false) {
+                    self::recordLoadError($file, 'Remote config could not be fetched (network error, non-200 response, or timeout).');
                     return [];
                 }
 
                 $config = ConfigLoader::parse($contents, $file, $replacementPaths);
-            } catch (\Exception) {
+            } catch (\Exception $exception) {
+                self::recordLoadError($file, $exception->getMessage());
             }
         } elseif (file_exists($file) && is_file($file) && !is_dir($file) && is_readable($file)) {
             try {
                 // Load the file and parse as YAML.
                 $config = ConfigLoader::load($file, $replacementPaths);
-            } catch (\Exception) {
+            } catch (\Exception $exception) {
+                // Everything ConfigLoader is careful to raise — malformed
+                // YAML, circular `configs:` includes, depth overflow, an
+                // unresolvable %env(...)% token, a disabled file:/require:
+                // processor — arrives here. Discarding it is what turned a
+                // broken ruleset into a firewall that allows everything (#78).
+                self::recordLoadError($file, $exception->getMessage());
             }
+        } else {
+            // No `else` used to exist at all: a mistyped path fell through
+            // both branches and returned [] as if the file had been empty.
+            self::recordLoadError($file, self::describeUnreadablePath($file));
         }
 
         return $config;

--- a/tests/Unit/FirewallTest.php
+++ b/tests/Unit/FirewallTest.php
@@ -16,6 +16,8 @@ use Kanopi\Firewall\Storage\FileStorage;
 use Kanopi\Firewall\Storage\InMemoryStorage;
 use Kanopi\Firewall\Storage\StorageInterface;
 use Kanopi\Firewall\Tests\Logging\TestLogHandler;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -927,5 +929,120 @@ class FirewallTest extends AbstractTestCase
                 ],
             ],
         ]);
+    }
+
+    /**
+     * Regression for #78: a config file that never loaded produced a
+     * firewall with no plugins, no exception, and nothing in the log. The
+     * default is still lenient, but the failure is now reported at `error`.
+     */
+    public function testCreateLogsErrorWhenConfigInputFailsToLoad(): void
+    {
+        $handler = $this->captureLogger();
+        $missing = sys_get_temp_dir() . '/fw78-does-not-exist-' . uniqid() . '.yml';
+
+        $firewall = Firewall::create([
+            $missing,
+            ['logger' => [['class' => $handler]]],
+        ]);
+
+        $this->assertInstanceOf(Firewall::class, $firewall);
+        $this->assertTrue(
+            $handler->hasErrorContaining('config file failed to load'),
+            'Expected an error log naming the config file that did not load.'
+        );
+    }
+
+    /**
+     * Regression for #78: a load that succeeds says nothing.
+     */
+    public function testCreateDoesNotLogConfigErrorWhenEveryInputLoads(): void
+    {
+        $handler = $this->captureLogger();
+
+        Firewall::create([
+            ['logger' => [['class' => $handler]]],
+        ]);
+
+        $this->assertFalse(
+            $handler->hasErrorContaining('config file failed to load'),
+            'Nothing failed to load — no config error should be reported.'
+        );
+    }
+
+    /**
+     * Regression for #78: `global.require_config: true` turns a silent
+     * fail-open into a startup failure, so a deploy that renames or fails
+     * to ship a config file fails the deploy instead.
+     */
+    public function testCreateThrowsWhenRequireConfigAndInputFailsToLoad(): void
+    {
+        $missing = sys_get_temp_dir() . '/fw78-does-not-exist-' . uniqid() . '.yml';
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage('global.require_config is enabled');
+        Firewall::create([
+            $missing,
+            ['global' => ['require_config' => true]],
+        ]);
+    }
+
+    /**
+     * Regression for #78: the flag is reachable through the override
+     * syntax too, which is the only route left when the config file that
+     * would have carried it is the one that failed to load.
+     */
+    public function testCreateThrowsWhenRequireConfigSetViaOverride(): void
+    {
+        $missing = sys_get_temp_dir() . '/fw78-does-not-exist-' . uniqid() . '.yml';
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage($missing);
+        Firewall::create([$missing], ['[global][require_config]' => true]);
+    }
+
+    /**
+     * Regression for #78: strict mode only fires on an actual failure — a
+     * complete load starts normally.
+     */
+    public function testCreateStartsWithRequireConfigWhenEveryInputLoads(): void
+    {
+        $firewall = Firewall::create([
+            ['global' => ['require_config' => true], 'plugins' => []],
+        ]);
+
+        $this->assertInstanceOf(Firewall::class, $firewall);
+    }
+
+    /**
+     * Regression for #78: `require_config: false` is honoured even though
+     * `create()` runs the `global` section through `array_filter()`, which
+     * strips the value before the posture check would otherwise see it.
+     */
+    public function testCreateRespectsExplicitRequireConfigFalse(): void
+    {
+        $missing = sys_get_temp_dir() . '/fw78-does-not-exist-' . uniqid() . '.yml';
+
+        $firewall = Firewall::create([
+            $missing,
+            ['global' => ['require_config' => false]],
+        ]);
+
+        $this->assertInstanceOf(Firewall::class, $firewall);
+    }
+
+    /**
+     * Regression for #78: when the only config file is the one that failed,
+     * its YAML cannot carry the flag — the constant can.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testCreateHonoursRequireConfigConstant(): void
+    {
+        define('KANOPI_FIREWALL_REQUIRE_CONFIG', true);
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage('global.require_config is enabled');
+        Firewall::create([sys_get_temp_dir() . '/fw78-constant-missing.yml']);
     }
 }

--- a/tests/Unit/Plugins/AbstractPluginBaseTest.php
+++ b/tests/Unit/Plugins/AbstractPluginBaseTest.php
@@ -105,6 +105,51 @@ final class AbstractPluginBaseTest extends AbstractTestCase
     }
 
     /**
+     * Regression for #78: a plugin config file that cannot be read left the
+     * plugin with an empty rule list — for a block plugin, one that matches
+     * nothing — without saying so. The plugin now logs the failure.
+     */
+    public function testPluginLogsWhenConfigFileCannotBeLoaded(): void
+    {
+        $handler = new TestHandler(Level::Debug);
+        LoggingFactory::setLogger(new Logger('test', [$handler]));
+
+        $missing = sys_get_temp_dir() . '/fw78-plugin-missing-' . uniqid() . '.yaml';
+        $plugin = new TestablePlugin(['config' => $missing], ['inline' => true]);
+
+        // The inline config still applies — only the unreadable file is lost.
+        $this->assertSame(['inline' => true], $plugin->getRawConfig());
+        $this->assertTrue(
+            $handler->hasRecordThatContains('Plugin config file failed to load', Level::Error),
+            'Expected an error log naming the plugin config file that did not load.'
+        );
+    }
+
+    /**
+     * Regression for #78: a plugin whose config files all load says nothing
+     * at error level.
+     */
+    public function testPluginLogsNoErrorWhenConfigFileLoads(): void
+    {
+        $handler = new TestHandler(Level::Debug);
+        LoggingFactory::setLogger(new Logger('test', [$handler]));
+
+        $file = __DIR__ . '/config-loads.yaml';
+        file_put_contents($file, "featureA: true\n");
+
+        try {
+            new TestablePlugin(['config' => $file], ['inline' => true]);
+
+            $this->assertFalse(
+                $handler->hasRecordThatContains('Plugin config file failed to load', Level::Error),
+                'The config file loaded — no error should be reported.'
+            );
+        } finally {
+            unlink($file);
+        }
+    }
+
+    /**
      * Tests that LoggingTrait logs messages when triggered through AbstractPluginBase.
      */
     public function testLoggingTraitWritesLog(): void

--- a/tests/Unit/Utility/ConfigTest.php
+++ b/tests/Unit/Utility/ConfigTest.php
@@ -987,4 +987,107 @@ class ConfigTest extends AbstractTestCase
         // Verify no double slashes in path
         $this->assertStringNotContainsString('//', $cacheFile);
     }
+
+    /**
+     * Regression for #78: a path that does not exist used to fall through
+     * both branches of loadFile() and return [] as if the file had been
+     * empty. It still returns [], but the reason is now recoverable.
+     */
+    public function testLoadFileRecordsErrorForMissingFile(): void
+    {
+        Config::clearLoadErrors();
+
+        $missing = sys_get_temp_dir() . '/fw78-does-not-exist-' . uniqid() . '.yml';
+        $this->assertSame([], Config::loadFile($missing));
+
+        $errors = Config::getLoadErrors();
+        $this->assertCount(1, $errors);
+        $this->assertSame($missing, $errors[0]['file']);
+        $this->assertStringContainsString('does not exist', $errors[0]['message']);
+    }
+
+    /**
+     * Regression for #78: a directory is reported as a directory, not as a
+     * generic failure, so the operator can see the path is wrong.
+     */
+    public function testLoadFileRecordsErrorForDirectory(): void
+    {
+        Config::clearLoadErrors();
+
+        $this->assertSame([], Config::loadFile(sys_get_temp_dir()));
+
+        $errors = Config::getLoadErrors();
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('directory', $errors[0]['message']);
+    }
+
+    /**
+     * Regression for #78: an unreadable file points at permissions.
+     */
+    public function testLoadFileRecordsErrorForUnreadableFile(): void
+    {
+        Config::clearLoadErrors();
+
+        $tempFile = tempnam(sys_get_temp_dir(), 'fw78_unreadable_');
+        file_put_contents($tempFile, Yaml::dump(['key' => 'value']));
+        chmod($tempFile, 0000);
+
+        $this->assertSame([], Config::loadFile($tempFile));
+
+        $errors = Config::getLoadErrors();
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('permissions', $errors[0]['message']);
+
+        chmod($tempFile, 0644);
+        @unlink($tempFile);
+    }
+
+    /**
+     * Regression for #78: ConfigLoader raises a descriptive exception for
+     * malformed YAML. loadFile() used to discard it entirely; it now keeps
+     * the message.
+     */
+    public function testLoadFileRecordsErrorForInvalidYaml(): void
+    {
+        Config::clearLoadErrors();
+
+        $this->assertSame([], Config::loadFile($this->tempFile3));
+
+        $errors = Config::getLoadErrors();
+        $this->assertCount(1, $errors);
+        $this->assertSame($this->tempFile3, $errors[0]['file']);
+        $this->assertNotSame('', $errors[0]['message']);
+    }
+
+    /**
+     * A load that works records nothing — the list only ever holds failures.
+     */
+    public function testLoadRecordsNoErrorsWhenEveryInputLoads(): void
+    {
+        Config::clearLoadErrors();
+
+        Config::load([$this->tempFile1, ['inline' => true], null]);
+
+        $this->assertSame([], Config::getLoadErrors());
+    }
+
+    /**
+     * Failures accumulate across a multi-file load so the caller sees every
+     * broken input, not just the first, and clearLoadErrors() resets them.
+     */
+    public function testLoadAccumulatesEveryFailureAndClearResets(): void
+    {
+        Config::clearLoadErrors();
+
+        $missing = sys_get_temp_dir() . '/fw78-missing-' . uniqid() . '.yml';
+        Config::load([$this->tempFile1, $missing, $this->tempFile3]);
+
+        $errors = Config::getLoadErrors();
+        $this->assertCount(2, $errors);
+        $this->assertSame($missing, $errors[0]['file']);
+        $this->assertSame($this->tempFile3, $errors[1]['file']);
+
+        Config::clearLoadErrors();
+        $this->assertSame([], Config::getLoadErrors());
+    }
 }

--- a/tests/Unit/Utility/ReadmeOverrideExamplesTest.php
+++ b/tests/Unit/Utility/ReadmeOverrideExamplesTest.php
@@ -50,6 +50,11 @@ final class ReadmeOverrideExamplesTest extends TestCase
             'redis host on a plugins: entry' => ['[plugins][3][metadata][storage][config][redis][host]', 'localhost'],
             'disable a plugins: entry' => ['[plugins][2][enable]', false],
 
+            // "Requiring the config to load" (#78) — the override form is the
+            // route that still works when the config file carrying the flag
+            // is the one that failed to load.
+            'require config' => ['[global][require_config]', true],
+
             // "Dynamic Configuration Overrides" — legacy block:/bypass: format.
             'legacy geoip db' => ['[block][\Kanopi\Firewall\Plugins\GeoLocation][metadata][reader][db]', '/tmp/GeoLite2-City.mmdb'],
             'legacy disable plugin' => ['[block][\Kanopi\Firewall\Plugins\UserAgent][enable]', false],


### PR DESCRIPTION
Fixes #78.

## Confirmed first

Reproduced all three shapes from the issue against `2.x` — each returned `true` from `evaluate()` for a request the real config would have blocked, with no exception and no log line:

- a mistyped config path,
- malformed YAML,
- a `%env(file:...)%` token with the filesystem processors left disabled.

## What changed

**`Config::loadFile()` records instead of discarding.** It still returns `[]` — optional config paths are established 2.x usage — but every skipped file and every swallowed `ConfigurationException` lands on a load-error list (`Config::getLoadErrors()` / `clearLoadErrors()`). The missing `else` branch that let a nonexistent path fall through both conditions is filled in, with a reason that distinguishes "does not exist" from "is a directory" from "not readable — check filesystem permissions".

Recording rather than logging on the spot is deliberate: during `Firewall::create()` the config is loaded *before* `LoggingFactory::setLogger()` runs, so a log written there would be dropped on a cold start yet duplicated in a long-running process where a previous logger is still installed. Each caller reports the list it collected, exactly once, when it has a logger.

**`Firewall::create()` reports, and optionally refuses to start.** Default stays lenient and logs each failure at `error`:

```
firewall.ERROR: Firewall config file failed to load — its rules are NOT active
    {"file":"/var/www/firewall.yml","reason":"File does not exist.","require_config":false}
```

`global.require_config: true` turns it into a startup `ConfigurationException` naming every input that failed, mirroring the existing `require_trusted_proxies` posture check (issue option 2 + option 3). Because the file that would carry the flag may be the one that failed to load, it is also readable from an override (`['[global][require_config]' => true]`) and from a `KANOPI_FIREWALL_REQUIRE_CONFIG` constant. An explicit `require_config: false` is read before `array_filter()` strips it, so YAML always wins over the constant.

Option 1 (propagate unconditionally) was not taken: 2.x is a released line and `create()` currently documents lenient loading, so this keeps the strict path opt-in — it can become the default in 3.x.

**Plugin config files were silent the same way.** `metadata.config` paths that failed `realpath()` became `false` and were dropped before `Config::load()` ever saw them. They are now kept as written so `loadFile()` can explain them, and each failure is logged against the plugin (`Plugin config file failed to load — its rules are NOT active`). `require_config` does not escalate these to a startup failure.

**Docs.** The `@throws`/behavior contract on `Config::loadFile()`, `Config::load()` and `Firewall::create()` is stated explicitly. In the README: a new "Requiring the config to load" section, and the "Fail open or fail closed?" workaround from #77 is replaced by the flag plus a `getLoadErrors()` example. The `%env(file:)%` note and the "notable omission" paragraph in Error Handling are corrected.

## Tests

16 new tests: load-error recording per failure mode (missing / directory / unreadable / malformed, plus accumulation and clearing), `create()` logging vs. throwing, `require_config` via YAML, override, constant, and explicit `false`, and the plugin-level reporting on both paths. The new override path is mirrored in `ReadmeOverrideExamplesTest` as that file asks.

| Check | Result |
|---|---|
| `phpunit --testsuite unit` | 727 tests, 1441 assertions — pass (711 before) |
| `phpunit --testsuite integration` | 42 tests, 417 assertions — pass |
| `phpcs --standard=phpcs_ruleset.xml src` | clean |
| `phpstan analyse` (level max) | clean |

The 2 reported deprecations are pre-existing (`ReflectionProperty::setValue()` in two test files) and present on `2.x` before this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)