### PR TITLE
Deploy the docs artifact with ghp-import, not mkdocs gh-deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,18 +342,25 @@ jobs:
             gh pr comment --body-file /tmp/docs-preview.md
 
   # Publish the reviewed build to the gh-pages branch, which GitHub Pages
-  # serves at https://kanopi.github.io/firewall/. Deploys exactly the artifact
-  # docs-build produced (`--no-build`) rather than rebuilding, so what ships is
-  # what CI checked.
+  # serves at https://kanopi.github.io/firewall/. Deploys exactly the site/
+  # directory docs-build produced and attached to the workspace, rather than
+  # rebuilding, so what ships is what CI checked.
   #
   # Runs only on a stable release tag — see the workflow filters below. The
   # published site therefore describes the last release, not the current tip of
   # 2.x.
   #
-  # `mkdocs gh-deploy` hands the built site/ directory to ghp-import, which
-  # commits it to the gh-pages branch and pushes. That branch holds rendered
-  # HTML only, no source, and is created on the first successful deploy — there
-  # is nothing to set up beforehand beyond pointing Pages at it.
+  # Calls ghp-import directly rather than going through `mkdocs gh-deploy`.
+  # gh-deploy always builds first — it has no flag to skip that — so it would
+  # discard the reviewed artifact and rebuild from source in this job. ghp-import
+  # is the tool gh-deploy wraps, invoked with the same arguments it passes
+  # (including --no-jekyll, without which Pages' Jekyll pass drops files whose
+  # names begin with an underscore).
+  #
+  # ghp-import commits the directory to the gh-pages branch and pushes. That
+  # branch holds rendered HTML only, no source, and is created on the first
+  # successful deploy — there is nothing to set up beforehand beyond pointing
+  # Pages at it.
   docs-deploy:
     docker:
       - image: cimg/python:3.12
@@ -388,14 +395,24 @@ jobs:
             # so a git failure cannot echo the token back into the build log.
             git remote set-url origin \
               "https://x-access-token:${TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
+            # Deploying an empty or missing site/ would replace the live docs
+            # with nothing, so fail loudly instead.
+            if [[ ! -f site/index.html ]]; then
+              echo "site/index.html is missing — the docs-build workspace did not attach."
+              echo "Nothing was deployed; gh-pages still holds the previous release."
+              exit 1
+            fi
             # `[ci skip]` keeps the gh-pages commit from triggering a build of
             # its own. The tag goes in the message so gh-pages history reads as
             # a list of releases rather than of SHAs.
-            mkdocs gh-deploy \
-              --no-build \
+            ghp-import \
+              --no-jekyll \
+              --push \
               --force \
-              --remote-name origin \
-              --message "docs: deploy ${CIRCLE_TAG:-${CIRCLE_SHA1:0:7}} [ci skip]"
+              --branch gh-pages \
+              --remote origin \
+              --message "docs: deploy ${CIRCLE_TAG:-${CIRCLE_SHA1:0:7}} [ci skip]" \
+              site
 
 workflows:
   test:

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -278,7 +278,12 @@ release, so a reader can trust it matches the version they installed. The
 tradeoff is that a merged documentation fix is not visible publicly until the
 next release goes out. Until then, the PR artifact is the way to read it.
 
-Mechanically, the `docs deploy` job hands the built site to `mkdocs gh-deploy`,
-which commits the rendered HTML to the `gh-pages` branch and pushes it. GitHub
-Pages serves that branch. Nothing on `2.x` changes — `gh-pages` holds only
-built output, never source.
+Mechanically, the `docs deploy` job hands the site that `docs-build` already
+produced to `ghp-import`, which commits the rendered HTML to the `gh-pages`
+branch and pushes it. GitHub Pages serves that branch. Nothing on `2.x` changes
+— `gh-pages` holds only built output, never source.
+
+It deliberately does not use `mkdocs gh-deploy`: that command always builds
+first, so it would throw away the artifact a reviewer approved and rebuild from
+source inside the deploy job. `ghp-import` is what `gh-deploy` calls underneath,
+so the published result is the same minus the rebuild.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,6 +10,10 @@
 # pymdown-extensions is held below 11 on purpose: mkdocs-material declares
 # `pymdown-extensions~=10.2`, and 11.x installs over that without complaint
 # only to fail at render time.
+#
+# ghp-import arrives as an mkdocs dependency, but the docs deploy job calls it
+# directly, so it is listed and pinned here rather than left to whatever mkdocs
+# happens to resolve.
 
 mkdocs==1.6.1
 mkdocs-material==9.7.7
@@ -17,3 +21,4 @@ mkdocs-glightbox==0.5.2
 mkdocs-minify-plugin==0.8.0
 pymdown-extensions==10.21.3
 Pygments==2.20.0
+ghp-import==2.1.0


### PR DESCRIPTION
## What

The `v2.9.0` tag build failed at `docs deploy`:

```
Usage: mkdocs gh-deploy [OPTIONS]
Try 'mkdocs gh-deploy -h' for help.

Error: No such option: --no-build
```

`mkdocs gh-deploy` has no `--no-build` flag — not in the pinned 1.6.1, and not in any release. `gh-deploy` always builds first, so the intent the flag was reaching for (deploy exactly the artifact `docs-build` produced, so what ships is what CI checked) was never expressible through that command. The job could only ever have died in argument parsing.

## How

Call `ghp-import` directly. It is the tool `gh-deploy` wraps — `mkdocs/commands/gh_deploy.py` hands it the built directory — so the published result is identical, minus the rebuild:

```yaml
ghp-import \
  --no-jekyll \
  --push \
  --force \
  --branch gh-pages \
  --remote origin \
  --message "docs: deploy ${CIRCLE_TAG:-${CIRCLE_SHA1:0:7}} [ci skip]" \
  site
```

- `--no-jekyll` is not optional. `gh-deploy` passes it, and without it Pages' Jekyll pass drops files whose names begin with an underscore.
- `gh-pages` / `origin` are stated explicitly rather than left to defaults, since `mkdocs.yml` sets neither `remote_branch` nor `remote_name`.
- Added a `site/index.html` guard ahead of it. `ghp-import` will commit whatever directory it is handed, so a workspace that failed to attach would replace the live site with an empty tree — a blank page rather than a failed build.
- Pinned `ghp-import==2.1.0` in `docs/requirements.txt`. It arrives as an mkdocs dependency, but a job invoking it directly should not rely on transitive resolution.
- Corrected the job comment and `docs/contributing/documentation.md`, both of which described the old mechanism and a flag that does not exist.

## Verification

- `circleci config validate` passes.
- The exact `ghp-import` invocation was run against a throwaway repo (minus `--push`): produced a `gh-pages` commit containing `.nojekyll` plus the site contents, with the expected commit message.
- Then run for real to publish 2.9.0 (see below): `gh-pages` created at `d7650a4`, 102 files including `.nojekyll`, and <https://kanopi.github.io/firewall/> serves HTTP 200.
- PATH is not a concern — the failing log shows `mkdocs` itself resolving from the same `pip install --user` prefix that `ghp-import` installs into.
- No PHP code touched, so the test suite is unaffected.

## Note on v2.9.0

`gh-pages` did not exist before this, so the documentation site had never published. The 2.9.0 docs have now been deployed manually from this branch's content, using the exact command above, and GitHub Pages is serving them from `gh-pages` at the root.

The `v2.9.0` tag points at `950fa0d`, which still carries the broken config, so re-running that tag's workflow will fail the same way. Once this merges, CI deploys correctly from the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)