### PR TITLE
Apply storage blocklist check to challenge submission POSTs (Fixes #75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,6 +828,8 @@ The firewall evaluates `response: allow` entries first (sorted by `weight`, lowe
 
 A valid pass token (set by a previously solved challenge) short-circuits the challenge bucket but does **not** suppress block plugins. See [Challenge Response Type](#challenge-response-type) below.
 
+A POST to `challenge.path` (the challenge submission endpoint) skips all three buckets — otherwise an unrelated rule matching the magic path would trap a legitimate visitor in a challenge loop with no way out. The durable storage block list still applies: an IP that already earned a block is rejected before the solution is verified, so it cannot solve its way back out.
+
 Suggested weight ranges:
 
 - **-200 to -100**: Early filters (IP allow-lists, trusted networks)

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -466,10 +466,14 @@ final class Firewall
             $this->getLogger()->debug('Request evaluation started', $this->getContext($request));
         }
 
-        // Intercept challenge solutions before any plugin evaluation so a
-        // POST to the magic path can never be blocked by an unrelated rule
-        // (e.g. a URL plugin matching the magic path itself).
+        // Intercept challenge solutions before plugin evaluation so a POST
+        // to the magic path can never be blocked by an unrelated rule (e.g.
+        // a URL plugin matching the magic path itself) — which would trap a
+        // legitimate visitor in a challenge loop with no way out. The
+        // durable storage blocklist is the one exception: an IP that already
+        // earned a block does not get to solve its way back out.
         if ($this->isChallengeSubmission($request)) {
+            $this->enforceStorageBlocklist($request);
             $this->handleChallengeSubmission($request);
             return true;
         }
@@ -482,14 +486,7 @@ final class Firewall
             return true;
         }
 
-        if (($data = $this->storage->isBlocked($this->storage->getKey($request))) !== false) {
-            if (array_key_exists('event_id', $data)) {
-                $request->attributes->set('x-request-id', $data['event_id']);
-            }
-
-            $this->repeatOffender($request);
-            $this->sendBlockingResponse($request, intval($this->config['repeat_offender_status'] ?? 0));
-        }
+        $this->enforceStorageBlocklist($request);
 
         // A held pass token short-circuits the challenge bucket. Block
         // plugins still run — the token only attests "I am human", not
@@ -802,6 +799,36 @@ final class Firewall
             'httponly' => true,
             'samesite' => 'Strict',
         ]);
+    }
+
+    /**
+     * Enforce the durable storage blocklist for this request key.
+     *
+     * Returns quietly when the key is not on the list. When it is, the
+     * offense is recorded and the request is terminated — the blocklist is
+     * durable repeat-offender state, so nothing downstream (including a
+     * validly signed challenge solution) gets to undo it.
+     *
+     * @param Request $request
+     *   Request to evaluate.
+     *
+     * @throws FirewallBlockedException
+     *   In `mode: exception`, when the request key is on the block list.
+     *   Every other mode writes the response and exits.
+     */
+    protected function enforceStorageBlocklist(Request $request): void
+    {
+        $data = $this->storage->isBlocked($this->storage->getKey($request));
+        if ($data === false) {
+            return;
+        }
+
+        if (array_key_exists('event_id', $data)) {
+            $request->attributes->set('x-request-id', $data['event_id']);
+        }
+
+        $this->repeatOffender($request);
+        $this->sendBlockingResponse($request, intval($this->config['repeat_offender_status'] ?? 0));
     }
 
     /**

--- a/tests/Integration/ChallengeFlowTest.php
+++ b/tests/Integration/ChallengeFlowTest.php
@@ -9,6 +9,7 @@ use Kanopi\Firewall\Challenge\MathChallengeProvider;
 use Kanopi\Firewall\Exception\ChallengeRequiredException;
 use Kanopi\Firewall\Exception\ChallengeSolvedException;
 use Kanopi\Firewall\Exception\ConfigurationException;
+use Kanopi\Firewall\Exception\FirewallBlockedException;
 use Kanopi\Firewall\Firewall;
 use Kanopi\Firewall\Traits\FileTrait;
 use PHPUnit\Framework\TestCase;
@@ -106,6 +107,35 @@ class ChallengeFlowTest extends TestCase
         );
 
         $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($request);
+    }
+
+    public function testBlockedIpCannotMintATokenViaSubmission(): void
+    {
+        $firewall = Firewall::create([$this->configWithChallenge()]);
+
+        [$state, $answer] = $this->generateSolvedState($firewall, '10.0.0.50');
+
+        // Durable repeat-offender state: this IP already earned a block.
+        $storageRef = new \ReflectionProperty($firewall, 'storage');
+        $storage = $storageRef->getValue($firewall);
+        $storage->set('10.0.0.50', ['event_id' => 'PRIOR-OFFENSE'], time() + 3600);
+
+        $request = Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [
+                MathChallengeProvider::STATE_FIELD => $state,
+                MathChallengeProvider::ANSWER_FIELD => $answer,
+                MathChallengeProvider::REDIRECT_FIELD => '/protected',
+                MathChallengeProvider::TTL_FIELD => '600',
+            ],
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.50']
+        );
+
+        $this->expectException(FirewallBlockedException::class);
         $firewall->evaluate($request);
     }
 


### PR DESCRIPTION
Fixes #75.

## Problem

`Firewall::evaluate()` intercepted a POST to `challenge.path` before any plugin evaluation, so an IP already on the durable storage blocklist could still post a validly signed solution and walk away with a fresh pass token — undoing repeat-offender state that is meant to be durable.

Confirmed with a failing test before the fix: a blocked IP submitting a legitimate solution got `ChallengeSolvedException`.

## Change

- Extracted the repeat-offender blocklist enforcement out of `evaluate()` into `Firewall::enforceStorageBlocklist()` — same behavior (event ID rehydration, `repeatOffender()`, `repeat_offender_status` response), now callable from two places.
- Called it inside the `isChallengeSubmission()` branch, before `handleChallengeSubmission()`.
- Updated the comment in `evaluate()` and added a note to the README's Plugin Execution Order section.

Effective order for `POST <challenge.path>`: storage blocklist → submission handler.

Bypass, challenge, and block plugins are still skipped on the submission path — running them would reintroduce the lockout risk the short-circuit was designed to prevent (an unrelated rule matching the magic path traps a legitimate visitor in a challenge loop). The known edge case from the issue stands: an IP on both the allow-bypass list and the storage blocklist is now rejected at submission time.

## Tests

- New `ChallengeFlowTest::testBlockedIpCannotMintATokenViaSubmission` — blocked IP posts a legitimately signed solution, expects `FirewallBlockedException`. Fails on `2.x`, passes here.
- Full suite: 835 tests pass. PHPCS clean, PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)