### PR TITLE
Pin phpstan below 2.2.6 to unbreak Rector in CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "dg/bypass-finals": "^1.9",
         "phpcompatibility/php-compatibility": "^9.3",
-        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan": "^2.1 <2.2.6",
         "phpunit/phpunit": "^10.5 || ^11.5",
         "rector/rector": "^2.0",
         "squizlabs/php_codesniffer": "^3.13",


### PR DESCRIPTION
## Description

Every `rector` job on every branch is currently failing. It is **not** a lint finding and **not** caused by any open PR — Rector dies with a fatal error before it reads a single file:

```
Rector\Exception\Reflection\MissingPrivatePropertyException:
Property "$container" was not found in "PHPStan\Parser\RichParser"
  in vendor/rector/rector/src/Util/Reflection/PrivatesAccessor.php:82
```

Rector's `PHPStanContainerMemento::removeRichVisitors()` reaches into PHPStan's `RichParser` for a private `$container` property via reflection. **phpstan 2.2.6, published 2026-07-26, removed it.** Rector's latest release (2.5.7, 2026-07-13) predates the change, so there is nothing to upgrade to yet.

## Evidence

| phpstan | rector | result |
|---|---|---|
| 2.2.5 | 2.5.7 | ✅ 53/53 files, `[OK] Rector is done!` |
| 2.2.6 | 2.5.7 | ❌ fatal, identical to CI |

Reproduced locally by upgrading **only** phpstan and changing nothing else.

Confirmed unrelated to any branch's code: **PR #90 touches zero PHP files and fails rector identically** on all five PHP versions.

## Changes Made

One line in `composer.json`:

```diff
-"phpstan/phpstan": "^2.1",
+"phpstan/phpstan": "^2.1 <2.2.6",
```

Drop the upper bound once Rector ships a compatible release.

## Why pin rather than commit `composer.lock`

A lock file would pin one dependency resolution for all five PHP versions, which defeats the point of the matrix — the whole reason `composer.lock` is gitignored here is so each PHP version resolves the versions appropriate to it. Pinning the one broken package keeps that intact.

The tradeoff to accept knowingly: because CI resolves fresh on every run, a third-party patch release can turn the build red with no commit involved. That is what happened here. The mitigation is narrow upper bounds on dev tools that reach into another tool's internals — Rector↔PHPStan is the fragile coupling, since Rector drives PHPStan's container by reflection rather than through a public API. It is the one pairing in this repo likely to break this way again.

## Testing

With the pin applied:

- `rector process src/ --dry-run --clear-cache` — 53/53 files, clean
- `phpstan analyse src --level max` — no errors
- `phpcs` — clean
- 788 unit tests pass
- `composer why-not phpstan/phpstan 2.2.6` confirms the constraint excludes the broken release
- A fresh resolve (what CI does) selects 2.2.5

Verified the pin is safe across the whole matrix, not just locally:

- phpstan 2.2.5 requires `php: ^7.4|^8.0`, so it installs identically on 8.1 through 8.5 — no PHP-version divergence for this package
- rector 2.5.7 requires `phpstan/phpstan: ^2.2.2`, which 2.2.5 satisfies — no dependency conflict introduced
- `composer update --dry-run` reports zero conflicts

## Breaking Changes

None. Dev dependency constraint only; nothing in `require` and no runtime code touched.

## Merge order

This should go in first — it unblocks #90 and #91, which both need a rebase (or a merge from `2.x`) afterwards to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)