### PR TITLE
Fix inverted Crs::evaluate() return value (Fixes #89)

### DIFF
--- a/src/Plugins/Crs.php
+++ b/src/Plugins/Crs.php
@@ -68,6 +68,9 @@ class Crs extends AbstractPluginBase
         $crsVerdict = $this->getEngine()->evaluate($this->adaptRequest($request));
         $this->lastVerdict = $crsVerdict;
 
+        // TRUE means "this plugin matched", not "allow the request" — the
+        // PluginManager applies the entry's `response:` when we return TRUE.
+        // See PluginInterface::evaluate().
         if ($crsVerdict->isBlocked()) {
             $this->getLogger()->info('CRS blocked request', $this->getContext($request, [
                 'rule_id'      => $crsVerdict->blockingRuleId,
@@ -76,9 +79,11 @@ class Crs extends AbstractPluginBase
                 'matched_rule' => $crsVerdict->matchedRules[0]['msg'] ?? '',
                 'matched_data' => $crsVerdict->matchedRules[0]['matched_data'] ?? '',
             ]));
-            return false;
+            return true;
         }
 
+        // Rules fired but the anomaly score stayed under threshold, or the
+        // plugin is in monitor mode. Report no match so the request proceeds.
         if ($crsVerdict->matchedRules !== []) {
             $this->getLogger()->debug('CRS matched but did not block', $this->getContext($request, [
                 'action'          => $crsVerdict->action,
@@ -87,7 +92,7 @@ class Crs extends AbstractPluginBase
             ]));
         }
 
-        return true;
+        return false;
     }
 
     /**

--- a/src/Plugins/PluginInterface.php
+++ b/src/Plugins/PluginInterface.php
@@ -29,13 +29,26 @@ interface PluginInterface
     public function getDescription(): string;
 
     /**
-     * Evaluate the current request to see if it passes the current plugin.
+     * Evaluate the current request against this plugin's rules.
+     *
+     * This reports whether the plugin **matched**, not whether the request
+     * should be allowed. What a match does is decided by the entry's
+     * `response:` setting, which PluginManager applies:
+     *
+     * - `response: allow`     — a match permits the request immediately.
+     * - `response: challenge` — a match serves the interstitial.
+     * - `response: block`     — a match rejects the request.
+     *
+     * So a plugin that detects something bad returns TRUE. Returning FALSE
+     * means "my rules did not apply to this request", which lets evaluation
+     * continue to the next plugin.
      *
      * @param Request $request
      *   Request to evaluate.
      *
      * @return bool
-     *   Return TRUE if allowed to pass.
+     *   TRUE if the request matched this plugin's rules and the configured
+     *   `response:` should be applied; FALSE if it did not match.
      */
     public function evaluate(Request $request): bool;
 

--- a/tests/Unit/Plugins/CrsTest.php
+++ b/tests/Unit/Plugins/CrsTest.php
@@ -17,6 +17,11 @@ use Symfony\Component\HttpFoundation\Request;
  * mapping, configuration plumbing, status/expiration accessors, and the
  * bool return contract of evaluate().
  *
+ * That contract is "did this plugin match", not "should the request pass" —
+ * see PluginInterface::evaluate(). A payload CRS blocks makes evaluate()
+ * return TRUE. PluginPolarityTest enforces the same convention across every
+ * shipped plugin.
+ *
  * Tests skip themselves if the engine's bundled rules haven't been generated
  * (vendor install pulls the rules cache in, but a fresh dev clone without
  * `composer install` won't have them).
@@ -63,57 +68,60 @@ class CrsTest extends AbstractTestCase
         $this->assertSame(7200, $plugin->getExpirationTime());
     }
 
-    public function testBenignRequestPasses(): void
+    public function testBenignRequestDoesNotMatch(): void
     {
         $plugin = new Crs([], ['paranoia' => 1]);
         $request = $this->request(['q' => 'hello world']);
-        $this->assertTrue($plugin->evaluate($request));
+        $this->assertFalse($plugin->evaluate($request), 'a benign request must not match');
         $this->assertNotNull($plugin->getLastVerdict());
         $this->assertFalse($plugin->getLastVerdict()->isBlocked());
     }
 
