### PR TITLE
Name the CRS anomaly thresholds honestly (Fixes #93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1863,15 +1863,48 @@ plugins:
       #   response_leak_java, response_leak_php, response_leak_iis,
       #   web_shell, correlation
       disabled_categories: []
-      # Override anomaly-score thresholds
+      # Anomaly-score thresholds. There are exactly two — see
+      # "Anomaly scores and thresholds" below before reaching for these.
       anomaly_thresholds:
-        critical: 5
-        error: 4
-        warning: 3
-        notice: 2
+        # Request-side score at or above which the request is rejected.
+        inbound: 5
+        # Response-side equivalent. Inert until response evaluation lands (#69).
+        outbound: 4
       # Custom rule cache location — defaults to vendor/kanopi/crs-engine/rules
       # rules_path: /etc/firewall/crs-rules
 ```
+
+#### Anomaly scores and thresholds
+
+A matching rule adds points to the request's anomaly score, weighted by the rule's CRS severity — critical contributes 5, error 4, warning 3, notice 2. **Those per-severity weights are fixed by CRS and are not configurable here.**
+
+What *is* configurable is the two thresholds the score is compared against:
+
+| Key | Default | Controls |
+|---|---|---|
+| `inbound` | `5` | Request-side threshold — the score at or above which a request is rejected. Read the caveat below before tuning it. |
+| `outbound` | `4` | Response-side equivalent. Inert until response evaluation lands (issue #69). |
+
+The severity-named spellings `critical` (= `inbound`) and `error` (= `outbound`) are still accepted so existing config keeps working. Any other key — including `warning` and `notice`, which earlier versions of this document showed — is read nowhere; the plugin now logs a warning naming the keys it ignored instead of accepting them silently. If both spellings of a threshold are present, `inbound` / `outbound` win.
+
+**The threshold is not the false-positive lever it looks like.** A rule whose CRS action is `block`, `deny`, or `drop` rejects the request the moment it matches, without consulting the score at all — and in the rule set shipped with `crs-engine` today, *every* rule that contributes to the anomaly score carries such an action. The score therefore never reaches the threshold comparison in block mode, and in monitor mode nothing blocks either way. Raising `inbound` from 5 to 500 changes nothing:
+
+```php
+foreach ([5, 50, 500] as $threshold) {
+    $crs = new Crs([], ['mode' => 'block', 'anomaly_thresholds' => ['inbound' => $threshold]]);
+    var_dump($crs->evaluate(Request::create('/', 'GET', ['id' => "1' UNION SELECT 1,2,3--"])));
+}
+// true, true, true — blocked by rule 942190 every time, score 5.
+```
+
+This mirrors ModSecurity's `deny` actions rather than stock CRS, where blocking is routed through the anomaly-evaluation rules (949110 / 959100) and the threshold governs everything. The setting is honoured by the engine and matters for rule sets whose score-contributing rules use non-blocking actions (`rules_path`), but for the bundled set treat it as inert.
+
+So, to tune a false positive:
+
+- **`disabled_rules`** — the precise lever. The blocked request's log line carries `rule_id`; add it here.
+- **`disabled_categories`** — blunter, when a whole class of rules is wrong for your app.
+- **`paranoia`** — lower it to drop the aggressive rule tiers wholesale.
+- **`mode: monitor`** — the only setting that reliably stops CRS rejecting anything while you tune.
 
 #### Coverage
 
@@ -1907,8 +1940,9 @@ $crs = new Crs(metadata: [], config: [
     'mode' => 'monitor',   // Score and report without blocking.
 ]);
 
-// evaluate() returns FALSE when CRS would block the request.
-$allowed = $crs->evaluate($request);
+// evaluate() returns TRUE when the plugin matched — i.e. when CRS would
+// block the request. See PluginInterface::evaluate().
+$matched = $crs->evaluate($request);
 
 $verdict = $crs->getLastVerdict();
 if ($verdict !== null) {

--- a/README.md
+++ b/README.md
@@ -1897,7 +1897,9 @@ foreach ([5, 50, 500] as $threshold) {
 // true, true, true — blocked by rule 942190 every time, score 5.
 ```
 
-This mirrors ModSecurity's `deny` actions rather than stock CRS, where blocking is routed through the anomaly-evaluation rules (949110 / 959100) and the threshold governs everything. The setting is honoured by the engine and matters for rule sets whose score-contributing rules use non-blocking actions (`rules_path`), but for the bundled set treat it as inert.
+This is not a deliberate departure from stock CRS. The anomaly-evaluation rules that normally do the blocking are present in the bundled set — 949111 chained with 949110 inbound, 959101 with 959100 outbound — and they do compare `TX.BLOCKING_INBOUND_ANOMALY_SCORE` against `%{tx.inbound_anomaly_score_threshold}` with a `deny` action. They can never fire, because the aggregator rules that feed that variable (949052–949063) have their `setvar` values compiled to a literal `0`: `crs-engine`'s parser inlines `%{tx.*}` macros at build time, which is right for fixed seeds like `%{tx.critical_anomaly_score}` but flattens the runtime accumulators `%{tx.inbound_anomaly_score_plN}` — which have no seed value — to zero. With its input pinned at 0 the whole anomaly-evaluation path is dead, and blocking falls back entirely to per-rule `block` actions.
+
+That is an upstream defect in `kanopi/crs-engine`, not something this plugin can fix. Note the threshold macro *is* preserved in the operator argument and resolved at runtime, so once the parser keeps those setvar macros, `inbound` becomes live and meaningful with no config change here.
 
 So, to tune a false positive:
 

--- a/README.md
+++ b/README.md
@@ -1836,6 +1836,12 @@ Evaluates each request against the [OWASP Core Rule Set](https://coreruleset.org
 - **In-process rule cache**: ~3-4 ms per request once warm (FPM worker steady state). Zero extension dependencies — no APCu / OPcache preload required.
 - **Auto-refreshed rules**: The `crs-engine` package CI fetches new CRS releases weekly and opens a reviewable PR; `composer update` pulls the latest curated bump.
 
+> ### Upgrading from a release built on `crs-engine` 0.1.0
+>
+> This plugin now requires `crs-engine` ^1.0, which is the first version where the engine actually enforces. In 0.1.0 the detection pipeline was substantially inert — the anomaly-evaluation rules could never fire, `TX:` targets never resolved, and `skipAfter` silently discarded the rest of the ruleset. **Traffic that used to pass will now be rejected**, because previously very little was.
+>
+> Roll it out with `mode: monitor` first. Let it run over real traffic, group the `contributing_rules` on the debug log lines by rule ID, and build your `disabled_rules` list from what you actually see before you let it block. CRS at paranoia 1 does flag some ordinary editorial content — a support ticket containing `cat /etc/hosts | grep` scores 15 and would be rejected — so on a CMS this step is not optional.
+
 #### Configuration Example
 
 ```yaml
@@ -1859,9 +1865,11 @@ plugins:
       # Or by category. Available categories:
       #   sqli, xss, lfi, rfi, rce, php, java, session_fixation,
       #   protocol_attack, protocol_enforcement, method_enforcement,
-      #   scanner, multipart, generic, response_leak_sql,
+      #   scanner, multipart, generic, response_leak, response_leak_sql,
       #   response_leak_java, response_leak_php, response_leak_iis,
-      #   web_shell, correlation
+      #   response_leak_ruby, web_shell, correlation, blocking_evaluation
+      # Do not disable blocking_evaluation — it is how anomaly scoring
+      # rejects anything at all.
       disabled_categories: []
       # Anomaly-score thresholds. There are exactly two — see
       # "Anomaly scores and thresholds" below before reaching for these.
@@ -1876,37 +1884,36 @@ plugins:
 
 #### Anomaly scores and thresholds
 
-A matching rule adds points to the request's anomaly score, weighted by the rule's CRS severity — critical contributes 5, error 4, warning 3, notice 2. **Those per-severity weights are fixed by CRS and are not configurable here.**
+A matching rule adds points to the request's anomaly score, weighted by the rule's CRS severity — critical contributes 5, error 4, warning 3, notice 2. Those per-severity weights are fixed by CRS and are not configurable through this plugin.
 
-What *is* configurable is the two thresholds the score is compared against:
+Once the accumulated score reaches the threshold, CRS rule 949110 rejects the request. The two thresholds are:
 
 | Key | Default | Controls |
 |---|---|---|
-| `inbound` | `5` | Request-side threshold — the score at or above which a request is rejected. Read the caveat below before tuning it. |
-| `outbound` | `4` | Response-side equivalent. Inert until response evaluation lands (issue #69). |
+| `inbound` | `5` | Request-side threshold — the score at or above which a request is rejected. |
+| `outbound` | `4` | Response-side equivalent. Not reached yet; this plugin does not call `evaluateResponse()` (issue #69). |
 
-The severity-named spellings `critical` (= `inbound`) and `error` (= `outbound`) are still accepted so existing config keeps working. Any other key — including `warning` and `notice`, which earlier versions of this document showed — is read nowhere; the plugin now logs a warning naming the keys it ignored instead of accepting them silently. If both spellings of a threshold are present, `inbound` / `outbound` win.
-
-**The threshold is not the false-positive lever it looks like.** A rule whose CRS action is `block`, `deny`, or `drop` rejects the request the moment it matches, without consulting the score at all — and in the rule set shipped with `crs-engine` today, *every* rule that contributes to the anomaly score carries such an action. The score therefore never reaches the threshold comparison in block mode, and in monitor mode nothing blocks either way. Raising `inbound` from 5 to 500 changes nothing:
+At the default of 5, a single critical rule is enough to reject. Raise it to require corroboration from several rules, lower it to reject on weaker evidence:
 
 ```php
-foreach ([5, 50, 500] as $threshold) {
-    $crs = new Crs([], ['mode' => 'block', 'anomaly_thresholds' => ['inbound' => $threshold]]);
-    var_dump($crs->evaluate(Request::create('/', 'GET', ['id' => "1' UNION SELECT 1,2,3--"])));
-}
-// true, true, true — blocked by rule 942190 every time, score 5.
+$payload = ['id' => "1' UNION SELECT 1,2,3--"];   // scores 10: rules 942190 + 942360
+
+(new Crs([], ['anomaly_thresholds' => ['inbound' => 5]]))->evaluate($request);    // true  — rejected
+(new Crs([], ['anomaly_thresholds' => ['inbound' => 500]]))->evaluate($request);  // false — allowed
 ```
 
-This is not a deliberate departure from stock CRS. The anomaly-evaluation rules that normally do the blocking are present in the bundled set — 949111 chained with 949110 inbound, 959101 with 959100 outbound — and they do compare `TX.BLOCKING_INBOUND_ANOMALY_SCORE` against `%{tx.inbound_anomaly_score_threshold}` with a `deny` action. They can never fire, because the aggregator rules that feed that variable (949052–949063) have their `setvar` values compiled to a literal `0`: `crs-engine`'s parser inlines `%{tx.*}` macros at build time, which is right for fixed seeds like `%{tx.critical_anomaly_score}` but flattens the runtime accumulators `%{tx.inbound_anomaly_score_plN}` — which have no seed value — to zero. With its input pinned at 0 the whole anomaly-evaluation path is dead, and blocking falls back entirely to per-rule `block` actions.
+The severity-named spellings `critical` (= `inbound`) and `error` (= `outbound`) are still accepted, so config written before the rename keeps working — the plugin translates them, which also keeps `crs-engine`'s deprecation notice out of your logs. Any other key, including the `warning` and `notice` that earlier versions of this document showed, has never had any effect; the plugin logs a warning naming what it ignored rather than accepting it silently. If both spellings of one threshold are present, `inbound` / `outbound` win.
 
-That is an upstream defect in `kanopi/crs-engine`, not something this plugin can fix. Note the threshold macro *is* preserved in the operator argument and resolved at runtime, so once the parser keeps those setvar macros, `inbound` becomes live and meaningful with no config change here.
+> **A block is attributed to rule 949110, not to the rule that caught the payload.**
+> 949110 is the CRS rule that compares the score to the threshold, so it is the `rule_id` on every anomaly-score block. **Never put it in `disabled_rules`** — that switches off anomaly blocking entirely. The rules worth excluding are in `contributing_rules` on the same log line.
 
-So, to tune a false positive:
+To tune a false positive, in rough order of precision:
 
-- **`disabled_rules`** — the precise lever. The blocked request's log line carries `rule_id`; add it here.
-- **`disabled_categories`** — blunter, when a whole class of rules is wrong for your app.
+- **`disabled_rules`** — the precise lever. Take the IDs from `contributing_rules` in the block's log line.
+- **`disabled_categories`** — blunter, when a whole class of rules is wrong for your app. Note `blocking_evaluation` is a category: disabling it turns off anomaly blocking, so treat it as off-limits.
+- **`anomaly_thresholds.inbound`** — raise it to require more corroboration before rejecting. Affects everything, so prefer the two above when you know which rule is wrong.
 - **`paranoia`** — lower it to drop the aggressive rule tiers wholesale.
-- **`mode: monitor`** — the only setting that reliably stops CRS rejecting anything while you tune.
+- **`mode: monitor`** — evaluates and logs but never rejects. The safe setting while you build an exclusion list.
 
 #### Coverage
 
@@ -1917,13 +1924,17 @@ The four CRS rules that rely on `libinjection` (`@detectSQLi` / `@detectXSS` —
 #### What gets logged
 
 Blocked requests log at `info` level with full context:
-- `rule_id` — the CRS rule that fired the block
+- `rule_id` — the CRS rule that fired the block. For an anomaly-score block this is always **949110**, the rule that compares the score to the threshold — not the rule that caught the payload, and not something to put in `disabled_rules`.
+- `contributing_rules` — the rules that actually detected something, in match order. **These are the IDs to feed to `disabled_rules`.**
 - `total_score` — accumulated anomaly score
 - `scores` — per-category breakdown (sqli, xss, lfi, etc.)
-- `matched_rule` — the rule's human-readable message
+- `matched_rule` — the first matching rule's human-readable message
 - `matched_data` — the substring of the request that matched
+- `operator_errors` / `truncations` — see below
 
-Non-blocking matches (monitor mode, or rules whose action is `pass`) log at `debug` level.
+Non-blocking matches (monitor mode, or a score under the threshold) log at `debug` level with the same `contributing_rules`, which is what makes monitor mode usable for building an exclusion list.
+
+Separately, the plugin logs at `warning` level when `operator_errors` or `truncations` is non-empty — a rule that could not run, or an inspection cap that engaged. Both mean part of the request went unexamined, so a clean verdict is weaker evidence than it looks. This fires even when nothing matched, because that is exactly when a silent gap in coverage is most likely to be believed.
 
 #### Inspecting the verdict programmatically
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/dbal": "^4.2",
         "geoip2/geoip2": "~2 || ^3",
         "guzzlehttp/guzzle": "^7.9",
-        "kanopi/crs-engine": "^0.1.0",
+        "kanopi/crs-engine": "^1.0",
         "matomo/device-detector": "^6.4",
         "monolog/monolog": "^3.9",
         "symfony/cache": "~6.4 || ~7.3",

--- a/example/config.notes.yml
+++ b/example/config.notes.yml
@@ -441,7 +441,8 @@ plugins:
       #
       # Note the threshold is only consulted for requests that trip no rule
       # carrying a block/deny/drop action, and in the bundled rule set every
-      # score-contributing rule carries one — so it is inert as shipped.
+      # score-contributing rule carries one — so it is inert as shipped. The
+      # cause is an upstream crs-engine parser defect, not a design choice.
       # Raising it will not quiet a false positive; use disabled_rules,
       # disabled_categories, a lower paranoia, or mode: monitor.
       anomaly_thresholds:

--- a/example/config.notes.yml
+++ b/example/config.notes.yml
@@ -412,10 +412,12 @@ plugins:
       # Paranoia level 1-4. 1 has the lowest false-positive rate; higher
       # levels enable progressively more aggressive rules.
       paranoia: 1
-      # `block` reports a match on any blocking-action rule so the firewall
-      # applies this entry's `response:`. `monitor` records the match in the
-      # logs but never reports one (useful for testing without impacting
-      # users).
+      # `block` reports a match once the anomaly score reaches the inbound
+      # threshold, so the firewall applies this entry's `response:`.
+      # `monitor` evaluates and records everything but never reports a
+      # match. Start on monitor: crs-engine 1.0.0 rejects traffic that
+      # earlier versions let through, so build an exclusion list from the
+      # logged contributing_rules before letting it block.
       mode: block
       # HTTP status returned for blocked requests.
       block_status: 403
@@ -431,26 +433,32 @@ plugins:
       # Whole categories to skip. Values:
       # sqli, xss, lfi, rfi, rce, php, java, session_fixation,
       # protocol_attack, protocol_enforcement, method_enforcement, scanner,
-      # multipart, generic, response_leak_sql, response_leak_java,
-      # response_leak_php, response_leak_iis, web_shell, correlation.
+      # multipart, generic, response_leak, response_leak_sql,
+      # response_leak_java, response_leak_php, response_leak_iis,
+      # response_leak_ruby, web_shell, correlation, blocking_evaluation.
+      # Leave blocking_evaluation alone — disabling it stops anomaly
+      # scoring rejecting anything at all.
       disabled_categories: []
       # Anomaly-score thresholds. There are exactly two, and only these two
       # keys are read — anything else (including the 'warning' and 'notice'
       # earlier versions of this file listed) is ignored and logged as such.
       # Per-severity score contributions are fixed by CRS, not set here.
       #
-      # Note the threshold is only consulted for requests that trip no rule
-      # carrying a block/deny/drop action, and in the bundled rule set every
-      # score-contributing rule carries one — so it is inert as shipped. The
-      # cause is an upstream crs-engine parser defect, not a design choice.
-      # Raising it will not quiet a false positive; use disabled_rules,
-      # disabled_categories, a lower paranoia, or mode: monitor.
+      # Matching rules accumulate a score; CRS rule 949110 rejects the
+      # request once it reaches the inbound threshold. At the default of 5 a
+      # single critical rule is enough. Raise it to require corroboration
+      # from several rules; lower it to reject on weaker evidence.
+      #
+      # A block is attributed to 949110, not to the rule that caught the
+      # payload. Never put 949110 in disabled_rules — it is how anomaly
+      # blocking works. The IDs worth excluding are on the log line as
+      # contributing_rules.
       anomaly_thresholds:
         # Request-side score at or above which the request is rejected.
         # Lower is stricter. The legacy spelling 'critical' still works.
         inbound: 5
-        # Response-side equivalent. Inert until response-side evaluation
-        # lands. The legacy spelling 'error' still works.
+        # Response-side equivalent. Not reached yet — this plugin does not
+        # run response-side evaluation. The legacy spelling 'error' works.
         outbound: 4
 
 # Loggers help log data in specific formats. Uses Monolog (https://seldaek.github.io/monolog/)

--- a/example/config.notes.yml
+++ b/example/config.notes.yml
@@ -412,10 +412,10 @@ plugins:
       # Paranoia level 1-4. 1 has the lowest false-positive rate; higher
       # levels enable progressively more aggressive rules.
       paranoia: 1
-      # `block` returns false from evaluate() on any blocking-action match
-      # so the firewall blocks the request. `monitor` records the match in
-      # the logs but never returns false (useful for testing without
-      # impacting users).
+      # `block` reports a match on any blocking-action rule so the firewall
+      # applies this entry's `response:`. `monitor` records the match in the
+      # logs but never reports one (useful for testing without impacting
+      # users).
       mode: block
       # HTTP status returned for blocked requests.
       block_status: 403
@@ -424,7 +424,9 @@ plugins:
       # Override paths only if you've vendored a custom CRS build. Default
       # is vendor/kanopi/crs-engine/rules.
       # rules_path: /etc/firewall/crs-rules
-      # Specific CRS rule IDs to skip (use for known false positives).
+      # Specific CRS rule IDs to skip. This — not the thresholds below — is
+      # the lever for a known false positive: the blocked request's log line
+      # carries the `rule_id` to add here.
       disabled_rules: []
       # Whole categories to skip. Values:
       # sqli, xss, lfi, rfi, rce, php, java, session_fixation,
@@ -432,13 +434,23 @@ plugins:
       # multipart, generic, response_leak_sql, response_leak_java,
       # response_leak_php, response_leak_iis, web_shell, correlation.
       disabled_categories: []
-      # Thresholds for the engine's anomaly-score aggregator (CRS-native
-      # severity weights). Lower 'critical' means more sensitive.
+      # Anomaly-score thresholds. There are exactly two, and only these two
+      # keys are read — anything else (including the 'warning' and 'notice'
+      # earlier versions of this file listed) is ignored and logged as such.
+      # Per-severity score contributions are fixed by CRS, not set here.
+      #
+      # Note the threshold is only consulted for requests that trip no rule
+      # carrying a block/deny/drop action, and in the bundled rule set every
+      # score-contributing rule carries one — so it is inert as shipped.
+      # Raising it will not quiet a false positive; use disabled_rules,
+      # disabled_categories, a lower paranoia, or mode: monitor.
       anomaly_thresholds:
-        critical: 5
-        error: 4
-        warning: 3
-        notice: 2
+        # Request-side score at or above which the request is rejected.
+        # Lower is stricter. The legacy spelling 'critical' still works.
+        inbound: 5
+        # Response-side equivalent. Inert until response-side evaluation
+        # lands. The legacy spelling 'error' still works.
+        outbound: 4
 
 # Loggers help log data in specific formats. Uses Monolog (https://seldaek.github.io/monolog/)
 # Multiple loggers can be added as the following are structured but added as arrays under the logger section.

--- a/src/Plugins/Crs.php
+++ b/src/Plugins/Crs.php
@@ -35,6 +35,11 @@ use Symfony\Component\HttpFoundation\Request;
  * score-contributing rule carries one. The threshold is therefore inert as
  * shipped, and raising it is not the false-positive lever it looks like —
  * `disabled_rules` / `disabled_categories` are. See anomalyThresholds().
+ *
+ * The cause is upstream: crs-engine's parser inlines `%{tx.*}` macros at
+ * build time and flattens the runtime accumulators feeding 949110 / 959100
+ * to a literal 0, so CRS's own anomaly-evaluation rules never fire. Nothing
+ * here can fix that; when it is fixed the threshold goes live as-is.
  */
 class Crs extends AbstractPluginBase
 {

--- a/src/Plugins/Crs.php
+++ b/src/Plugins/Crs.php
@@ -29,17 +29,18 @@ use Symfony\Component\HttpFoundation\Request;
  * Response-side evaluation (RESPONSE-* rules for SQL error / stack-trace
  * leakage) lives in a follow-up — see firewall issue #69.
  *
- * A note on thresholds, because it surprises people arriving from stock CRS:
- * a rule carrying a `block` / `deny` / `drop` action rejects on first match
- * without consulting the anomaly score, and in the bundled rule set every
- * score-contributing rule carries one. The threshold is therefore inert as
- * shipped, and raising it is not the false-positive lever it looks like —
- * `disabled_rules` / `disabled_categories` are. See anomalyThresholds().
+ * Requires crs-engine ^1.0. In 0.1.0 the anomaly-evaluation rules could never
+ * fire, so the threshold was inert and blocking came from whichever rule
+ * happened to carry a `block` action. 1.0.0 fixed that: score accumulates,
+ * 949110 denies once it crosses the threshold, and `anomaly_thresholds` is
+ * now the primary tuning lever. The practical effect of that upgrade is that
+ * traffic which used to pass is now blocked — see the README's CRS section
+ * before rolling it out.
  *
- * The cause is upstream: crs-engine's parser inlines `%{tx.*}` macros at
- * build time and flattens the runtime accumulators feeding 949110 / 959100
- * to a literal 0, so CRS's own anomaly-evaluation rules never fire. Nothing
- * here can fix that; when it is fixed the threshold goes live as-is.
+ * One consequence worth knowing when reading logs: an anomaly-score block is
+ * attributed to rule 949110, not to the rule that found the payload. The
+ * rules that actually contributed are in `contributing_rules` on the log
+ * context, and those are what belong in `disabled_rules`.
  */
 class Crs extends AbstractPluginBase
 {
@@ -57,17 +58,18 @@ class Crs extends AbstractPluginBase
      * Engine threshold key => the config spellings that set it, preferred
      * spelling first.
      *
-     * The engine names its two thresholds after CRS severities, which reads
-     * as though there is one threshold per severity. There is not: `critical`
-     * is the single inbound threshold and `error` the single outbound one.
-     * `inbound` / `outbound` are the honest names and the ones documented;
-     * the severity names stay accepted so existing config keeps working.
+     * There are two thresholds and they are directional. Before crs-engine
+     * 1.0.0 they were keyed `critical` / `error`, which read as though there
+     * were one per CRS severity; the engine still accepts those spellings but
+     * emits a deprecation for them. Translating here means config written
+     * either way keeps working without the host application seeing a
+     * deprecation on every request.
      *
      * @var array<string, list<string>>
      */
     protected const THRESHOLD_KEYS = [
-        'critical' => ['inbound', 'critical'],
-        'error'    => ['outbound', 'error'],
+        'inbound'  => ['inbound', 'critical'],
+        'outbound' => ['outbound', 'error'],
     ];
 
     /**
@@ -112,11 +114,14 @@ class Crs extends AbstractPluginBase
         // See PluginInterface::evaluate().
         if ($crsVerdict->isBlocked()) {
             $this->getLogger()->info('CRS blocked request', $this->getContext($request, [
-                'rule_id'      => $crsVerdict->blockingRuleId,
-                'total_score'  => $crsVerdict->totalScore,
-                'scores'       => $crsVerdict->scores,
-                'matched_rule' => $crsVerdict->matchedRules[0]['msg'] ?? '',
-                'matched_data' => $crsVerdict->matchedRules[0]['matched_data'] ?? '',
+                'rule_id'            => $crsVerdict->blockingRuleId,
+                'contributing_rules' => $this->contributingRuleIds($crsVerdict),
+                'total_score'        => $crsVerdict->totalScore,
+                'scores'             => $crsVerdict->scores,
+                'matched_rule'       => $crsVerdict->matchedRules[0]['msg'] ?? '',
+                'matched_data'       => $crsVerdict->matchedRules[0]['matched_data'] ?? '',
+                'operator_errors'    => $crsVerdict->operatorErrors,
+                'truncations'        => $crsVerdict->truncations,
             ]));
             return true;
         }
@@ -125,9 +130,22 @@ class Crs extends AbstractPluginBase
         // plugin is in monitor mode. Report no match so the request proceeds.
         if ($crsVerdict->matchedRules !== []) {
             $this->getLogger()->debug('CRS matched but did not block', $this->getContext($request, [
+                'action'             => $crsVerdict->action,
+                'matched_rules'      => count($crsVerdict->matchedRules),
+                'contributing_rules' => $this->contributingRuleIds($crsVerdict),
+                'total_score'        => $crsVerdict->totalScore,
+            ]));
+        }
+
+        // An operator error or a truncation means part of the request went
+        // uninspected, so "no match" is weaker evidence than it looks. Say so
+        // even when nothing fired — a clean verdict is the case where a silent
+        // gap in coverage is most likely to be believed.
+        if ($crsVerdict->hasOperatorErrors() || $crsVerdict->wasTruncated()) {
+            $this->getLogger()->warning('CRS inspected less of the request than it appears', $this->getContext($request, [
                 'action'          => $crsVerdict->action,
-                'matched_rules'   => count($crsVerdict->matchedRules),
-                'total_score'     => $crsVerdict->totalScore,
+                'operator_errors' => $crsVerdict->operatorErrors,
+                'truncations'     => $crsVerdict->truncations,
             ]));
         }
 
@@ -181,15 +199,45 @@ class Crs extends AbstractPluginBase
     }
 
     /**
+     * The rules that actually found something, in match order.
+     *
+     * `blockingRuleId` is 949110 for every anomaly-score block, because that
+     * is the CRS rule that compares the accumulated score to the threshold.
+     * It says nothing about what was detected and must never be fed to
+     * `disabled_rules` — doing so would switch off anomaly blocking wholesale.
+     * The IDs here are the ones worth excluding, so drop the blocking-
+     * evaluation bookkeeping and keep the detections.
+     *
+     * @return array<int, int>
+     */
+    protected function contributingRuleIds(CrsVerdict $crsVerdict): array
+    {
+        $ids = [];
+        foreach ($crsVerdict->matchedRules as $matchedRule) {
+            if ($matchedRule['category'] === 'blocking_evaluation') {
+                continue;
+            }
+
+            $ids[] = $matchedRule['id'];
+        }
+
+        return $ids;
+    }
+
+    /**
      * Normalise `anomaly_thresholds` into the two thresholds the engine reads.
      *
-     * The engine has exactly two: inbound (the request-side anomaly score at
-     * or above which a request is blocked) and outbound (the response-side
-     * equivalent, inert until response evaluation lands — see issue #69). It
-     * keys them `critical` and `error`, which invites operators to supply a
-     * `warning` and a `notice` alongside them and believe all four do
-     * something. They do not — anything beyond the two is read nowhere, so
-     * say so rather than accepting it in silence (#93).
+     * There are exactly two: inbound (the request-side score at or above which
+     * a request is rejected) and outbound (the response-side equivalent, which
+     * this plugin does not yet reach — see issue #69). Pre-1.0 config keyed
+     * them by CRS severity, which invited operators to supply a `warning` and
+     * a `notice` alongside and believe all four did something. They never did
+     * (#93), so name the inert ones rather than accepting them in silence.
+     *
+     * Deliberately more forgiving than the engine, which throws
+     * `ConfigurationException` on an unrecognised key. A typo in a YAML file
+     * should not take a site down: drop the key, say so at warning level, and
+     * carry on protecting the site with the rest of the config.
      *
      * @return array<string, int>
      *   Engine-shaped thresholds, always with both keys populated.
@@ -206,8 +254,8 @@ class Crs extends AbstractPluginBase
         }
 
         $thresholds = [
-            'critical' => self::DEFAULT_INBOUND_THRESHOLD,
-            'error'    => self::DEFAULT_OUTBOUND_THRESHOLD,
+            'inbound'  => self::DEFAULT_INBOUND_THRESHOLD,
+            'outbound' => self::DEFAULT_OUTBOUND_THRESHOLD,
         ];
 
         // The preferred spelling is tried first, so it wins when both are
@@ -238,11 +286,11 @@ class Crs extends AbstractPluginBase
         $inert = array_values(array_diff(array_map(strval(...), array_keys($configured)), $accepted));
 
         if ($inert !== []) {
-            $this->getLogger()->warning('CRS anomaly_thresholds keys are ignored — the engine has only an inbound and an outbound threshold', [
+            $this->getLogger()->warning('CRS anomaly_thresholds keys are ignored — there are only an inbound and an outbound threshold', [
                 'plugin'   => $this->getName(),
                 'ignored'  => $inert,
                 'accepted' => $accepted,
-                'hint'     => 'Per-severity score contributions are fixed by CRS and are not configurable. To silence a false positive use disabled_rules or disabled_categories.',
+                'hint'     => 'Severity names are not thresholds. Raise or lower `inbound` to tune sensitivity, or use disabled_rules / disabled_categories to silence a specific false positive.',
             ]);
         }
 

--- a/src/Plugins/Crs.php
+++ b/src/Plugins/Crs.php
@@ -28,9 +28,43 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * Response-side evaluation (RESPONSE-* rules for SQL error / stack-trace
  * leakage) lives in a follow-up — see firewall issue #69.
+ *
+ * A note on thresholds, because it surprises people arriving from stock CRS:
+ * a rule carrying a `block` / `deny` / `drop` action rejects on first match
+ * without consulting the anomaly score, and in the bundled rule set every
+ * score-contributing rule carries one. The threshold is therefore inert as
+ * shipped, and raising it is not the false-positive lever it looks like —
+ * `disabled_rules` / `disabled_categories` are. See anomalyThresholds().
  */
 class Crs extends AbstractPluginBase
 {
+    /**
+     * Default inbound (request-side) anomaly score threshold.
+     */
+    protected const DEFAULT_INBOUND_THRESHOLD = 5;
+
+    /**
+     * Default outbound (response-side) anomaly score threshold.
+     */
+    protected const DEFAULT_OUTBOUND_THRESHOLD = 4;
+
+    /**
+     * Engine threshold key => the config spellings that set it, preferred
+     * spelling first.
+     *
+     * The engine names its two thresholds after CRS severities, which reads
+     * as though there is one threshold per severity. There is not: `critical`
+     * is the single inbound threshold and `error` the single outbound one.
+     * `inbound` / `outbound` are the honest names and the ones documented;
+     * the severity names stay accepted so existing config keeps working.
+     *
+     * @var array<string, list<string>>
+     */
+    protected const THRESHOLD_KEYS = [
+        'critical' => ['inbound', 'critical'],
+        'error'    => ['outbound', 'error'],
+    ];
+
     /**
      * Constructed once on first evaluate(); subsequent calls reuse it.
      * The engine itself memoises the loaded ruleset per directory for the
@@ -131,12 +165,7 @@ class Crs extends AbstractPluginBase
             $this->engine = new CrsEngine(new CrsConfig(
                 paranoia:           (int) ($this->config['paranoia'] ?? 1),
                 mode:               (string) ($this->config['mode'] ?? CrsConfig::MODE_BLOCK),
-                anomalyThresholds:  $this->config['anomaly_thresholds'] ?? [
-                    'critical' => 5,
-                    'error'    => 4,
-                    'warning'  => 3,
-                    'notice'   => 2,
-                ],
+                anomalyThresholds:  $this->anomalyThresholds(),
                 disabledRules:      array_map(intval(...), $this->config['disabled_rules'] ?? []),
                 disabledCategories: $this->config['disabled_categories'] ?? [],
                 rulesPath:          $this->config['rules_path'] ?? null,
@@ -144,6 +173,75 @@ class Crs extends AbstractPluginBase
         }
 
         return $this->engine;
+    }
+
+    /**
+     * Normalise `anomaly_thresholds` into the two thresholds the engine reads.
+     *
+     * The engine has exactly two: inbound (the request-side anomaly score at
+     * or above which a request is blocked) and outbound (the response-side
+     * equivalent, inert until response evaluation lands — see issue #69). It
+     * keys them `critical` and `error`, which invites operators to supply a
+     * `warning` and a `notice` alongside them and believe all four do
+     * something. They do not — anything beyond the two is read nowhere, so
+     * say so rather than accepting it in silence (#93).
+     *
+     * @return array<string, int>
+     *   Engine-shaped thresholds, always with both keys populated.
+     */
+    protected function anomalyThresholds(): array
+    {
+        $configured = $this->config['anomaly_thresholds'] ?? [];
+        if (!is_array($configured)) {
+            $this->getLogger()->warning('CRS anomaly_thresholds must be a mapping — ignoring it and using defaults', [
+                'plugin' => $this->getName(),
+                'given'  => get_debug_type($configured),
+            ]);
+            $configured = [];
+        }
+
+        $thresholds = [
+            'critical' => self::DEFAULT_INBOUND_THRESHOLD,
+            'error'    => self::DEFAULT_OUTBOUND_THRESHOLD,
+        ];
+
+        // The preferred spelling is tried first, so it wins when both are
+        // present — config migrated key by key behaves the same in either
+        // write order.
+        foreach (self::THRESHOLD_KEYS as $engineKey => $names) {
+            foreach ($names as $name) {
+                if (!isset($configured[$name])) {
+                    continue;
+                }
+
+                if (!is_numeric($configured[$name])) {
+                    $this->getLogger()->warning('CRS anomaly threshold is not a number — using the default', [
+                        'plugin'  => $this->getName(),
+                        'key'     => $name,
+                        'given'   => get_debug_type($configured[$name]),
+                        'default' => $thresholds[$engineKey],
+                    ]);
+                    continue;
+                }
+
+                $thresholds[$engineKey] = (int) $configured[$name];
+                break;
+            }
+        }
+
+        $accepted = array_merge(...array_values(self::THRESHOLD_KEYS));
+        $inert = array_values(array_diff(array_map(strval(...), array_keys($configured)), $accepted));
+
+        if ($inert !== []) {
+            $this->getLogger()->warning('CRS anomaly_thresholds keys are ignored — the engine has only an inbound and an outbound threshold', [
+                'plugin'   => $this->getName(),
+                'ignored'  => $inert,
+                'accepted' => $accepted,
+                'hint'     => 'Per-severity score contributions are fixed by CRS and are not configurable. To silence a false positive use disabled_rules or disabled_categories.',
+            ]);
+        }
+
+        return $thresholds;
     }
 
     /**

--- a/tests/Unit/Plugins/CrsTest.php
+++ b/tests/Unit/Plugins/CrsTest.php
@@ -140,39 +140,40 @@ class CrsTest extends AbstractTestCase
     }
 
     /**
-     * #93: the engine reads exactly two thresholds, keyed by CRS severity
-     * names that read as though there were one per severity. `inbound` and
-     * `outbound` are the honest names, and they map onto those two keys.
+     * #93: there are exactly two thresholds and they are directional.
+     * crs-engine 1.0.0 keys them `inbound` / `outbound`; the pre-1.0
+     * severity spellings still work but make the engine emit a deprecation,
+     * so the plugin hands over the canonical names.
      */
     public function testCanonicalThresholdNamesMapToEngineKeys(): void
     {
         $plugin = $this->thresholdProbe(['inbound' => 9, 'outbound' => 7]);
-        $this->assertSame(['critical' => 9, 'error' => 7], $plugin->thresholds());
+        $this->assertSame(['inbound' => 9, 'outbound' => 7], $plugin->thresholds());
     }
 
     public function testLegacySeverityThresholdNamesStillWork(): void
     {
         $plugin = $this->thresholdProbe(['critical' => 9, 'error' => 7]);
-        $this->assertSame(['critical' => 9, 'error' => 7], $plugin->thresholds());
+        $this->assertSame(['inbound' => 9, 'outbound' => 7], $plugin->thresholds());
     }
 
     public function testCanonicalThresholdNameWinsOverLegacySpelling(): void
     {
         // Config migrated one key at a time must not depend on write order.
         $this->assertSame(
-            ['critical' => 9, 'error' => 4],
+            ['inbound' => 9, 'outbound' => 4],
             $this->thresholdProbe(['critical' => 3, 'inbound' => 9])->thresholds(),
         );
         $this->assertSame(
-            ['critical' => 9, 'error' => 4],
+            ['inbound' => 9, 'outbound' => 4],
             $this->thresholdProbe(['inbound' => 9, 'critical' => 3])->thresholds(),
         );
     }
 
     public function testOmittedThresholdsFallBackToDefaults(): void
     {
-        $this->assertSame(['critical' => 5, 'error' => 4], $this->thresholdProbe([])->thresholds());
-        $this->assertSame(['critical' => 9, 'error' => 4], $this->thresholdProbe(['inbound' => 9])->thresholds());
+        $this->assertSame(['inbound' => 5, 'outbound' => 4], $this->thresholdProbe([])->thresholds());
+        $this->assertSame(['inbound' => 9, 'outbound' => 4], $this->thresholdProbe(['inbound' => 9])->thresholds());
     }
 
     /**
@@ -192,7 +193,7 @@ class CrsTest extends AbstractTestCase
             'notice'   => 2,
         ]);
 
-        $this->assertSame(['critical' => 5, 'error' => 4], $plugin->thresholds());
+        $this->assertSame(['inbound' => 5, 'outbound' => 4], $plugin->thresholds());
         $this->assertTrue(
             $handler->hasRecordThatContains('CRS anomaly_thresholds keys are ignored', Level::Warning),
             'Keys the engine never reads must be reported, not silently accepted.',
@@ -222,7 +223,7 @@ class CrsTest extends AbstractTestCase
 
         $plugin = $this->thresholdProbe(['inbound' => 'high']);
 
-        $this->assertSame(['critical' => 5, 'error' => 4], $plugin->thresholds());
+        $this->assertSame(['inbound' => 5, 'outbound' => 4], $plugin->thresholds());
         $this->assertTrue(
             $handler->hasRecordThatContains('CRS anomaly threshold is not a number', Level::Warning),
         );
@@ -235,58 +236,78 @@ class CrsTest extends AbstractTestCase
 
         $plugin = $this->thresholdProbe(5);
 
-        $this->assertSame(['critical' => 5, 'error' => 4], $plugin->thresholds());
+        $this->assertSame(['inbound' => 5, 'outbound' => 4], $plugin->thresholds());
         $this->assertTrue(
             $handler->hasRecordThatContains('CRS anomaly_thresholds must be a mapping', Level::Warning),
         );
     }
 
     /**
-     * #93, the consequential half: a rule carrying a block / deny / drop
-     * action rejects on first match without consulting the score, so raising
-     * the threshold is not the false-positive lever it looks like. Pinning
-     * that here so the behaviour the README now describes cannot drift away
-     * from it silently.
+     * The inverse of what this test asserted against crs-engine 0.1.0, where
+     * the anomaly-evaluation rules could never fire and the threshold changed
+     * nothing. Since 1.0.0 the score governs: the same SQLi payload is
+     * rejected at the default threshold and allowed once the threshold is
+     * lifted above its score.
      */
-    public function testRaisingTheThresholdDoesNotDisarmBlockingRules(): void
+    public function testThresholdGovernsWhetherAPayloadIsRejected(): void
     {
-        foreach ([5, 50, 500] as $threshold) {
+        $payload = ['id' => "1' UNION SELECT 1,2,3--"];
+
+        $strict = new Crs([], ['paranoia' => 1, 'mode' => 'block', 'anomaly_thresholds' => ['inbound' => 5]]);
+        $this->assertTrue($strict->evaluate($this->request($payload)), 'SQLi must be rejected at the default threshold');
+
+        $lax = new Crs([], ['paranoia' => 1, 'mode' => 'block', 'anomaly_thresholds' => ['inbound' => 500]]);
+        $this->assertFalse($lax->evaluate($this->request($payload)), 'a threshold above the score must let it through');
+
+        // Same detections either way — only the verdict differs.
+        $this->assertSame($strict->getLastVerdict()->totalScore, $lax->getLastVerdict()->totalScore);
+    }
+
+    /**
+     * Monitor mode never rejects, whatever the score does.
+     */
+    public function testMonitorModeIgnoresTheThreshold(): void
+    {
+        foreach ([1, 100000] as $threshold) {
             $plugin = new Crs([], [
                 'paranoia' => 1,
-                'mode' => 'block',
+                'mode' => 'monitor',
                 'anomaly_thresholds' => ['inbound' => $threshold],
             ]);
 
-            $this->assertTrue(
+            $this->assertFalse(
                 $plugin->evaluate($this->request(['id' => "1' UNION SELECT 1,2,3--"])),
-                sprintf('SQLi is rejected on match, so threshold %d must change nothing', $threshold),
+                sprintf('monitor mode must not reject, threshold %d', $threshold),
             );
         }
     }
 
     /**
-     * Monitor mode does not rescue the threshold either: nothing blocks
-     * there, so both sides of the threshold comparison produce the same
-     * verdict.
-     *
-     * Together with the test above this pins the README's claim that the
-     * threshold is inert against the bundled rule set. If the engine ever
-     * routes blocking through the anomaly-evaluation rules (949110 / 959100)
-     * the way stock CRS does, these two tests fail — which is the signal to
-     * revisit that section, not to weaken the tests.
+     * An anomaly-score block is attributed to 949110, the CRS rule that
+     * compares the score to the threshold. Feeding that to `disabled_rules`
+     * would switch off anomaly blocking altogether, so the log has to carry
+     * the rules that actually detected something.
      */
-    public function testThresholdDoesNotChangeMonitorModeVerdicts(): void
+    public function testBlockLogNamesTheContributingRulesNotJust949110(): void
     {
-        $payload = ['q' => '/etc/passwd'];
+        $handler = new TestHandler(Level::Debug);
+        LoggingFactory::setLogger(new Logger('test', [$handler]));
 
-        $strict = new Crs([], ['paranoia' => 1, 'mode' => 'monitor', 'anomaly_thresholds' => ['inbound' => 1]]);
-        $lax    = new Crs([], ['paranoia' => 1, 'mode' => 'monitor', 'anomaly_thresholds' => ['inbound' => 100000]]);
+        $plugin = new Crs([], ['paranoia' => 1, 'mode' => 'block']);
+        $this->assertTrue($plugin->evaluate($this->request(['id' => "1' UNION SELECT 1,2,3--"])));
 
-        $strict->evaluate($this->request($payload));
-        $lax->evaluate($this->request($payload));
+        $this->assertSame(949110, $plugin->getLastVerdict()->blockingRuleId, 'guards the premise of this test');
 
-        $this->assertSame($strict->getLastVerdict()->action, $lax->getLastVerdict()->action);
-        $this->assertSame($strict->getLastVerdict()->totalScore, $lax->getLastVerdict()->totalScore);
+        $records = array_values(array_filter(
+            $handler->getRecords(),
+            static fn ($record): bool => str_contains((string) $record->message, 'CRS blocked request'),
+        ));
+        $this->assertCount(1, $records);
+
+        $contributing = $records[0]->context['contributing_rules'] ?? [];
+        $this->assertNotEmpty($contributing, 'the log must name the rules that detected the payload');
+        $this->assertNotContains(949110, $contributing, 'the blocking-evaluation rule is not a tuning target');
+        $this->assertContains(942190, $contributing);
     }
 
     /**

--- a/tests/Unit/Plugins/CrsTest.php
+++ b/tests/Unit/Plugins/CrsTest.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Kanopi\Firewall\Tests\Unit\Plugins;
 
+use Kanopi\Firewall\Logging\LoggingFactory;
 use Kanopi\Firewall\Plugins\Crs;
 use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use Monolog\Handler\TestHandler;
+use Monolog\Level;
+use Monolog\Logger;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -34,6 +38,17 @@ class CrsTest extends AbstractTestCase
         if (!is_file(__DIR__ . '/../../../vendor/kanopi/crs-engine/rules/compiled.php')) {
             $this->markTestSkipped('CRS engine rules not available — run `composer install` to pull them.');
         }
+    }
+
+    protected function tearDown(): void
+    {
+        // Reset the process-wide logger so a handler installed by one test
+        // does not collect records from the next.
+        $prop = (new \ReflectionClass(LoggingFactory::class))->getProperty('logger');
+        $prop->setAccessible(true);
+        $prop->setValue(null, null);
+
+        parent::tearDown();
     }
 
     public function testGetName(): void
@@ -122,6 +137,172 @@ class CrsTest extends AbstractTestCase
         ]);
         $request = $this->request(['id' => '1 UNION SELECT password FROM users']);
         $this->assertFalse($plugin->evaluate($request));
+    }
+
+    /**
+     * #93: the engine reads exactly two thresholds, keyed by CRS severity
+     * names that read as though there were one per severity. `inbound` and
+     * `outbound` are the honest names, and they map onto those two keys.
+     */
+    public function testCanonicalThresholdNamesMapToEngineKeys(): void
+    {
+        $plugin = $this->thresholdProbe(['inbound' => 9, 'outbound' => 7]);
+        $this->assertSame(['critical' => 9, 'error' => 7], $plugin->thresholds());
+    }
+
+    public function testLegacySeverityThresholdNamesStillWork(): void
+    {
+        $plugin = $this->thresholdProbe(['critical' => 9, 'error' => 7]);
+        $this->assertSame(['critical' => 9, 'error' => 7], $plugin->thresholds());
+    }
+
+    public function testCanonicalThresholdNameWinsOverLegacySpelling(): void
+    {
+        // Config migrated one key at a time must not depend on write order.
+        $this->assertSame(
+            ['critical' => 9, 'error' => 4],
+            $this->thresholdProbe(['critical' => 3, 'inbound' => 9])->thresholds(),
+        );
+        $this->assertSame(
+            ['critical' => 9, 'error' => 4],
+            $this->thresholdProbe(['inbound' => 9, 'critical' => 3])->thresholds(),
+        );
+    }
+
+    public function testOmittedThresholdsFallBackToDefaults(): void
+    {
+        $this->assertSame(['critical' => 5, 'error' => 4], $this->thresholdProbe([])->thresholds());
+        $this->assertSame(['critical' => 9, 'error' => 4], $this->thresholdProbe(['inbound' => 9])->thresholds());
+    }
+
+    /**
+     * #93: `warning` and `notice` were documented, accepted, and read
+     * nowhere. They are still accepted — dropping them would break existing
+     * config — but the plugin now says they do nothing.
+     */
+    public function testInertThresholdKeysAreIgnoredAndReported(): void
+    {
+        $handler = new TestHandler(Level::Debug);
+        LoggingFactory::setLogger(new Logger('test', [$handler]));
+
+        $plugin = $this->thresholdProbe([
+            'critical' => 5,
+            'error'    => 4,
+            'warning'  => 3,
+            'notice'   => 2,
+        ]);
+
+        $this->assertSame(['critical' => 5, 'error' => 4], $plugin->thresholds());
+        $this->assertTrue(
+            $handler->hasRecordThatContains('CRS anomaly_thresholds keys are ignored', Level::Warning),
+            'Keys the engine never reads must be reported, not silently accepted.',
+        );
+
+        $record = $handler->getRecords()[count($handler->getRecords()) - 1];
+        $this->assertSame(['warning', 'notice'], $record->context['ignored']);
+    }
+
+    public function testSupportedThresholdKeysAloneLogNoWarning(): void
+    {
+        $handler = new TestHandler(Level::Debug);
+        LoggingFactory::setLogger(new Logger('test', [$handler]));
+
+        $this->thresholdProbe(['inbound' => 5, 'outbound' => 4])->thresholds();
+
+        $this->assertFalse(
+            $handler->hasRecordThatContains('CRS anomaly_thresholds keys are ignored', Level::Warning),
+            'Config using only the supported keys must stay quiet.',
+        );
+    }
+
+    public function testNonNumericThresholdFallsBackToTheDefault(): void
+    {
+        $handler = new TestHandler(Level::Debug);
+        LoggingFactory::setLogger(new Logger('test', [$handler]));
+
+        $plugin = $this->thresholdProbe(['inbound' => 'high']);
+
+        $this->assertSame(['critical' => 5, 'error' => 4], $plugin->thresholds());
+        $this->assertTrue(
+            $handler->hasRecordThatContains('CRS anomaly threshold is not a number', Level::Warning),
+        );
+    }
+
+    public function testNonArrayThresholdsAreIgnoredAndReported(): void
+    {
+        $handler = new TestHandler(Level::Debug);
+        LoggingFactory::setLogger(new Logger('test', [$handler]));
+
+        $plugin = $this->thresholdProbe(5);
+
+        $this->assertSame(['critical' => 5, 'error' => 4], $plugin->thresholds());
+        $this->assertTrue(
+            $handler->hasRecordThatContains('CRS anomaly_thresholds must be a mapping', Level::Warning),
+        );
+    }
+
+    /**
+     * #93, the consequential half: a rule carrying a block / deny / drop
+     * action rejects on first match without consulting the score, so raising
+     * the threshold is not the false-positive lever it looks like. Pinning
+     * that here so the behaviour the README now describes cannot drift away
+     * from it silently.
+     */
+    public function testRaisingTheThresholdDoesNotDisarmBlockingRules(): void
+    {
+        foreach ([5, 50, 500] as $threshold) {
+            $plugin = new Crs([], [
+                'paranoia' => 1,
+                'mode' => 'block',
+                'anomaly_thresholds' => ['inbound' => $threshold],
+            ]);
+
+            $this->assertTrue(
+                $plugin->evaluate($this->request(['id' => "1' UNION SELECT 1,2,3--"])),
+                sprintf('SQLi is rejected on match, so threshold %d must change nothing', $threshold),
+            );
+        }
+    }
+
+    /**
+     * Monitor mode does not rescue the threshold either: nothing blocks
+     * there, so both sides of the threshold comparison produce the same
+     * verdict.
+     *
+     * Together with the test above this pins the README's claim that the
+     * threshold is inert against the bundled rule set. If the engine ever
+     * routes blocking through the anomaly-evaluation rules (949110 / 959100)
+     * the way stock CRS does, these two tests fail — which is the signal to
+     * revisit that section, not to weaken the tests.
+     */
+    public function testThresholdDoesNotChangeMonitorModeVerdicts(): void
+    {
+        $payload = ['q' => '/etc/passwd'];
+
+        $strict = new Crs([], ['paranoia' => 1, 'mode' => 'monitor', 'anomaly_thresholds' => ['inbound' => 1]]);
+        $lax    = new Crs([], ['paranoia' => 1, 'mode' => 'monitor', 'anomaly_thresholds' => ['inbound' => 100000]]);
+
+        $strict->evaluate($this->request($payload));
+        $lax->evaluate($this->request($payload));
+
+        $this->assertSame($strict->getLastVerdict()->action, $lax->getLastVerdict()->action);
+        $this->assertSame($strict->getLastVerdict()->totalScore, $lax->getLastVerdict()->totalScore);
+    }
+
+    /**
+     * Expose the normalised thresholds the plugin hands the engine.
+     */
+    private function thresholdProbe(mixed $configured): Crs
+    {
+        return new class ([], ['anomaly_thresholds' => $configured]) extends Crs {
+            /**
+             * @return array<string, int>
+             */
+            public function thresholds(): array
+            {
+                return $this->anomalyThresholds();
+            }
+        };
     }
 
     public function testSingleFileUploadIsAdaptedToEngineDto(): void


### PR DESCRIPTION
> ### Updated for `crs-engine` 1.0.0
>
> Since this PR was opened, 1.0.0 shipped and fixed the upstream defects described below — including the `inbound`/`outbound` rename this PR proposed downstream (crs-engine#14) and the dead anomaly-evaluation path (crs-engine#13, crs-engine#1). **The threshold now works.** The analysis below is preserved as the record of why #93 was filed and what 0.1.0 actually did; where it says the threshold is inert, that is history. See [What changed for 1.0.0](#what-changed-for-100) at the bottom for the current state of the branch.

Fixes #93.

## The issue is real

Verified against `kanopi/crs-engine` 0.1.0 as vendored:

- `anomaly_thresholds` accepts four keys and reads two. `critical` is the single **inbound** threshold, `error` the **outbound** one. `warning` and `notice` are read nowhere — `grep -rn anomalyThresholds src/` in the engine returns only the two lines in `CrsTxDefaults` and one in `RuleEvaluator`.
- The threshold is bypassed whenever a rule carrying a `block` / `deny` / `drop` action matches, because `RuleEvaluator` breaks on first such match and `decideAction()` returns `block` without consulting the score.

**It is worse than the issue reports.** The issue puts it at 59% of rules. Scanning the bundled compiled ruleset for rules that increment `tx.inbound_anomaly_score_pl*` — the only thing `totalScore()` sums:

```
block: 208
pass:    0
```

Every score-contributing rule carries a `block` action. So in block mode the first one short-circuits and the threshold is never compared; in monitor mode nothing blocks and both sides of the comparison return `log`. **The inbound threshold has no observable effect on any verdict with the shipped rule set.** Confirmed end to end:

```
block    t=5       action=block  score=5   rule=942190
block    t=50      action=block  score=5   rule=942190
block    t=500     action=block  score=5   rule=942190
monitor  t=1       action=log    score=10
monitor  t=100000  action=log    score=10
```

## What this PR changes

The engine lives in a separate package, so the rename lands at the plugin's config surface — which is what firewall users actually write.

**`src/Plugins/Crs.php`**
- Accept `inbound` / `outbound` and map them onto the engine's `critical` / `error`. Severity spellings stay accepted so existing config keeps working; the preferred spelling wins when both are present, so config migrated one key at a time behaves the same in either write order.
- Any other key — including the `warning` / `notice` our own README told people to write — logs a warning naming what it ignored and pointing at `disabled_rules`, instead of looking like it worked.
- A non-numeric threshold, or a non-mapping `anomaly_thresholds`, falls back to the default and says so rather than silently casting to `0` (which would have made the engine maximally strict).

**`README.md`** — new *Anomaly scores and thresholds* section: which two keys are read, that per-severity weights are fixed by CRS and not configurable, that the threshold is inert against the shipped rule set, and the four settings that actually do move a false positive (`disabled_rules`, `disabled_categories`, `paranoia`, `mode: monitor`).

**`example/config.notes.yml`** — same correction.

**`tests/Unit/Plugins/CrsTest.php`** — 10 new tests. Key mapping, precedence, defaults, the inert-key warning, non-numeric and non-mapping fallbacks, plus two that pin the inertness claim in block and monitor mode. If the engine ever routes blocking through the anomaly-evaluation rules (949110 / 959100) the way stock CRS does, those two fail — which is the signal to revisit the README section rather than weaken the tests.

## Root cause is upstream, and it is not a design choice

The issue frames the short-circuit as deliberate — "it mirrors ModSecurity's `deny` actions" rather than stock CRS. That is not what is happening. CRS's anomaly-evaluation rules **are** in the bundled set:

```
949111 action=deny op=ge arg=%{tx.inbound_anomaly_score_threshold}  target=BLOCKING_INBOUND_ANOMALY_SCORE
  chained 949110 ... same comparison, phase 2
959101 action=deny op=ge arg=%{tx.outbound_anomaly_score_threshold} target=BLOCKING_OUTBOUND_ANOMALY_SCORE
  chained 959100 ...
```

They can never fire. The aggregator rules that feed `TX.BLOCKING_INBOUND_ANOMALY_SCORE` (949052–949063) have their `setvar` values compiled to a literal `0`, and the flattening happens at parse time — `REQUEST-949-BLOCKING-EVALUATION.json` already carries `0`, before `compiled.php` is built:

```json
{ "id": 949052, "setvars": [ { "name": "tx.blocking_inbound_anomaly_score", "op": "+", "value": "0" } ] }
```

`crs-engine`'s parser inlines `%{tx.*}` macros at build time. That is correct for fixed seeds — `%{tx.critical_anomaly_score}` becomes `"5"`, as in 930120 — but wrong for the runtime accumulators `%{tx.inbound_anomaly_score_plN}`, which have no seed in `CrsTxDefaults` and resolve to zero. Across the shipped ruleset, **no compiled setvar retains a macro at all** and 32 increment by a literal `0`.

With its input pinned at `0`, the entire anomaly-evaluation path is dead and blocking falls back to per-rule `block` actions — exactly the symptom #93 reports. Note the threshold macro *is* preserved in the operator argument and resolved at runtime, so the moment the parser keeps those setvar macros, `anomaly_thresholds.inbound` goes live with no config change on this side. That is the argument for keeping the key rather than deprecating it.

## Not done here

The parser defect above is the real fix and belongs in `kanopi/crs-engine`. So do two of the issue's other suggestions: throwing `ConfigurationException` on unknown keys in `CrsConfig`, and making the per-severity score contributions (`tx.critical_anomaly_score` and friends) configurable. Nothing in this repo can address them — `crs-engine` currently has no issues filed; happy to open one with the reproduction above.

## Drive-by

Both stale since #91 inverted `Crs::evaluate()`, both in sections this PR was already editing:

- README's `getLastVerdict()` example said "evaluate() returns FALSE when CRS would block the request" and assigned it to `$allowed`.
- `config.notes.yml` described `mode: block` as "returns false from evaluate()".

## Verification

811 unit tests and 49 integration tests pass. PHPCS, PHPStan at level max, and Rector are clean.

---

## What changed for 1.0.0

Three things, none cosmetic. Verified against 1.0.0 in an isolated sandbox and a throwaway worktree before touching the working tree.

### It would not install

`"kanopi/crs-engine": "^0.1.0"` excludes 1.0.0 — `composer prohibits` confirms. Bumped to `^1.0`. Not worth supporting 0.1.0 alongside; the engine's own release notes call its detection pipeline "substantially inert".

### The shim emitted deprecated keys on every request

1.0.0 keys thresholds `inbound`/`outbound` and emits `E_USER_DEPRECATED` for the old severity spellings. This plugin's `anomalyThresholds()` normalised *to* `critical`/`error`, so it took the alias path — two deprecations per plugin instance, for **every** user, including those with no `anomaly_thresholds` config at all, since we always passed both keys explicitly. It now emits the canonical names:

```
config #0 []                          deprecations=0
config #1 {"inbound":7}               deprecations=0
config #2 {"critical":7}              deprecations=0
config #3 {"critical":7,"warning":3}  deprecations=0
```

Legacy config keeps working, and doing the translation here keeps the engine's deprecation out of the host application's logs.

### The threshold is now the lever, and the docs said the opposite

`testRaisingTheThresholdDoesNotDisarmBlockingRules` was written in this PR to fail when this got fixed. It did — the single failure across 811 unit + 49 integration tests run against 1.0.0:

```
inbound=5    matched=true   action=block  score=10  rule=949110
inbound=50   matched=false  action=log    score=10  rule=-
inbound=500  matched=false  action=log    score=10  rule=-
```

Replaced with its inverse: the same SQLi payload is rejected at threshold 5 and allowed at 500, same score either way. README, the class docblock and `config.notes.yml` rewritten accordingly.

### The sharpest edge, which the rename does not cover

Blocking now routes through CRS rule **949110**, so `rule_id` is 949110 on every anomaly-score block rather than the rule that caught the payload. The old README told operators to take `rule_id` and put it in `disabled_rules` — following that today disables anomaly blocking wholesale.

Added `contributing_rules` to the block and debug log lines (detections only, `blocking_evaluation` dropped) and repointed all tuning guidance at it. Also logging the new `CrsVerdict::$operatorErrors` / `$truncations`, at warning level even when nothing matched — a clean verdict over a partly-uninspected request is exactly where a coverage gap gets believed.

### Smaller items

- Category list gained `blocking_evaluation`, `response_leak`, `response_leak_ruby`. Documented, with `blocking_evaluation` flagged off-limits for `disabled_categories` for the same reason as 949110.
- The plugin stays more forgiving than the engine, now deliberately: 1.0.0 throws `ConfigurationException` on an unknown threshold key, this plugin drops it with a warning. A YAML typo should not take a site down. Stated in the docblock so it reads as a choice.
- Upgrade note added to the README. Traffic that passed under 0.1.0 will now be rejected, and CRS at PL1 flags some ordinary editorial content — a support ticket containing `cat /etc/hosts | grep` scores 15 and is rejected. Default stays `mode: block` with monitor-first rollout documented, rather than silently weakening an existing deployment's protection.

### Verification

812 unit + 49 integration tests pass. PHPCS, PHPStan at level max (`composer check:security`), and Rector clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
