### PR TITLE
Add an AbuseIPDB reputation plugin (Fixes #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   - [Rate Limit Plugin](#rate-limit-plugin)
   - [Vulnerability Score Plugin](#vulnerability-score-plugin)
   - [CRS (OWASP Core Rule Set) Plugin](#crs-owasp-core-rule-set-plugin)
+  - [AbuseIPDB Plugin](#abuseipdb-plugin)
 - [Conditional Logic](#conditional-logic)
 - [Logging Configuration](#logging-configuration)
   - [Sensitive Value Redaction](#sensitive-value-redaction)
@@ -47,6 +48,7 @@
 - **Multiple Storage Backends**: In-memory, file-based, and database storage for blocked clients, plus in-memory, file, database, PSR-6 cache, and Redis backends for rate-limit counters — or bring your own
 - **Comprehensive Request Analysis**: Evaluate requests based on IP, location, ASN, user agent, URL patterns, and more
 - **OWASP Core Rule Set**: Real CRS rules (SQLi, XSS, LFI/RFI, RCE, scanners) with tunable paranoia levels
+- **IP Reputation**: Turn away addresses reported to AbuseIPDB, cached to stay inside the free tier and failing open when the service is unreachable
 - **Vulnerability Scoring**: Advanced risk assessment based on multiple factors with configurable thresholds
 - **Rate Limiting**: Built-in rate limiting with configurable storage backends
 - **Challenge Responses**: Serve a proof-of-effort interstitial instead of a hard block, with HMAC-signed, IP-bound pass tokens
@@ -1971,6 +1973,86 @@ if ($verdict !== null) {
 ```
 
 This pairs naturally with `mode: monitor`, where the request is allowed through and you want to record what *would* have been blocked in more detail than the log line carries. `getLastVerdict()` returns `null` until `evaluate()` has run at least once on that instance.
+
+### AbuseIPDB Plugin
+
+**Namespace**: `\Kanopi\Firewall\Plugins\AbuseIpdb`
+
+Checks the client IP against [AbuseIPDB](https://www.abuseipdb.com/), which scores an address 0-100 by how confidently it has been reported for abuse. The plugin matches when that score reaches `threshold`, so a known-bad address can be turned away before the expensive rule-matching plugins run.
+
+Requires a free API key from [abuseipdb.com/account/api](https://www.abuseipdb.com/account/api). With no `api_key` the plugin is a no-op that matches nothing, so it is safe to add to a config before the key is provisioned.
+
+#### Configuration Example
+
+```yaml
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\AbuseIpdb"
+    response: block
+    # Cheaper than CRS, dearer than a static IP list — sit between them.
+    weight: 40
+    enable: true
+    config:
+      # Required. An %env()% token keeps the key out of the config file —
+      # see "Environment Variables in YAML" above.
+      api_key: "%env(ABUSEIPDB_API_KEY)%"
+      # Abuse confidence (0-100) at or above which the plugin matches.
+      threshold: 75
+      # How long a verdict is reused before asking again (seconds).
+      cache_ttl: 86400
+      # How long a *failed* lookup is remembered (seconds). See below.
+      error_cache_ttl: 300
+      # Seconds to wait on the API before giving up and allowing the request.
+      timeout: 2.0
+      # How far back AbuseIPDB should consider reports.
+      max_age_in_days: 30
+      # Where verdicts are cached. Defaults to the system temp directory,
+      # or KANOPI_FIREWALL_CACHE_DIR when that constant is defined.
+      # cache_dir: /var/cache/firewall
+      # HTTP status returned for blocked requests
+      block_status: 403
+      # How long the firewall remembers the offending IP (seconds)
+      block_duration: 3600
+```
+
+#### Choosing a threshold
+
+AbuseIPDB's confidence score is not a count of reports — it is a weighting of how many distinct reporters, how recently, and how reputable. 75 is the point AbuseIPDB's own guidance treats as strong enough to act on, and it is the default here.
+
+| Threshold | Effect |
+|---|---|
+| `100` | Only addresses AbuseIPDB is certain about. Very few false positives, catches less. |
+| `75` | The default. Corroborated reports from multiple reporters. |
+| `50` | More aggressive; starts catching addresses with a thinner report history. |
+| `25` and below | Not recommended. At this level the score largely reflects a handful of reports and will turn away real users on recycled residential IPs. |
+
+Addresses AbuseIPDB marks as whitelisted — search-engine crawlers and similar known-good infrastructure — never match, whatever their score.
+
+#### It fails open, deliberately
+
+A lookup that times out, is refused, or runs into a spent quota reports **no match**, logs at `warning` level, and lets evaluation continue to the next plugin. Nothing here blocks a request it could not get an answer for.
+
+That is a deliberate trade. Reputation is corroborating evidence, not the last line of defence, and a third-party outage should not become an outage on your site. If you need an address blocked regardless of whether AbuseIPDB is reachable, put it in the [IP Address plugin](#ip-address-plugin) — that is what a local blocklist is for.
+
+#### Quota and caching
+
+The free tier allows **1,000 checks per day**, which a modest site would exhaust before lunch if every request meant an API call. Two things keep it inside that budget:
+
+- **Verdicts are cached per address** for `cache_ttl`, 24 hours by default. Cost is roughly one call per unique visitor per day; repeat visitors and crawlers are free. Clean results are cached too — that is most of the saving.
+- **Private and reserved ranges are never looked up.** A local or intranet deployment spends no quota at all, and `127.0.0.1` in development costs nothing.
+
+Failures are cached as well, for the much shorter `error_cache_ttl` (5 minutes). Without that, a provider outage would make every single request wait out the full `timeout` before failing open — availability preserved on paper while the site crawls. Raise `error_cache_ttl` to be more patient during an outage, lower it to notice recovery sooner.
+
+If a site is large enough that unique visitors alone exceed the quota, put the plugin behind a cheaper filter so it only ever sees traffic that got past the static rules — see [Plugin Execution Order](#plugin-execution-order).
+
+#### What gets logged
+
+A match logs at `info` level with `ip`, `abuse_confidence_score`, `threshold`, `total_reports`, and `country_code`.
+
+A failed lookup logs at `warning` with `error`, `http_status`, and a note that the request was allowed through. Distinct causes are named rather than collapsed into one message — a rejected API key, an exhausted quota, and an unreachable endpoint need different responses from whoever reads the log.
+
+Skips (no API key, a non-routable address, a score under the threshold, a whitelisted address, a still-cached recent failure) log at `debug`.
+
+Cache entries are named by SHA-1 of the address rather than the address itself, so client IPs are not readable from a directory listing.
 
 ## Conditional Logic
 

--- a/example/config.notes.yml
+++ b/example/config.notes.yml
@@ -461,6 +461,62 @@ plugins:
         # run response-side evaluation. The legacy spelling 'error' works.
         outbound: 4
 
+  # AbuseIPDB reputation plugin. Scores the client IP 0-100 by how
+  # confidently it has been reported for abuse, and matches once that score
+  # reaches the threshold. Needs a free API key from
+  # https://www.abuseipdb.com/account/api — with no api_key the plugin
+  # matches nothing, so it is safe to leave configured but unkeyed.
+  - plugin: "Kanopi\\Firewall\\Plugins\\AbuseIpdb"
+    response: block
+    # One cached lookup per visitor per day, so cheaper than CRS but dearer
+    # than the static IP / UA / ASN filters. Sits between them.
+    weight: 40
+    enable: false
+    config:
+      # Required. Use an %env()% token rather than committing the key.
+      api_key: "%env(ABUSEIPDB_API_KEY)%"
+      # Abuse confidence (0-100) at or above which this plugin matches.
+      # 75 is AbuseIPDB's own "strong enough to act on" mark. Going below
+      # about 25 will turn away real users on recycled residential IPs.
+      threshold: 75
+      # How long a verdict is reused before asking again. The free tier
+      # allows 1,000 checks a day, and clean results are cached too, so this
+      # is what keeps a normal site inside the quota. Lower it only if you
+      # have the quota to spare.
+      cache_ttl: 86400
+      # How long a *failed* lookup is remembered. Without this every request
+      # during an outage would wait out the full timeout below before
+      # failing open — availability on paper, a crawl in practice. Raise to
+      # be more patient during an outage, lower to notice recovery sooner.
+      error_cache_ttl: 300
+      # Seconds to wait on the API before giving up. This sits in the
+      # request path, so the ceiling on added latency matters more than
+      # getting an answer.
+      timeout: 2.0
+      # How far back AbuseIPDB should consider reports.
+      max_age_in_days: 30
+      # Where verdicts are cached. Defaults to the system temp directory, or
+      # KANOPI_FIREWALL_CACHE_DIR when that constant is defined. Entries are
+      # named by hash, so client IPs are not readable from a listing.
+      # cache_dir: /var/cache/firewall
+      # HTTP status returned for blocked requests.
+      block_status: 403
+      # How long the firewall keeps the offending IP on its blocklist.
+      block_duration: 3600
+      #
+      # Two behaviours with no config key, worth knowing:
+      #
+      # This plugin fails open. A timeout, a refused key or a spent quota
+      # reports no match, logs at warning level, and lets the request
+      # continue. Reputation is corroborating evidence, not the last line of
+      # defence — put addresses you want blocked unconditionally in the
+      # IpAddress plugin instead.
+      #
+      # Private and reserved ranges are never looked up, so a local or
+      # intranet deployment spends no quota, and addresses AbuseIPDB marks
+      # as whitelisted (search-engine crawlers and the like) never match
+      # however high they score.
+
 # Loggers help log data in specific formats. Uses Monolog (https://seldaek.github.io/monolog/)
 # Multiple loggers can be added as the following are structured but added as arrays under the logger section.
 logger:

--- a/src/Plugins/AbuseIpdb.php
+++ b/src/Plugins/AbuseIpdb.php
@@ -1,0 +1,612 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kanopi\Firewall\Plugins;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Check the client IP's reputation against AbuseIPDB.
+ *
+ * AbuseIPDB scores an address 0-100 by how confidently it has been reported
+ * for abuse. This plugin matches when that confidence reaches `threshold`,
+ * so with `response: block` a known-bad address is rejected before the
+ * expensive rule-matching plugins ever run.
+ *
+ * Three behaviours are worth knowing before enabling it.
+ *
+ * **It fails open.** A lookup that times out, is refused, or runs into a spent
+ * quota reports no match, logs at warning level, and lets evaluation continue.
+ * Reputation is corroborating evidence, not the last line of defence — a
+ * third-party outage must not become an outage here. Nothing in this plugin
+ * blocks a request it could not get an answer for.
+ *
+ * **It is cached, because the quota is small.** The free tier allows 1,000
+ * checks a day, which a modest site would burn through before lunch if every
+ * request meant a call. Verdicts are cached per address for `cache_ttl`
+ * (24h by default), so cost is one call per unique visitor per day; repeat
+ * visitors and crawlers are free. Failures are cached too, for a much shorter
+ * `error_cache_ttl` — without that, a provider outage would make every request
+ * pay the full `timeout`, which is a site slowdown dressed up as failing open.
+ *
+ * **It never calls the API for an address that cannot be in the database.**
+ * Private and reserved ranges are skipped, so a local or intranet deployment
+ * spends no quota at all.
+ *
+ * Addresses AbuseIPDB marks as whitelisted — search-engine crawlers and
+ * similar known-good infrastructure — never match, whatever their score.
+ *
+ * Requires an API key from https://www.abuseipdb.com/account/api. With no
+ * `api_key` the plugin is a no-op that matches nothing, so adding it to a
+ * config before the key is provisioned is safe.
+ */
+class AbuseIpdb extends AbstractPluginBase
+{
+    /**
+     * AbuseIPDB v2 single-address check endpoint.
+     */
+    protected const ENDPOINT = 'https://api.abuseipdb.com/api/v2/check';
+
+    /**
+     * Confidence score at or above which the plugin matches.
+     *
+     * AbuseIPDB's own guidance treats 75 as the point where a report set is
+     * strong enough to act on. Below roughly 25 the score mostly reflects a
+     * handful of reports and is not worth blocking over.
+     */
+    protected const DEFAULT_THRESHOLD = 75;
+
+    /**
+     * How long a successful verdict stays cached, in seconds.
+     */
+    protected const DEFAULT_CACHE_TTL = 86400;
+
+    /**
+     * How long a failed lookup stays cached, in seconds.
+     *
+     * Deliberately short: long enough to stop an outage costing every request
+     * a full timeout, short enough that recovery is picked up promptly.
+     */
+    protected const DEFAULT_ERROR_CACHE_TTL = 300;
+
+    /**
+     * Seconds to wait on the API before giving up.
+     *
+     * This sits in the request path, so the ceiling on added latency matters
+     * more than getting an answer.
+     */
+    protected const DEFAULT_TIMEOUT = 2.0;
+
+    /**
+     * How far back AbuseIPDB should consider reports, in days.
+     */
+    protected const DEFAULT_MAX_AGE_IN_DAYS = 30;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'AbuseIPDB';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription(): string
+    {
+        return 'Check the client IP address reputation against AbuseIPDB and match when its abuse confidence reaches the configured threshold';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function evaluate(Request $request): bool
+    {
+        $apiKey = $this->apiKey();
+        if ($apiKey === null) {
+            // Not configured — the plugin is inert. Returning TRUE here would
+            // block every request for someone who added the plugin before
+            // provisioning a key.
+            $this->getLogger()->debug('AbuseIPDB evaluation skipped - no api_key configured', $this->getContext($request));
+            return false;
+        }
+
+        $ip = $request->getClientIp();
+        if ($ip === null || $ip === '') {
+            $this->getLogger()->debug('AbuseIPDB evaluation skipped - no client IP on the request', $this->getContext($request));
+            return false;
+        }
+
+        if (!$this->isPubliclyRoutable($ip)) {
+            // Private and reserved space is never in the database. Calling for
+            // it would spend quota to be told nothing.
+            $this->getLogger()->debug('AbuseIPDB evaluation skipped - client IP is not publicly routable', $this->getContext($request, [
+                'ip' => $ip,
+            ]));
+            return false;
+        }
+
+        $report = $this->lookup($ip, $apiKey, $request);
+        if ($report === null) {
+            // Already logged at warning level by the lookup. Fail open.
+            return false;
+        }
+
+        if ($report['is_whitelisted']) {
+            $this->getLogger()->debug('AbuseIPDB reports the client IP as whitelisted - not matching', $this->getContext($request, [
+                'ip'                     => $ip,
+                'abuse_confidence_score' => $report['abuse_confidence_score'],
+            ]));
+            return false;
+        }
+
+        $threshold = $this->threshold();
+
+        // TRUE means "this plugin matched", not "allow the request" — the
+        // PluginManager applies the entry's `response:` when we return TRUE.
+        // See PluginInterface::evaluate().
+        if ($report['abuse_confidence_score'] >= $threshold) {
+            $this->getLogger()->info('AbuseIPDB matched a reported IP address', $this->getContext($request, [
+                'ip'                     => $ip,
+                'abuse_confidence_score' => $report['abuse_confidence_score'],
+                'threshold'              => $threshold,
+                'total_reports'          => $report['total_reports'],
+                'country_code'           => $report['country_code'],
+            ]));
+            return true;
+        }
+
+        $this->getLogger()->debug('AbuseIPDB score is under the threshold', $this->getContext($request, [
+            'ip'                     => $ip,
+            'abuse_confidence_score' => $report['abuse_confidence_score'],
+            'threshold'              => $threshold,
+        ]));
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStatusCode(?Request $request = null): int
+    {
+        return (int) ($this->config['block_status'] ?? 403);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExpirationTime(?Request $request = null): int
+    {
+        return (int) ($this->config['block_duration'] ?? 3600);
+    }
+
+    /**
+     * Resolve an address to a reputation report, cache first.
+     *
+     * @param string $ip
+     *   The address to check. Assumed publicly routable.
+     * @param string $apiKey
+     *   AbuseIPDB API key.
+     * @param Request $request
+     *   The request under evaluation, for log context.
+     *
+     * @return array{abuse_confidence_score: int, is_whitelisted: bool, total_reports: int, country_code: string}|null
+     *   The report, or NULL when no answer could be obtained — in which case a
+     *   warning has already been logged and the caller must fail open.
+     */
+    protected function lookup(string $ip, string $apiKey, Request $request): ?array
+    {
+        $cached = $this->readCache($ip);
+
+        if ($cached !== null && isset($cached['error'])) {
+            // A recent failure, still inside error_cache_ttl. Report it at
+            // debug rather than warning — the warning was written when the
+            // lookup actually failed, and repeating it once per request for
+            // the whole window would bury everything else.
+            $this->getLogger()->debug('AbuseIPDB lookup skipped - a recent lookup failed and is still cached', $this->getContext($request, [
+                'ip'    => $ip,
+                'error' => $cached['error'],
+            ]));
+            return null;
+        }
+
+        if ($cached !== null) {
+            // Anything still cached and not a failure is a usable verdict.
+            return $cached['report'];
+        }
+
+        $result = $this->fetch($ip, $apiKey);
+
+        if (isset($result['error'])) {
+            $this->getLogger()->warning('AbuseIPDB lookup failed - allowing the request through', $this->getContext($request, [
+                'ip'          => $ip,
+                'error'       => $result['error'],
+                'http_status' => $result['http_status'],
+                'hint'        => 'Reputation is advisory here: the request proceeds to the next plugin. Check the API key and the daily quota.',
+            ]));
+            $this->writeCache($ip, ['error' => $result['error'], 'http_status' => $result['http_status']]);
+            return null;
+        }
+
+        $this->writeCache($ip, ['report' => $result['report']]);
+
+        return $result['report'];
+    }
+
+    /**
+     * Call AbuseIPDB for a single address.
+     *
+     * Uses the stream wrapper rather than an HTTP client library, matching the
+     * one other place this package fetches over the network
+     * (`Config::fileGetContents()`), and keeping a security library's
+     * dependency surface unchanged. `ignore_errors` is on so a 4xx body can be
+     * read for its status rather than surfacing as an opaque failure.
+     *
+     * @param string $ip
+     *   The address to check.
+     * @param string $apiKey
+     *   AbuseIPDB API key.
+     *
+     * @return array{report: array{abuse_confidence_score: int, is_whitelisted: bool, total_reports: int, country_code: string}, error?: null, http_status?: null}|array{error: string, http_status: int|null, report?: null}
+     *   Either a report or a described failure.
+     */
+    protected function fetch(string $ip, string $apiKey): array
+    {
+        $url = self::ENDPOINT . '?' . http_build_query([
+            'ipAddress'     => $ip,
+            'maxAgeInDays'  => $this->maxAgeInDays(),
+        ]);
+
+        $context = stream_context_create([
+            'http' => [
+                'method'        => 'GET',
+                'timeout'       => $this->timeout(),
+                'ignore_errors' => true,
+                'header'        => [
+                    'Key: ' . $apiKey,
+                    'Accept: application/json',
+                ],
+            ],
+        ]);
+
+        $handle = @fopen($url, 'r', false, $context);
+        if ($handle === false) {
+            return ['error' => 'could not reach the AbuseIPDB API', 'http_status' => null];
+        }
+
+        $metadata = stream_get_meta_data($handle);
+        $body = stream_get_contents($handle);
+        fclose($handle);
+
+        /** @var array<int, string> $headers */
+        $headers = is_array($metadata['wrapper_data'] ?? null) ? $metadata['wrapper_data'] : [];
+        $status = $this->statusFromHeaders($headers);
+
+        if ($status !== 200) {
+            return ['error' => $this->describeStatus($status), 'http_status' => $status];
+        }
+
+        if ($body === false || $body === '') {
+            return ['error' => 'the AbuseIPDB API returned an empty body', 'http_status' => $status];
+        }
+
+        $decoded = json_decode($body, true);
+        if (!is_array($decoded) || !isset($decoded['data']) || !is_array($decoded['data'])) {
+            return ['error' => 'the AbuseIPDB API returned a body that is not a check result', 'http_status' => $status];
+        }
+
+        $data = $decoded['data'];
+
+        return [
+            'report' => [
+                'abuse_confidence_score' => (int) ($data['abuseConfidenceScore'] ?? 0),
+                'is_whitelisted'         => (bool) ($data['isWhitelisted'] ?? false),
+                'total_reports'          => (int) ($data['totalReports'] ?? 0),
+                'country_code'           => (string) ($data['countryCode'] ?? ''),
+            ],
+        ];
+    }
+
+    /**
+     * Read a cached entry for an address, if one is present and still fresh.
+     *
+     * Successful verdicts and failures have different lifetimes, so which TTL
+     * applies depends on what was stored.
+     *
+     * @param string $ip
+     *   The address to read.
+     *
+     * @return array{report: array{abuse_confidence_score: int, is_whitelisted: bool, total_reports: int, country_code: string}}|array{error: string, http_status: int|null}|null
+     *   The entry, or NULL on a miss, an expired entry, or an unreadable one.
+     */
+    protected function readCache(string $ip): ?array
+    {
+        $path = $this->cachePath($ip);
+        if ($path === null || !is_file($path)) {
+            return null;
+        }
+
+        $contents = @file_get_contents($path);
+        if ($contents === false) {
+            return null;
+        }
+
+        $entry = json_decode($contents, true);
+        if (!is_array($entry)) {
+            // Truncated or hand-edited. Treat it as a miss and let the next
+            // successful fetch overwrite it.
+            return null;
+        }
+
+        $age = time() - (int) @filemtime($path);
+
+        if (isset($entry['error'])) {
+            if ($age >= $this->errorCacheTtl()) {
+                return null;
+            }
+
+            return [
+                'error'       => (string) $entry['error'],
+                'http_status' => isset($entry['http_status']) ? (int) $entry['http_status'] : null,
+            ];
+        }
+
+        if ($age >= $this->cacheTtl() || !isset($entry['report']) || !is_array($entry['report'])) {
+            return null;
+        }
+
+        $report = $entry['report'];
+
+        return [
+            'report' => [
+                'abuse_confidence_score' => (int) ($report['abuse_confidence_score'] ?? 0),
+                'is_whitelisted'         => (bool) ($report['is_whitelisted'] ?? false),
+                'total_reports'          => (int) ($report['total_reports'] ?? 0),
+                'country_code'           => (string) ($report['country_code'] ?? ''),
+            ],
+        ];
+    }
+
+    /**
+     * Store an entry for an address.
+     *
+     * A cache that cannot be written is not fatal — it costs quota, not
+     * correctness — so this reports the problem and returns.
+     *
+     * @param string $ip
+     *   The address the entry describes.
+     * @param array<string, mixed> $entry
+     *   Either `['report' => [...]]` or `['error' => string, 'http_status' => ?int]`.
+     */
+    protected function writeCache(string $ip, array $entry): void
+    {
+        $path = $this->cachePath($ip);
+        if ($path === null) {
+            return;
+        }
+
+        $encoded = json_encode($entry);
+        if ($encoded === false) {
+            return;
+        }
+
+        if (@file_put_contents($path, $encoded, LOCK_EX) === false) {
+            $this->getLogger()->warning('AbuseIPDB could not write its cache - every request will spend quota', [
+                'plugin' => $this->getName(),
+                'path'   => $path,
+                'hint'   => 'Point cache_dir at a writable directory. The free tier allows 1,000 checks a day.',
+            ]);
+        }
+    }
+
+    /**
+     * Absolute path of the cache entry for an address.
+     *
+     * The address is hashed rather than used directly: it keeps client IPs out
+     * of directory listings, and guarantees a filesystem-safe name for IPv6.
+     *
+     * @param string $ip
+     *   The address to derive a path for.
+     *
+     * @return string|null
+     *   The path, or NULL when the cache directory could not be created.
+     */
+    protected function cachePath(string $ip): ?string
+    {
+        $directory = rtrim($this->cacheDir(), '/');
+
+        if (!is_dir($directory) && !@mkdir($directory, 0775, true) && !is_dir($directory)) {
+            $this->getLogger()->warning('AbuseIPDB cache directory could not be created - every request will spend quota', [
+                'plugin' => $this->getName(),
+                'path'   => $directory,
+            ]);
+            return null;
+        }
+
+        return $directory . '/abuseipdb-' . sha1($ip) . '.json';
+    }
+
+    /**
+     * Whether an address is one AbuseIPDB could plausibly have a report for.
+     *
+     * @param string $ip
+     *   The address to test.
+     */
+    protected function isPubliclyRoutable(string $ip): bool
+    {
+        return filter_var(
+            $ip,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+        ) !== false;
+    }
+
+    /**
+     * Turn an HTTP status into something an operator can act on.
+     *
+     * @param int|null $status
+     *   The status code, or NULL when none could be parsed.
+     */
+    protected function describeStatus(?int $status): string
+    {
+        return match ($status) {
+            401 => 'AbuseIPDB rejected the API key',
+            422 => 'AbuseIPDB rejected the address as invalid',
+            429 => 'AbuseIPDB daily quota is exhausted',
+            null => 'the AbuseIPDB API returned no parseable status',
+            default => 'the AbuseIPDB API returned HTTP ' . $status,
+        };
+    }
+
+    /**
+     * Extract the status code from stream wrapper headers.
+     *
+     * @param array<int, string> $headers
+     *   Raw response header lines, status line first.
+     *
+     * @return int|null
+     *   The code, or NULL when the status line could not be parsed.
+     */
+    protected function statusFromHeaders(array $headers): ?int
+    {
+        foreach ($headers as $header) {
+            if (preg_match('#^HTTP/\S+\s+(\d{3})#', $header, $matches) === 1) {
+                return (int) $matches[1];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The configured API key, or NULL when the plugin is unconfigured.
+     */
+    protected function apiKey(): ?string
+    {
+        $key = $this->config['api_key'] ?? null;
+
+        if (!is_string($key) || trim($key) === '') {
+            return null;
+        }
+
+        return trim($key);
+    }
+
+    /**
+     * Confidence score at or above which the plugin matches.
+     */
+    protected function threshold(): int
+    {
+        return $this->intConfig('threshold', self::DEFAULT_THRESHOLD);
+    }
+
+    /**
+     * Lifetime of a cached verdict, in seconds.
+     */
+    protected function cacheTtl(): int
+    {
+        return $this->intConfig('cache_ttl', self::DEFAULT_CACHE_TTL);
+    }
+
+    /**
+     * Lifetime of a cached failure, in seconds.
+     */
+    protected function errorCacheTtl(): int
+    {
+        return $this->intConfig('error_cache_ttl', self::DEFAULT_ERROR_CACHE_TTL);
+    }
+
+    /**
+     * How far back AbuseIPDB should consider reports, in days.
+     */
+    protected function maxAgeInDays(): int
+    {
+        return $this->intConfig('max_age_in_days', self::DEFAULT_MAX_AGE_IN_DAYS);
+    }
+
+    /**
+     * Seconds to wait on the API before giving up.
+     */
+    protected function timeout(): float
+    {
+        $configured = $this->config['timeout'] ?? null;
+
+        if ($configured === null) {
+            return self::DEFAULT_TIMEOUT;
+        }
+
+        if (!is_numeric($configured)) {
+            $this->getLogger()->warning('AbuseIPDB timeout is not a number - using the default', [
+                'plugin'  => $this->getName(),
+                'given'   => get_debug_type($configured),
+                'default' => self::DEFAULT_TIMEOUT,
+            ]);
+            return self::DEFAULT_TIMEOUT;
+        }
+
+        return (float) $configured;
+    }
+
+    /**
+     * Directory holding cached verdicts.
+     *
+     * Follows `Config`'s convention so a deployment that already sets
+     * KANOPI_FIREWALL_CACHE_DIR does not have to say it twice, with an
+     * explicit `cache_dir` winning when present.
+     */
+    protected function cacheDir(): string
+    {
+        $configured = $this->config['cache_dir'] ?? null;
+
+        if (is_string($configured) && trim($configured) !== '') {
+            return trim($configured);
+        }
+
+        if (defined('KANOPI_FIREWALL_CACHE_DIR')) {
+            return (string) constant('KANOPI_FIREWALL_CACHE_DIR');
+        }
+
+        return sys_get_temp_dir() . '/kanopi-firewall-abuseipdb';
+    }
+
+    /**
+     * Read an integer config value, warning rather than silently coercing.
+     *
+     * Deliberately forgiving: a typo in a YAML file should degrade this plugin
+     * to its default, not take a site down.
+     *
+     * @param string $key
+     *   Config key to read.
+     * @param int $default
+     *   Value to use when the key is absent or unusable.
+     */
+    protected function intConfig(string $key, int $default): int
+    {
+        $configured = $this->config[$key] ?? null;
+
+        if ($configured === null) {
+            return $default;
+        }
+
+        if (!is_numeric($configured)) {
+            $this->getLogger()->warning('AbuseIPDB ' . $key . ' is not a number - using the default', [
+                'plugin'  => $this->getName(),
+                'given'   => get_debug_type($configured),
+                'default' => $default,
+            ]);
+            return $default;
+        }
+
+        return (int) $configured;
+    }
+}

--- a/tests/Unit/Plugins/AbuseIpdbTest.php
+++ b/tests/Unit/Plugins/AbuseIpdbTest.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Plugins;
+
+use Kanopi\Firewall\Plugins\AbuseIpdb;
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Tests for the AbuseIPDB reputation plugin.
+ *
+ * The network call is the one thing these tests replace: `fetch()` is
+ * overridden by a double that returns scripted results and counts how often it
+ * was asked. Everything else — the threshold comparison, the cache, the
+ * fail-open path, the routable-address check — is the shipped code.
+ *
+ * Call counting is load-bearing rather than incidental. The free tier allows
+ * 1,000 checks a day, so "how many times did this call the API" is a
+ * correctness property of the plugin, not an optimisation detail.
+ */
+class AbuseIpdbTest extends AbstractTestCase
+{
+    /**
+     * Per-test cache directory, removed on tear-down.
+     */
+    private string $cacheDir;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cacheDir = sys_get_temp_dir() . '/abuseipdb-test-' . bin2hex(random_bytes(6));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        foreach ((array) glob($this->cacheDir . '/*') as $file) {
+            @unlink((string) $file);
+        }
+        @rmdir($this->cacheDir);
+
+        parent::tearDown();
+    }
+
+    public function testMissingApiKeyMatchesNothingAndCallsNoApi(): void
+    {
+        $plugin = $this->plugin(['api_key' => null, 'threshold' => 75], [self::report(100)]);
+
+        $this->assertFalse(
+            $plugin->evaluate($this->getRequest('203.0.113.5')),
+            'With no api_key the plugin must be inert. Matching here would block every request for someone who added the plugin before provisioning a key.',
+        );
+        $this->assertSame(0, $plugin->fetchCount, 'An unconfigured plugin must not call the API.');
+    }
+
+    public function testPrivateAddressIsNotLookedUp(): void
+    {
+        $plugin = $this->plugin([], [self::report(100)]);
+
+        $this->assertFalse($plugin->evaluate($this->getRequest('10.0.0.5')));
+        $this->assertSame(0, $plugin->fetchCount, 'Private space cannot be in AbuseIPDB — looking it up spends quota to learn nothing.');
+    }
+
+    public function testReservedAddressIsNotLookedUp(): void
+    {
+        $plugin = $this->plugin([], [self::report(100)]);
+
+        $this->assertFalse($plugin->evaluate($this->getRequest('127.0.0.1')));
+        $this->assertSame(0, $plugin->fetchCount);
+    }
+
+    public function testScoreAtTheThresholdMatches(): void
+    {
+        $plugin = $this->plugin(['threshold' => 75], [self::report(75)]);
+
+        $this->assertTrue(
+            $plugin->evaluate($this->getRequest('203.0.113.5')),
+            'The threshold is inclusive — a score equal to it must match.',
+        );
+    }
+
+    public function testScoreOneUnderTheThresholdDoesNotMatch(): void
+    {
+        $plugin = $this->plugin(['threshold' => 75], [self::report(74)]);
+
+        $this->assertFalse($plugin->evaluate($this->getRequest('203.0.113.5')));
+    }
+
+    public function testWhitelistedAddressNeverMatchesEvenAtFullConfidence(): void
+    {
+        $plugin = $this->plugin(['threshold' => 75], [self::report(100, true)]);
+
+        $this->assertFalse(
+            $plugin->evaluate($this->getRequest('203.0.113.5')),
+            'AbuseIPDB whitelists known-good infrastructure such as search-engine crawlers. Blocking one because it also carries reports would take out legitimate traffic.',
+        );
+    }
+
+    public function testLookupFailureAllowsTheRequestThrough(): void
+    {
+        $plugin = $this->plugin([], [self::failure('AbuseIPDB daily quota is exhausted', 429)]);
+
+        $this->assertFalse(
+            $plugin->evaluate($this->getRequest('203.0.113.5')),
+            'The plugin fails open: a spent quota or an outage must not become a block.',
+        );
+    }
+
+    public function testVerdictIsCachedSoRepeatVisitsCostNoQuota(): void
+    {
+        $plugin = $this->plugin(['threshold' => 75], [self::report(100)]);
+        $request = $this->getRequest('203.0.113.5');
+
+        $this->assertTrue($plugin->evaluate($request));
+        $this->assertTrue($plugin->evaluate($request), 'The cached verdict must produce the same decision.');
+        $this->assertSame(1, $plugin->fetchCount, 'A second request from the same address must be served from cache.');
+    }
+
+    public function testDifferentAddressesEachCostOneLookup(): void
+    {
+        $plugin = $this->plugin(['threshold' => 75], [self::report(100), self::report(0)]);
+
+        $this->assertTrue($plugin->evaluate($this->getRequest('203.0.113.5')));
+        $this->assertFalse($plugin->evaluate($this->getRequest('203.0.113.6')));
+        $this->assertSame(2, $plugin->fetchCount, 'The cache is keyed per address, so a new address is a new lookup.');
+    }
+
+    public function testExpiredVerdictIsRefetched(): void
+    {
+        $plugin = $this->plugin(['cache_ttl' => 0, 'threshold' => 75], [self::report(100), self::report(0)]);
+
+        $this->assertTrue($plugin->evaluate($this->getRequest('203.0.113.5')));
+        $this->assertFalse(
+            $plugin->evaluate($this->getRequest('203.0.113.5')),
+            'With the TTL expired the second call must consult the API again and use its fresher answer.',
+        );
+        $this->assertSame(2, $plugin->fetchCount);
+    }
+
+    public function testFailureIsCachedSoAnOutageDoesNotCostEveryRequestATimeout(): void
+    {
+        $plugin = $this->plugin(
+            ['threshold' => 75],
+            [self::failure('could not reach the AbuseIPDB API', null), self::report(100)],
+        );
+        $request = $this->getRequest('203.0.113.5');
+
+        $this->assertFalse($plugin->evaluate($request));
+        $this->assertFalse($plugin->evaluate($request));
+        $this->assertSame(
+            1,
+            $plugin->fetchCount,
+            'A failure must be remembered briefly. Retrying on every request would make each one wait the full timeout, which is a slowdown wearing fail-open as a disguise.',
+        );
+    }
+
+    public function testCachedFailureExpiresSoRecoveryIsPickedUp(): void
+    {
+        $plugin = $this->plugin(
+            ['error_cache_ttl' => 0, 'threshold' => 75],
+            [self::failure('could not reach the AbuseIPDB API', null), self::report(100)],
+        );
+        $request = $this->getRequest('203.0.113.5');
+
+        $this->assertFalse($plugin->evaluate($request));
+        $this->assertTrue(
+            $plugin->evaluate($request),
+            'Once the short failure window lapses the plugin must try again rather than staying blind.',
+        );
+        $this->assertSame(2, $plugin->fetchCount);
+    }
+
+    public function testCorruptCacheEntryIsRefetchedRatherThanTrusted(): void
+    {
+        $plugin = $this->plugin(['threshold' => 75], [self::report(100)]);
+        $path = $plugin->exposedCachePath('203.0.113.5');
+
+        $this->assertNotNull($path);
+        file_put_contents((string) $path, '{ this is not json');
+
+        $this->assertTrue(
+            $plugin->evaluate($this->getRequest('203.0.113.5')),
+            'A truncated or hand-edited entry must count as a miss, not as a clean verdict.',
+        );
+        $this->assertSame(1, $plugin->fetchCount);
+    }
+
+    public function testCacheFileNameDoesNotContainTheAddress(): void
+    {
+        $plugin = $this->plugin([], []);
+        $path = (string) $plugin->exposedCachePath('203.0.113.5');
+
+        $this->assertStringNotContainsString('203.0.113.5', $path, 'Client addresses should not be readable from a directory listing.');
+        $this->assertStringContainsString(sha1('203.0.113.5'), $path);
+    }
+
+    public function testNonNumericThresholdFallsBackToTheDefault(): void
+    {
+        $plugin = $this->plugin(['threshold' => 'very high'], [self::report(80)]);
+
+        $this->assertTrue(
+            $plugin->evaluate($this->getRequest('203.0.113.5')),
+            'An unusable threshold must degrade to the documented default of 75, not disable the plugin or block everything.',
+        );
+    }
+
+    public function testBlockStatusAndDurationAreConfigurable(): void
+    {
+        $plugin = $this->plugin(['block_status' => 429, 'block_duration' => 60], []);
+
+        $this->assertSame(429, $plugin->getStatusCode());
+        $this->assertSame(60, $plugin->getExpirationTime());
+    }
+
+    public function testBlockStatusAndDurationHaveDefaults(): void
+    {
+        $plugin = $this->plugin([], []);
+
+        $this->assertSame(403, $plugin->getStatusCode());
+        $this->assertSame(3600, $plugin->getExpirationTime());
+    }
+
+    public function testStatusLineIsParsedFromWrapperHeaders(): void
+    {
+        $plugin = $this->plugin([], []);
+
+        $this->assertSame(200, $plugin->exposedStatusFromHeaders(['HTTP/1.1 200 OK', 'Content-Type: application/json']));
+        $this->assertSame(429, $plugin->exposedStatusFromHeaders(['HTTP/2 429 Too Many Requests']));
+        $this->assertNull($plugin->exposedStatusFromHeaders(['Content-Type: application/json']));
+        $this->assertNull($plugin->exposedStatusFromHeaders([]));
+    }
+
+    public function testFailuresAreDescribedInTermsAnOperatorCanActOn(): void
+    {
+        $plugin = $this->plugin([], []);
+
+        $this->assertStringContainsString('API key', $plugin->exposedDescribeStatus(401));
+        $this->assertStringContainsString('quota', $plugin->exposedDescribeStatus(429));
+        $this->assertStringContainsString('invalid', $plugin->exposedDescribeStatus(422));
+        $this->assertStringContainsString('503', $plugin->exposedDescribeStatus(503));
+        $this->assertStringContainsString('no parseable status', $plugin->exposedDescribeStatus(null));
+    }
+
+    public function testNameAndDescriptionAreReported(): void
+    {
+        $plugin = $this->plugin([], []);
+
+        $this->assertSame('AbuseIPDB', $plugin->getName());
+        $this->assertStringContainsString('AbuseIPDB', $plugin->getDescription());
+    }
+
+    /**
+     * A successful scripted fetch result.
+     *
+     * @return array<string, mixed>
+     */
+    private static function report(int $score, bool $whitelisted = false): array
+    {
+        return ['report' => [
+            'abuse_confidence_score' => $score,
+            'is_whitelisted'         => $whitelisted,
+            'total_reports'          => $score > 0 ? 7 : 0,
+            'country_code'           => 'RU',
+        ]];
+    }
+
+    /**
+     * A failed scripted fetch result.
+     *
+     * @return array<string, mixed>
+     */
+    private static function failure(string $error, ?int $status): array
+    {
+        return ['error' => $error, 'http_status' => $status];
+    }
+
+    /**
+     * Build the plugin with the network replaced by scripted results.
+     *
+     * `api_key` defaults to a placeholder because most cases want a configured
+     * plugin; the unconfigured case omits it explicitly.
+     *
+     * @param array<string, mixed> $config
+     *   Plugin config. `cache_dir` is filled in with this test's directory.
+     * @param array<int, array<string, mixed>> $fetchResults
+     *   Results to return from successive fetch() calls, in order.
+     */
+    private function plugin(array $config, array $fetchResults): AbuseIpdb
+    {
+        $config['cache_dir'] ??= $this->cacheDir;
+
+        // Most cases want a configured plugin. Pass an explicit
+        // `'api_key' => null` to exercise the unconfigured path.
+        if (!array_key_exists('api_key', $config)) {
+            $config['api_key'] = 'test-key';
+        }
+
+        return new class ([], $config, $fetchResults) extends AbuseIpdb {
+            /**
+             * How many times the API was called.
+             */
+            public int $fetchCount = 0;
+
+            /**
+             * Remaining scripted results.
+             *
+             * @var array<int, array<string, mixed>>
+             */
+            private array $scripted;
+
+            /**
+             * @param array<int|string, mixed> $metadata
+             * @param array<int|string, mixed> $config
+             * @param array<int, array<string, mixed>> $scripted
+             */
+            public function __construct(array $metadata, array $config, array $scripted)
+            {
+                parent::__construct($metadata, $config);
+                $this->scripted = $scripted;
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            protected function fetch(string $ip, string $apiKey): array
+            {
+                $this->fetchCount++;
+
+                $next = array_shift($this->scripted);
+                if ($next === null) {
+                    return ['error' => 'the test scripted no further results', 'http_status' => null];
+                }
+
+                /** @phpstan-ignore-next-line — scripted shape is asserted by the test that supplies it. */
+                return $next;
+            }
+
+            /**
+             * Expose cachePath() for assertions.
+             */
+            public function exposedCachePath(string $ip): ?string
+            {
+                return $this->cachePath($ip);
+            }
+
+            /**
+             * Expose statusFromHeaders() for assertions.
+             *
+             * @param array<int, string> $headers
+             */
+            public function exposedStatusFromHeaders(array $headers): ?int
+            {
+                return $this->statusFromHeaders($headers);
+            }
+
+            /**
+             * Expose describeStatus() for assertions.
+             */
+            public function exposedDescribeStatus(?int $status): string
+            {
+                return $this->describeStatus($status);
+            }
+        };
+    }
+}

--- a/tests/Unit/Plugins/PluginPolarityTest.php
+++ b/tests/Unit/Plugins/PluginPolarityTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanopi\Firewall\Tests\Unit\Plugins;
 
+use Kanopi\Firewall\Plugins\AbuseIpdb;
 use Kanopi\Firewall\Plugins\Crs;
 use Kanopi\Firewall\Plugins\IpAddress;
 use Kanopi\Firewall\Plugins\PluginInterface;
@@ -38,6 +39,16 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class PluginPolarityTest extends AbstractTestCase
 {
+    /**
+     * Address the AbuseIPDB case pre-scores above the threshold.
+     */
+    private const ABUSEIPDB_REPORTED_IP = '203.0.113.66';
+
+    /**
+     * Address the AbuseIPDB case pre-scores at zero.
+     */
+    private const ABUSEIPDB_CLEAN_IP = '203.0.113.77';
+
     /**
      * @return array<string, array{callable(): PluginInterface, callable(): Request, callable(): Request}>
      */
@@ -96,7 +107,52 @@ class PluginPolarityTest extends AbstractTestCase
                 fn (): Request => self::browserRequest('/?id=1 UNION SELECT password FROM users'),
                 fn (): Request => self::browserRequest('/?q=hello world'),
             ],
+            // Seeded through the cache rather than a stubbed subclass, so this
+            // exercises the shipped class and never touches the network: one
+            // address pre-scored above the threshold, one below.
+            'AbuseIpdb' => [
+                fn (): PluginInterface => new AbuseIpdb([], [
+                    'api_key'   => 'polarity-test-key',
+                    'threshold' => 75,
+                    'cache_dir' => self::seedAbuseIpdbCache(),
+                ]),
+                fn (): Request => self::browserRequest('/', ['REMOTE_ADDR' => self::ABUSEIPDB_REPORTED_IP]),
+                fn (): Request => self::browserRequest('/', ['REMOTE_ADDR' => self::ABUSEIPDB_CLEAN_IP]),
+            ],
         ];
+    }
+
+    /**
+     * Write the two AbuseIPDB cache entries the polarity case relies on.
+     *
+     * @return string
+     *   The cache directory to hand the plugin.
+     */
+    private static function seedAbuseIpdbCache(): string
+    {
+        $directory = sys_get_temp_dir() . '/abuseipdb-polarity';
+        if (!is_dir($directory)) {
+            mkdir($directory, 0775, true);
+        }
+
+        $entries = [
+            self::ABUSEIPDB_REPORTED_IP => 100,
+            self::ABUSEIPDB_CLEAN_IP    => 0,
+        ];
+
+        foreach ($entries as $ip => $score) {
+            file_put_contents(
+                $directory . '/abuseipdb-' . sha1((string) $ip) . '.json',
+                (string) json_encode(['report' => [
+                    'abuse_confidence_score' => $score,
+                    'is_whitelisted'         => false,
+                    'total_reports'          => $score > 0 ? 42 : 0,
+                    'country_code'           => 'RU',
+                ]]),
+            );
+        }
+
+        return $directory;
     }
 
     /**


### PR DESCRIPTION
## Description

Adds a `AbuseIpdb` plugin that checks the client IP against [AbuseIPDB](https://www.abuseipdb.com/), which scores an address 0-100 by how confidently it has been reported for abuse. The plugin matches once that score reaches `threshold`, so with `response: block` a known-bad address is turned away for the cost of one cached lookup — before CRS spends 3-4 ms on rule matching.

Closes #16, which asked for "a service like AbuseIPDB or something similar". Shipped as a single concrete plugin rather than a provider abstraction; a second provider can be added later without disturbing this one.

## Three decisions worth reviewing

**It fails open.** A timeout, a refused key, or a spent quota reports **no match**, logs at `warning`, and lets evaluation continue. Reputation is corroborating evidence, not the last line of defence — a third-party outage must not become an outage here. Addresses that should be blocked regardless belong in the `IpAddress` plugin, and the README says so rather than leaving it implied.

**It is cached, because the quota is the real constraint.** The free tier allows 1,000 checks/day; a modest site would exhaust that before lunch if every request meant a call.

| Mechanism | Effect |
|---|---|
| Verdicts cached per address for `cache_ttl` (24h), clean results included | ~1 call per unique visitor per day |
| Private / reserved ranges never looked up | Local and intranet deployments spend zero quota |
| Failures cached for `error_cache_ttl` (5 min) | An outage doesn't cost every request a full `timeout` |

That last row is the non-obvious half of "fails open". Without it, availability is preserved on paper while the site crawls through a 2 s timeout on every request. It has its own test.

**Whitelisted addresses never match**, whatever they score. AbuseIPDB flags search-engine crawlers and similar known-good infrastructure, which also accumulate reports; blocking one would take out legitimate traffic.

## Safety properties

- **Unconfigured, it matches nothing.** No `api_key` means the plugin is inert, so adding it to a config before the key is provisioned cannot block anything.
- **Bad config degrades to documented defaults** with a warning naming the offending key — following the `Crs` precedent that a typo in a YAML file should not take a site down.
- **Cache entries are named by SHA-1 of the address**, so client IPs aren't readable from a directory listing.

## Implementation notes

Uses the stream wrapper rather than Guzzle, matching the one other place this package fetches over the network (`Config::fileGetContents()`) and leaving a security library's dependency surface unchanged. `ignore_errors` is on so a 4xx body can be read for its status instead of surfacing as an opaque failure — that's what lets a rejected key, an exhausted quota, and an unreachable endpoint be reported as three different things.

`fetch()` is the single network seam, which is what keeps the suite hermetic.

## Testing

- **22 new unit tests.** Call counts are asserted throughout: "how many times did this hit the API" is a correctness property here, not an optimisation detail. The cache, the failure cache, the routable-address skip, and the unconfigured no-op are each verified by fetch count rather than by trusting the code path.
- **`PluginPolarityTest` row seeded through the real cache**, not a stubbed subclass — so the contract test from #91 exercises the shipped class with no network: one address pre-scored at 100, one at 0. This also satisfies `testEveryShippedPluginIsCovered`, which fails the build for a new plugin with no polarity case.
- Boundary covered explicitly: score 75 against threshold 75 matches (inclusive), 74 does not.
- 834 unit and 49 integration tests pass. PHPCS, PHPStan at level max, and Rector clean.

The 2 reported deprecations are a pre-existing `ReflectionProperty::setValue()` call in `LoggingFactoryTest`, unrelated to this change.

## Documentation

README gains an "AbuseIPDB Plugin" section covering threshold choice (with a table on what each level actually costs you), the fail-open trade, the quota arithmetic, and what lands in the log at which level. `example/config.notes.yml` gains the annotated entry.

Both use `%env(ABUSEIPDB_API_KEY)%`. Worth flagging: I first wrote `${ABUSEIPDB_API_KEY}` and verified against `TokenSubstitute` that it does **not** resolve — `%env(NAME)%` is the supported syntax, confirmed resolving through nested plugin config.

## Follow-up

Docs here target `README.md`, which is the doc surface on `2.x`. Once #90 merges and moves that content to the MkDocs site, this section needs porting to `docs/plugins/abuseipdb.md` plus a `nav:` entry — happy to do that as a small follow-up in whichever order you land the two.

## Breaking Changes

None. New opt-in plugin; no existing class or config key changes behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)