-    public function testSqliRequestBlocks(): void
+    public function testSqliRequestMatches(): void
     {
         $plugin = new Crs([], ['paranoia' => 1]);
         $request = $this->request(['id' => '1 UNION SELECT password FROM users']);
-        $this->assertFalse($plugin->evaluate($request));
+        $this->assertTrue($plugin->evaluate($request), 'SQLi must match so `response:` is applied');
         $verdict = $plugin->getLastVerdict();
         $this->assertNotNull($verdict);
         $this->assertTrue($verdict->isBlocked());
         $this->assertNotNull($verdict->blockingRuleId);
     }
 
-    public function testXssRequestBlocks(): void
+    public function testXssRequestMatches(): void
     {
         $plugin = new Crs([], ['paranoia' => 1]);
         $request = $this->request(['c' => '<script>alert(1)</script>']);
-        $this->assertFalse($plugin->evaluate($request));
+        $this->assertTrue($plugin->evaluate($request));
     }
 
-    public function testScannerUserAgentBlocks(): void
+    public function testScannerUserAgentMatches(): void
     {
         $plugin = new Crs([], ['paranoia' => 1]);
         $request = $this->request([], ['HTTP_USER_AGENT' => 'sqlmap/1.5.2#stable (http://sqlmap.org)']);
-        $this->assertFalse($plugin->evaluate($request));
+        $this->assertTrue($plugin->evaluate($request));
     }
 
-    public function testMonitorModeNeverBlocks(): void
+    public function testMonitorModeNeverMatches(): void
     {
+        // Monitor mode scores and logs but never sets a blocking verdict, so
+        // the plugin must report no match and let the request through.
         $plugin = new Crs([], ['paranoia' => 1, 'mode' => 'monitor']);
         $request = $this->request(['id' => '1 UNION SELECT password FROM users']);
-        $this->assertTrue($plugin->evaluate($request), 'monitor mode should not block even on SQLi');
+        $this->assertFalse($plugin->evaluate($request), 'monitor mode must not block, even on SQLi');
         $this->assertNotEmpty($plugin->getLastVerdict()->matchedRules, 'rule should still have matched');
     }
 
     public function testDisabledRulesAreSkipped(): void
     {
-        // Disable everything that would normally catch this payload — should pass.
+        // Disable everything that would normally catch this payload — with no
+        // rule left to fire, the plugin must report no match.
         $plugin = new Crs([], [
             'paranoia' => 1,
             'disabled_categories' => ['sqli', 'rce', 'scanner'],
         ]);
         $request = $this->request(['id' => '1 UNION SELECT password FROM users']);
-        $this->assertTrue($plugin->evaluate($request));
+        $this->assertFalse($plugin->evaluate($request));
     }
 
     public function testSingleFileUploadIsAdaptedToEngineDto(): void
@@ -129,7 +137,7 @@ class CrsTest extends AbstractTestCase
             );
 
             $plugin = new Crs([], ['paranoia' => 1]);
-            $this->assertTrue($plugin->evaluate($request));
+            $this->assertFalse($plugin->evaluate($request), 'a benign upload must not match');
         } finally {
             @unlink($tmp);
         }
@@ -156,7 +164,7 @@ class CrsTest extends AbstractTestCase
             );
 
             $plugin = new Crs([], ['paranoia' => 1]);
