### PR TITLE
Exempt log mode from storage blocklist enforcement (Fixes #44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ The `mode` setting controls how the firewall responds when a request is matched 
 | `disabled` | No | No | No (skips all evaluation) |
 
 - **`block`** — Default production behavior. Blocked requests receive an HTTP error response and the script exits.
-- **`log`** — Useful for dry-run/audit deployments. Plugins are evaluated normally, but blocks are only logged (at `warning` level) without stopping the request or recording offenses in storage.
+- **`log`** — Useful for dry-run/audit deployments. Plugins are evaluated normally, but blocks are only logged (at `warning` level) without stopping the request or recording offenses in storage. This includes clients already on the durable storage blocklist: the hit is logged, the ban is neither enforced nor extended, and the request continues.
 - **`exception`** — Throws instead of calling `exit()`, allowing host frameworks (Laravel, Symfony, etc.) to catch and render their own responses. A block throws `FirewallBlockedException`, which carries the status code (via `getStatusCode()`) and banning message. The challenge flow throws `ChallengeRequiredException` or `ChallengeSolvedException` instead — see [Error Handling & Exceptions](#error-handling--exceptions) for all of them and what to do with each.
 - **`disabled`** — Bypasses the firewall entirely. No plugins are evaluated and the request is immediately allowed. Useful for maintenance or feature-flag toggling.
 

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -809,12 +809,19 @@ final class Firewall
      * durable repeat-offender state, so nothing downstream (including a
      * validly signed challenge solution) gets to undo it.
      *
+     * `mode: log` is the exception: it is a dry-run mode, so a listed key is
+     * reported at `warning` level and the request continues. Recording the
+     * offense would extend a real ban from an audit-only deployment, and
+     * terminating would make `log` indistinguishable from `block` for every
+     * repeat offender.
+     *
      * @param Request $request
      *   Request to evaluate.
      *
      * @throws FirewallBlockedException
      *   In `mode: exception`, when the request key is on the block list.
-     *   Every other mode writes the response and exits.
+     *   `mode: log` logs and returns; every other mode writes the response
+     *   and exits.
      */
     protected function enforceStorageBlocklist(Request $request): void
     {
@@ -825,6 +832,13 @@ final class Firewall
 
         if (array_key_exists('event_id', $data)) {
             $request->attributes->set('x-request-id', $data['event_id']);
+        }
+
+        if ($this->firewallMode === FirewallMode::Log) {
+            $this->getLogger()->warning('Request would be blocked by storage blocklist (log mode)', $this->getContext($request, [
+                'mode' => 'log',
+            ]));
+            return;
         }
 
         $this->repeatOffender($request);

--- a/tests/Unit/FirewallModeTest.php
+++ b/tests/Unit/FirewallModeTest.php
@@ -7,9 +7,13 @@ namespace Kanopi\Firewall\Tests\Unit;
 use Kanopi\Firewall\Exception\FirewallBlockedException;
 use Kanopi\Firewall\Firewall;
 use Kanopi\Firewall\FirewallMode;
+use Kanopi\Firewall\Logging\LoggingFactory;
 use Kanopi\Firewall\Plugins\PluginInterface;
 use Kanopi\Firewall\Plugins\PluginManager;
 use Kanopi\Firewall\Storage\StorageInterface;
+use Monolog\Handler\TestHandler;
+use Monolog\Level;
+use Monolog\Logger;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -71,6 +75,72 @@ class FirewallModeTest extends AbstractTestCase
 
         $firewall = $this->createFirewall(['mode' => 'log']);
         $this->assertTrue($firewall->evaluate($request));
+    }
+
+    /**
+     * Regression for #44: `mode: log` is documented as a dry run that
+     * neither writes to storage nor terminates the request, but the durable
+     * storage blocklist was enforced unconditionally — so an audit-only
+     * deployment still hard-blocked every repeat offender and extended
+     * their ban.
+     *
+     * Calls the blocklist check directly: `evaluate()` short-circuits under
+     * PHP_SAPI === 'cli' for every mode but `exception`, so the log-mode
+     * path is not reachable through it in the unit suite.
+     */
+    public function testLogModeDoesNotEnforceStorageBlocklist(): void
+    {
+        $handler = new TestHandler(Level::Debug);
+        LoggingFactory::setLogger(new Logger('test', [$handler]));
+
+        $this->storage->method('getKey')->willReturn('1.2.3.4');
+        $this->storage->method('isBlocked')->willReturn(['event_id' => 'prior-block']);
+        $this->storage->expects($this->never())->method('addToExpire');
+        $this->storage->expects($this->never())->method('recordOffense');
+
+        $firewall = $this->createFirewall(['mode' => 'log']);
+        $request = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '1.2.3.4']);
+
+        $this->invokeEnforceStorageBlocklist($firewall, $request);
+
+        $this->assertTrue(
+            $handler->hasRecordThatContains('Request would be blocked by storage blocklist (log mode)', Level::Warning),
+            'Expected a warning naming the blocklist hit that log mode declined to enforce.'
+        );
+        $this->assertSame(
+            'prior-block',
+            $request->attributes->get('x-request-id'),
+            'The stored event ID should still be adopted so the audit log ties back to the original block.'
+        );
+    }
+
+    /**
+     * Companion to #44: every other mode still enforces the blocklist —
+     * recording the offense, extending the ban, and terminating.
+     */
+    public function testExceptionModeStillEnforcesStorageBlocklist(): void
+    {
+        $this->storage->method('getKey')->willReturn('1.2.3.4');
+        $this->storage->method('isBlocked')->willReturn(['event_id' => 'prior-block']);
+        $this->storage->expects($this->once())->method('addToExpire')->with('1.2.3.4', 3600);
+        $this->storage->expects($this->once())->method('recordOffense')->with('1.2.3.4');
+
+        $firewall = $this->createFirewall(['mode' => 'exception']);
+        $request = Request::create('/', 'GET', [], [], [], ['REMOTE_ADDR' => '1.2.3.4']);
+
+        $this->expectException(FirewallBlockedException::class);
+        $this->invokeEnforceStorageBlocklist($firewall, $request);
+    }
+
+    /**
+     * Invoke the protected blocklist check, bypassing the CLI guard in
+     * evaluate().
+     */
+    private function invokeEnforceStorageBlocklist(Firewall $firewall, Request $request): void
+    {
+        $method = new \ReflectionMethod(Firewall::class, 'enforceStorageBlocklist');
+        $method->setAccessible(true);
+        $method->invoke($firewall, $request);
     }
 
     public function testExceptionModeThrowsFirewallBlockedException(): void