-            $this->assertTrue($plugin->evaluate($request));
+            $this->assertFalse($plugin->evaluate($request), 'benign uploads must not match');
         } finally {
             @unlink($tmpA);
             @unlink($tmpB);

--- a/tests/Unit/Plugins/PluginPolarityTest.php
+++ b/tests/Unit/Plugins/PluginPolarityTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Plugins;
+
+use Kanopi\Firewall\Plugins\Crs;
+use Kanopi\Firewall\Plugins\IpAddress;
+use Kanopi\Firewall\Plugins\PluginInterface;
+use Kanopi\Firewall\Plugins\RateLimit;
+use Kanopi\Firewall\Plugins\Url;
+use Kanopi\Firewall\Plugins\UserAgent;
+use Kanopi\Firewall\Plugins\VulnerabilityScore;
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Contract test for the polarity of PluginInterface::evaluate().
+ *
+ * Every plugin must answer the same question the same way: TRUE means "my
+ * rules matched this request, apply my `response:`", FALSE means "not mine,
+ * keep going". PluginManager::evaluate() is the only consumer and it treats
+ * a truthy return as a match.
+ *
+ * A plugin that inverts this is worse than useless — with `response: block`
+ * it rejects benign traffic and waves attacks through. That shipped once
+ * (issue #89, the CRS plugin), because each plugin's own test file was free
+ * to encode whichever convention its author assumed. This file gives the
+ * convention a single home: add a plugin, add a row, and an inverted
+ * implementation cannot pass.
+ *
+ * Each case supplies one request that must match and one that must not.
+ *
+ * GeoLocation and Asn are absent deliberately — both need MaxMind .mmdb
+ * databases that are not available in a plain unit-test run. Their polarity
+ * is covered by the integration suite.
+ */
+class PluginPolarityTest extends AbstractTestCase
+{
+    /**
+     * @return array<string, array{callable(): PluginInterface, callable(): Request, callable(): Request}>
+     */
+    public static function pluginProvider(): array
+    {
+        return [
+            'IpAddress' => [
+                fn (): PluginInterface => new IpAddress([], ['203.0.113.10', '198.51.100.0/24']),
+                fn (): Request => self::browserRequest('/', ['REMOTE_ADDR' => '203.0.113.10']),
+                fn (): Request => self::browserRequest('/', ['REMOTE_ADDR' => '192.0.2.55']),
+            ],
+            'Url' => [
+                fn (): PluginInterface => new Url([], ['path@starts_with:/admin']),
+                fn (): Request => self::browserRequest('/admin/users'),
+                fn (): Request => self::browserRequest('/about'),
+            ],
+            'UserAgent' => [
+                fn (): PluginInterface => new UserAgent([], ['bot:true']),
+                fn (): Request => self::browserRequest('/', [
+                    'HTTP_USER_AGENT' => 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+                ]),
+                fn (): Request => self::browserRequest('/'),
+            ],
+            'VulnerabilityScore' => [
+                fn (): PluginInterface => new VulnerabilityScore([], [
+                    'scoring' => [
+                        'patterns' => [
+                            [
+                                'pattern'   => '/union.*select/i',
+                                'score'     => 60,
+                                'type'      => 'regex',
+                                'locations' => ['uri', 'query_string'],
+                            ],
+                        ],
+                    ],
+                    'risk_levels' => [
+                        'low'  => ['threshold' => 0,  'block' => false],
+                        'high' => ['threshold' => 50, 'block' => true],
+                    ],
+                ]),
+                fn (): Request => self::browserRequest('/?id=1 UNION SELECT password FROM users'),
+                fn (): Request => self::browserRequest('/?id=42'),
+            ],
+            'RateLimit' => [
+                fn (): PluginInterface => new RateLimit(
+                    ['default_rate' => 1, 'default_sample' => 60],
+                    [['path' => '/*', 'rate' => 1, 'sample' => 60]],
+                ),
+                // The first call inside the test consumes the single allowed
+                // request, so the assertion below sees the limit exceeded.
+                fn (): Request => self::browserRequest('/burst'),
+                fn (): Request => self::browserRequest('/quiet'),
+            ],
+            'Crs' => [
+                fn (): PluginInterface => new Crs([], ['paranoia' => 1, 'mode' => 'block']),
+                fn (): Request => self::browserRequest('/?id=1 UNION SELECT password FROM users'),
+                fn (): Request => self::browserRequest('/?q=hello world'),
+            ],
+        ];
+    }
+
+    /**
+     * A request the plugin's rules cover must return TRUE.
+     *
+     * @param callable(): PluginInterface $makePlugin
+     * @param callable(): Request $makeMatching
+     * @param callable(): Request $makeNonMatching
+     */
+    #[DataProvider('pluginProvider')]
+    public function testMatchingRequestReturnsTrue(
+        callable $makePlugin,
+        callable $makeMatching,
+        callable $makeNonMatching,
+    ): void {
+        $this->skipIfUnavailable($makePlugin);
+        $plugin = $makePlugin();
+        $request = $makeMatching();
+
+        // RateLimit only matches once its window is already full, so prime it.
+        if ($plugin instanceof RateLimit) {
+            $plugin->evaluate($request);
+        }
+
+        $this->assertTrue(
+            $plugin->evaluate($request),
+            sprintf(
+                '%s::evaluate() must return TRUE for a request its rules match. '
+                . 'Returning FALSE inverts the plugin: with `response: block` it '
+                . 'would let this request through and block everything else.',
+                $plugin::class,
+            ),
+        );
+    }
+
+    /**
+     * A request outside the plugin's rules must return FALSE.
+     *
+     * @param callable(): PluginInterface $makePlugin
+     * @param callable(): Request $makeMatching
+     * @param callable(): Request $makeNonMatching
+     */
+    #[DataProvider('pluginProvider')]
+    public function testNonMatchingRequestReturnsFalse(
+        callable $makePlugin,
+        callable $makeMatching,
+        callable $makeNonMatching,
+    ): void {
+        $this->skipIfUnavailable($makePlugin);
+        $plugin = $makePlugin();
+
+        $this->assertFalse(
+            $plugin->evaluate($makeNonMatching()),
+            sprintf(
+                '%s::evaluate() must return FALSE for a request its rules do not '
+                . 'match, so evaluation continues to the next plugin.',
+                $plugin::class,
+            ),
+        );
+    }
+
+    /**
+     * Every shipped plugin should appear in the provider.
+     *
+     * Keeps the contract from silently going stale: a new plugin added to
+     * src/Plugins/ without a polarity case fails here rather than shipping
+     * unverified.
+     */
+    public function testEveryShippedPluginIsCovered(): void
+    {
+        $exempt = [
+            // Need MaxMind .mmdb databases — covered in the integration suite.
+            'GeoLocation',
+            'Asn',
+        ];
+
+        $shipped = [];
+        foreach ((array) glob(__DIR__ . '/../../../src/Plugins/*.php') as $file) {
+            $name = basename((string) $file, '.php');
+            if (str_starts_with($name, 'Abstract') || str_ends_with($name, 'Interface') || $name === 'PluginManager') {
+                continue;
+            }
+            $shipped[] = $name;
+        }
+
+        $covered = array_merge(array_keys(self::pluginProvider()), $exempt);
+        $missing = array_diff($shipped, $covered);
+
+        $this->assertSame([], array_values($missing), sprintf(
+            'These plugins have no polarity case: %s. Add one to '
+            . 'PluginPolarityTest::pluginProvider() so an inverted evaluate() '
+            . 'cannot ship (see issue #89).',
+            implode(', ', $missing),
+        ));
+    }
+
+    /**
+     * Skip a case whose backing engine is not installed in this environment.
+     */
+    private function skipIfUnavailable(callable $makePlugin): void
+    {
+        $plugin = $makePlugin();
+        if ($plugin instanceof Crs
+            && !is_file(__DIR__ . '/../../../vendor/kanopi/crs-engine/rules/compiled.php')) {
+            $this->markTestSkipped('CRS engine rules not available — run `composer install` to pull them.');
+        }
+    }
+
+    /**
+     * Build a browser-shaped request so CRS protocol rules do not fire on the
+     * scaffolding rather than the payload under test.
+     *
+     * @param array<string, string> $serverOverrides
+     */
+    private static function browserRequest(string $uri, array $serverOverrides = []): Request
+    {
+        [$path, $rawQuery] = array_pad(explode('?', $uri, 2), 2, '');
+        parse_str($rawQuery, $query);
+
+        // Re-encode the query string. A raw space in REQUEST_URI is an invalid
+        // request line and trips CRS protocol-enforcement rules, which would
+        // make a "non-matching" case match for a reason the test never intended.
+        $requestUri = $query === [] ? $path : $path . '?' . http_build_query($query);
+
+        return new Request(
+            query: $query,
+            server: array_merge([
+                'REMOTE_ADDR'          => '203.0.113.10',
+                'REQUEST_METHOD'       => 'GET',
+                'REQUEST_URI'          => $requestUri,
+                'SERVER_PROTOCOL'      => 'HTTP/1.1',
+                'HTTP_HOST'            => 'example.com',
+                'HTTP_USER_AGENT'      => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15',
+                'HTTP_ACCEPT'          => 'text/html,application/xhtml+xml',
+                'HTTP_ACCEPT_LANGUAGE' => 'en-US,en;q=0.5',
+            ], $serverOverrides),
+        );
+    }
+}


### PR DESCRIPTION
## Description

Fixes #89. `Crs::evaluate()` returned the opposite boolean to every other plugin, so with `response: block` the CRS plugin **blocked benign traffic and let genuine attacks through**.

I reproduced the issue exactly as reported before changing anything:

```
-- Crs, mode: block --
  benign GET /       => true  expected false <-- WRONG   engine: action=allow score=0
  SQL injection      => false expected true  <-- WRONG   engine: action=block score=3

-- Crs, mode: monitor --
  benign GET /       => true  expected false <-- WRONG
  SQL injection      => true  expected false <-- WRONG
```

The engine was never at fault — `getLastVerdict()` was correct in every case. Only the plugin's translation of that verdict into a bool was wrong. Monitor mode was *worse* than block mode rather than safer: the engine never sets a blocking verdict there, so the inverted `return true` fired for **every** request, leaving no safe configuration of this plugin.

## Related Issue

Fixes #89

## Changes Made

**`src/Plugins/Crs.php`** — swap the two returns. Two-line behavioral change, plus comments explaining the polarity at both sites.

**`src/Plugins/PluginInterface.php`** — the root cause. The docblock said `@return TRUE if allowed to pass`, which contradicts `PluginManager::evaluate()` (treats truthy as *matched*), the other seven plugins, and the README's own custom-plugin example. CRS was the one implementation written against the docblock, so fixing only the plugin would leave the trap for the next contributor. Rewritten to state the actual contract — TRUE means the request matched and the entry's `response:` should be applied. Every plugin inherits this via `{@inheritdoc}`, so all of them are corrected.

**`tests/Unit/Plugins/CrsTest.php`** — CI stayed green because this file encoded the same misreading, asserting TRUE for benign input and FALSE for SQLi. Assertions inverted and tests renamed to say what they actually check. `testMonitorModeNeverBlocks` asserted the opposite of its own name and inline comment.

**`tests/Unit/Plugins/PluginPolarityTest.php`** (new) — a contract test giving the convention one home. Each plugin supplies a request that must match and one that must not. A coverage check fails when a plugin in `src/Plugins/` has no case, so an outlier cannot ship again. `GeoLocation` and `Asn` are exempt with a stated reason — both need MaxMind `.mmdb` files unavailable to unit tests.

## Testing

- **Verified the new test catches the original defect.** Restoring the inverted returns fails 10 tests across `PluginPolarityTest` and `CrsTest`. Without that check the contract test would be decoration.
- The issue's own reproduction script now passes every case, including both monitor-mode cases.
- 801 unit tests, 1,629 assertions — pass
- 49 integration tests, 460 assertions — pass
- PHPCS clean, PHPStan level max clean, Rector clean

One scaffolding note: my first draft of the contract test built `REQUEST_URI` with a raw space, which trips CRS protocol-enforcement rules and made a "non-matching" case match for a reason the test never intended. The helper now re-encodes the query string.

## Breaking Changes

None in the API sense — the signature is unchanged. But this **changes runtime behavior for anyone running the CRS plugin**, which is the point: CRS verdicts now apply the way the configuration says they should.

## Follow-ups not in this PR

- **Release note.** Anyone who enabled the CRS plugin should check for legitimate traffic that was blocked, and for attacks let through while it was active. Worth calling out prominently given `mode: monitor` was also affected.
- **#74** (3.x merged-bucket proposal) — its worked example assumes CRS correctly blocks a SQLi payload from an allow-listed IP, which is true as of this PR.
- The issue suggests renaming `evaluate()` to `matches()` in 3.x to remove the ambiguity permanently. Reasonable, but out of scope for a patch fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)