### PR DESCRIPTION
Fixes #44.

## Problem

`mode: log` is documented as a dry run — README's mode table says it does not write to storage and does not terminate the request. But `Firewall::enforceStorageBlocklist()` ran with no mode check at all.

So for any client already on the durable storage blocklist, an audit-only deployment still:

1. recorded an offense and extended the ban via `add_to_expire` (`repeatOffender()`), and
2. terminated the request with a real blocking response (`sendBlockingResponse()` → `http_response_code()` + `exit()`).

That makes `log` indistinguishable from `block` for every repeat offender — the exact scenario log mode exists to avoid. The plugin buckets already honored log mode (`Firewall.php:497` and `:510`); the storage blocklist was the one path that was missed, likely because it predates those branches.

This answers the open question in #44: the docs already committed to an answer, the code just didn't match.

## Fix

Add a `FirewallMode::Log` branch to `enforceStorageBlocklist()` that logs at `warning` level and returns, shaped like the two existing log-mode branches.

Two deliberate details:

- **The `event_id` adoption stays above the new branch**, so the request still inherits the stored event ID and the audit warning ties back to the original block event. That's in-memory only and persists nothing.
- **Exception mode still enforces.** It's documented as writing to storage; it only delegates termination to the host framework instead of calling `exit()`.

README's `log` bullet now states the blocklist case explicitly, since it was easy to miss.

## Tests

- `testLogModeDoesNotEnforceStorageBlocklist` — asserts `addToExpire`/`recordOffense` are never called, the warning is logged, and the event ID is still adopted.
- `testExceptionModeStillEnforcesStorageBlocklist` — guard against over-correcting: offense recorded, ban extended by 3600, `FirewallBlockedException` thrown.

Verified the regression test isn't vacuous: reverting only the source change fails it with `addToExpire('1.2.3.4', 3600): bool was not expected to be called`, which is precisely the bug.

Both tests invoke the protected method via reflection rather than `evaluate()`. That's necessary — `evaluate()` returns early under `PHP_SAPI === 'cli'` for every mode except `exception` (`Firewall.php:447`), so no log-mode path is reachable through `evaluate()` in the unit suite.

**Worth flagging:** this means the pre-existing `testLogModeDoesNotBlock` (`FirewallModeTest.php:60`) has always passed vacuously — it never gets past the CLI guard, so it isn't protecting anything. Left as-is here to keep this PR scoped.

## Checks

- `phpunit` — 837 tests, 2076 assertions, pass. (The 2 deprecations are pre-existing PHP 8.4 `ReflectionProperty::setValue()` warnings in `LoggingFactoryTest` / `AbstractPluginBaseTest`, unrelated to this change.)
- `composer check:code` (phpcs) — clean
- `composer check:security` (phpstan, level max) — no errors
- `composer check:rector` — clean

## Adjacent, not changed

`handleChallengeSubmission()` (`Firewall.php:587`, `:612`) also has no log-mode branch and `exit()`s on both the valid and invalid solution paths. Out of scope for #44, and unreachable in a pure-log deployment since log mode never issues a challenge (`:497`) — but it would need the same treatment if that ever changes. Happy to file a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)