### PR TITLE
Let operators assert there is no proxy (Fixes #99)

### DIFF
--- a/docs/configuration/global.md
+++ b/docs/configuration/global.md
@@ -8,6 +8,7 @@ global:
   mode: block
   banning_status_code: 429
   banning_message: '{{request.id}} Request Banned'
+  behind_proxy: false
   require_trusted_proxies: false
   require_config: false
   blocking_escalation:
@@ -26,12 +27,48 @@ global:
 
 ## Trusted Proxies
 
-`require_trusted_proxies` controls how `Firewall::create()` reacts when `Symfony\Component\HttpFoundation\Request::getTrustedProxies()` is empty:
+Every plugin reads `$request->getClientIp()`, and Symfony only honours proxy headers (`X-Forwarded-For`, `Forwarded`, …) once you have called `Request::setTrustedProxies(...)`. If the application sits behind a proxy and you have not, a client can spoof its source IP and walk past IP allowlists and per-IP rate limits.
+
+The library cannot detect whether a proxy is actually in front of it, so two settings cover the two separate questions.
+
+### `behind_proxy` — asserting the deployment fact
 
 | Value | Behaviour |
 |-------|-----------|
-| `false` (default) | Logs a `warning` and continues. Suitable for development or when the application is reachable only directly. |
+| unset (default) | The posture is unknown. Logs a `warning` when trusted proxies are empty, on every request, because the question is unresolved. |
+| `false` | Asserted: nothing sits in front of this deployment. The check is skipped silently — there is no proxy to spoof a forwarding header through. |
+| `true` | Asserted: there *is* a proxy. Empty trusted proxies is then a definite misconfiguration rather than an open question, so it is logged at `error` instead of `warning`. |
+
+`behind_proxy: false` is the supported way to silence the warning on a site with nothing in front of it:
+
+```yaml
+global:
+  behind_proxy: false
+```
+
+A value that is not interpretable as a boolean — including `behind_proxy:` with nothing after it, or an `%env()%` token that resolves to an empty string — is treated as *unknown* rather than as `false`, and still warns. Silencing a security warning because a key was left half-written is the wrong direction to fail in.
+
+### `require_trusted_proxies` — how loud the unresolved cases are
+
+| Value | Behaviour |
+|-------|-----------|
+| `false` (default) | Log only, at the level `behind_proxy` selects above. |
 | `true` | Throws `Kanopi\Firewall\Exception\ConfigurationException` and refuses to start. Recommended for production deployments behind a load balancer / CDN / reverse proxy. |
+
+`behind_proxy: false` wins over `require_trusted_proxies: true`. An explicit assertion that there is no proxy makes the requirement moot, and throwing anyway would leave an operator who told the truth about their deployment with no way to start.
+
+The two combine to cover the realistic postures:
+
+```yaml
+# No proxy. Silent.
+global:
+  behind_proxy: false
+
+# Behind a CDN, and a missing setTrustedProxies() should fail the deploy.
+global:
+  behind_proxy: true
+  require_trusted_proxies: true
+```
 
 See the trusted-proxies note in [Basic Implementation](../getting-started/quick-start.md#basic-implementation) for the `Request::setTrustedProxies(...)` call you need to add before `Firewall::create()`.
 

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -142,6 +142,14 @@ final class Firewall
             isset($config['global']) && is_array($config['global']) ? $config['global'] : []
         );
 
+        // Same reason, and the same trap: `behind_proxy: false` is the whole
+        // point of the setting (#99), and array_filter() would strip it as a
+        // falsy value before checkTrustedProxiesPosture() ever saw it —
+        // leaving "asserted: no proxy" indistinguishable from "never said".
+        $behindProxy = self::behindProxy(
+            isset($config['global']) && is_array($config['global']) ? $config['global'] : []
+        );
+
         // Set the default values.
         $config['logger'] = isset($config['logger']) && is_array($config['logger']) ? array_filter($config['logger']) : [];
         $config['storage'] = isset($config['storage']) && is_array($config['storage']) ? array_filter($config['storage']) : [];
@@ -163,13 +171,22 @@ final class Firewall
         //
         // We can't detect "is there actually a proxy in front of me?" — that's
         // deployment-specific. What we can do is surface that the firewall is
-        // currently trusting whatever Symfony does by default. Operators who
-        // know they're not behind a proxy can silence the warning with
-        // `global.require_trusted_proxies: false` (the default). Operators
-        // who know they *are* behind a proxy should set it to `true` and
-        // configure `Request::setTrustedProxies(...)` — startup will then
-        // throw a clear error if the wiring is missing.
-        self::checkTrustedProxiesPosture($config['global']);
+        // currently trusting whatever Symfony does by default, and let the
+        // operator assert the fact we cannot observe:
+        //
+        //   * `global.behind_proxy: false` — asserted: nothing in front of this
+        //     deployment. The check is skipped silently.
+        //   * `global.behind_proxy: true` — asserted: there IS a proxy, so a
+        //     missing `Request::setTrustedProxies(...)` is a definite
+        //     misconfiguration and is logged at `error`.
+        //   * unset — the posture is genuinely unknown, so warn and continue.
+        //     This one still fires per request, deliberately: it is an
+        //     unresolved security question, and it is now resolvable from
+        //     config rather than something an operator has to live with.
+        //
+        // `global.require_trusted_proxies: true` escalates whichever of those
+        // applies into a startup `ConfigurationException`.
+        self::checkTrustedProxiesPosture($config['global'], $behindProxy);
 
         // Normalize configuration to the new plugins: array format.
         $config = PluginConfigNormalizer::normalize($config);
@@ -369,6 +386,45 @@ final class Firewall
     }
 
     /**
+     * Resolve `global.behind_proxy` into the operator's asserted posture.
+     *
+     * Must be called on the raw global config, before `create()` runs
+     * `array_filter()` over it — see the call site.
+     *
+     * Accepts the boolean-ish strings `filter_var()` understands ("false",
+     * "0", "no", "off" and their true counterparts) so a value arriving from
+     * an `%env()%` token or a quoted YAML scalar behaves like a real boolean.
+     *
+     * @param array<string, mixed> $globalConfig
+     *   The `global` config section, unfiltered.
+     *
+     * @return bool|null
+     *   TRUE or FALSE when the operator asserted a posture, NULL when the key
+     *   is absent or its value is not interpretable as a boolean. NULL means
+     *   "unknown", which warns — failing safe, because silencing a security
+     *   warning is the dangerous direction to guess in.
+     */
+    private static function behindProxy(array $globalConfig): ?bool
+    {
+        if (!array_key_exists('behind_proxy', $globalConfig)) {
+            return null;
+        }
+
+        $value = $globalConfig['behind_proxy'];
+
+        // `behind_proxy:` with nothing after it parses to NULL, and an
+        // `%env()%` token resolving to an unset variable gives ''. filter_var()
+        // reads both as FALSE, which would silence a security warning because
+        // someone left a key half-written. Neither is an assertion, so treat
+        // them as "unknown" and let the warning stand.
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+    }
+
+    /**
      * Detect and warn (or fail) on a missing trusted-proxies posture.
      *
      * If `Request::getTrustedProxies()` returns an empty list, the firewall
@@ -379,37 +435,86 @@ final class Firewall
      * default could change that. Log a warning so operators behind a proxy
      * see the misconfiguration in their normal log channel.
      *
-     * Behaviour switches on `global.require_trusted_proxies`:
-     *   * `false` / unset (default) — warn only.
+     * Two settings interact, because they answer two different questions.
+     *
+     * `global.behind_proxy` states a fact about the deployment that the
+     * library cannot observe for itself (#99):
+     *   * `false` — asserted: no proxy in front of this deployment. Nothing
+     *     can spoof a forwarding header past a proxy that does not exist, so
+     *     the check returns silently. This is the only way to stop the
+     *     warning without lying to `Request::setTrustedProxies()`.
+     *   * `true` — asserted: there IS a proxy. Missing trusted proxies is
+     *     then a definite misconfiguration rather than an open question, so
+     *     it is logged at `error` instead of `warning`.
+     *   * unset — unknown. Warn, as 2.x always has.
+     *
+     * `global.require_trusted_proxies` decides how loud the unresolved cases
+     * are, and is unchanged from 2.x:
+     *   * `false` / unset (default) — log only.
      *   * `true` — throw `ConfigurationException` at startup so a missing
      *     trusted-proxies setup is a hard failure in production.
      *
+     * `behind_proxy: false` wins over `require_trusted_proxies: true`: an
+     * explicit assertion that there is no proxy makes the requirement moot,
+     * and throwing anyway would leave the operator with no way to run.
+     *
      * @param array<string, mixed> $globalConfig
      *   The `global` config section.
+     * @param bool|null $behindProxy
+     *   The operator's asserted posture, resolved by `behindProxy()` from the
+     *   unfiltered config. NULL when they did not say.
      *
      * @throws ConfigurationException
-     *   When `require_trusted_proxies` is true and no trusted proxies
-     *   have been configured before `Firewall::create()` runs.
+     *   When `require_trusted_proxies` is true, no trusted proxies have been
+     *   configured before `Firewall::create()` runs, and `behind_proxy` has
+     *   not asserted that there is no proxy.
      */
-    protected static function checkTrustedProxiesPosture(array $globalConfig): void
+    protected static function checkTrustedProxiesPosture(array $globalConfig, ?bool $behindProxy = null): void
     {
         if (Request::getTrustedProxies() !== []) {
             return;
         }
 
+        // Asserted "there is no proxy": nothing to spoof through, so there is
+        // nothing to report. Checked before `require_trusted_proxies` on
+        // purpose — see the docblock.
+        if ($behindProxy === false) {
+            return;
+        }
+
         $require = !empty($globalConfig['require_trusted_proxies']);
+
         $message = 'Symfony Request::getTrustedProxies() is empty. If this '
             . 'application sits behind a proxy / load balancer, the firewall '
             . 'cannot trust the client IP and IP-based block / allow / rate-'
             . 'limit rules can be bypassed via X-Forwarded-For. Call '
             . 'Request::setTrustedProxies(...) before Firewall::create() with '
-            . 'the proxy CIDRs and the header bitmask you trust. Set '
+            . 'the proxy CIDRs and the header bitmask you trust. If nothing '
+            . 'is in front of this deployment, set global.behind_proxy=false '
+            . 'to assert that and silence this message. Set '
             . 'global.require_trusted_proxies=true to make this a fatal '
             . 'startup error.';
+
+        if ($behindProxy === true) {
+            $message = 'global.behind_proxy is true but Symfony '
+                . 'Request::getTrustedProxies() is empty, so the firewall '
+                . 'cannot trust the client IP behind the proxy you have '
+                . 'declared: IP-based block / allow / rate-limit rules can be '
+                . 'bypassed via X-Forwarded-For. Call '
+                . 'Request::setTrustedProxies(...) before Firewall::create() '
+                . 'with the proxy CIDRs and the header bitmask you trust.';
+        }
 
         if ($require) {
             LoggingFactory::logger()->error($message);
             throw new ConfigurationException($message);
+        }
+
+        // An asserted-but-unwired proxy is a known defect, not an open
+        // question, so it earns `error` rather than `warning`.
+        if ($behindProxy === true) {
+            LoggingFactory::logger()->error($message);
+            return;
         }
 
         LoggingFactory::logger()->warning($message);

--- a/tests/Unit/FirewallTest.php
+++ b/tests/Unit/FirewallTest.php
@@ -16,6 +16,7 @@ use Kanopi\Firewall\Storage\FileStorage;
 use Kanopi\Firewall\Storage\InMemoryStorage;
 use Kanopi\Firewall\Storage\StorageInterface;
 use Kanopi\Firewall\Tests\Logging\TestLogHandler;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -834,6 +835,222 @@ class FirewallTest extends AbstractTestCase
         } finally {
             Request::setTrustedProxies($previous, $previousHeaderSet);
         }
+    }
+
+    /**
+     * Regression for #99: `global.behind_proxy: false` asserts the fact the
+     * library cannot observe — that nothing sits in front of this deployment
+     * — and silences the check entirely.
+     *
+     * Before this existed there was no such setting. `create()` runs per
+     * request, so a site with no proxy logged an unsilenceable warning on
+     * 100% of requests, and the only escape was passing
+     * `Request::setTrustedProxies()` a value that was not true.
+     */
+    public function testCreateIsSilentWhenBehindProxyAssertedFalse(): void
+    {
+        $previous = Request::getTrustedProxies();
+        $previousHeaderSet = Request::getTrustedHeaderSet();
+        Request::setTrustedProxies([], 0);
+
+        try {
+            $handler = $this->captureLogger();
+            Firewall::create([
+                [
+                    'logger' => [['class' => $handler]],
+                    'global' => ['behind_proxy' => false],
+                ],
+            ]);
+
+            $this->assertFalse(
+                $handler->hasWarningContaining('getTrustedProxies() is empty'),
+                'behind_proxy: false must silence the trusted-proxies warning.'
+            );
+            $this->assertFalse(
+                $handler->hasErrorContaining('getTrustedProxies() is empty'),
+                'behind_proxy: false must not downgrade to an error either.'
+            );
+        } finally {
+            Request::setTrustedProxies($previous, $previousHeaderSet);
+        }
+    }
+
+    /**
+     * Regression for #99: an explicit "there is no proxy" assertion wins over
+     * `require_trusted_proxies: true`.
+     *
+     * Throwing anyway would leave an operator who has told the truth about
+     * their deployment with no way to start the firewall at all.
+     */
+    public function testBehindProxyFalseOverridesRequireTrustedProxies(): void
+    {
+        $previous = Request::getTrustedProxies();
+        $previousHeaderSet = Request::getTrustedHeaderSet();
+        Request::setTrustedProxies([], 0);
+
+        try {
+            $firewall = Firewall::create([
+                [
+                    'global' => [
+                        'behind_proxy' => false,
+                        'require_trusted_proxies' => true,
+                    ],
+                ],
+            ]);
+
+            $this->assertInstanceOf(
+                Firewall::class,
+                $firewall,
+                'behind_proxy: false should make require_trusted_proxies moot, not fatal.'
+            );
+        } finally {
+            Request::setTrustedProxies($previous, $previousHeaderSet);
+        }
+    }
+
+    /**
+     * Regression for #99: asserting `behind_proxy: true` without wiring
+     * `Request::setTrustedProxies()` is a definite misconfiguration rather
+     * than an open question, so it is logged at `error` — but it still does
+     * not throw unless `require_trusted_proxies` says so.
+     */
+    public function testCreateLogsErrorWhenBehindProxyAssertedButUnwired(): void
+    {
+        $previous = Request::getTrustedProxies();
+        $previousHeaderSet = Request::getTrustedHeaderSet();
+        Request::setTrustedProxies([], 0);
+
+        try {
+            $handler = $this->captureLogger();
+            Firewall::create([
+                [
+                    'logger' => [['class' => $handler]],
+                    'global' => ['behind_proxy' => true],
+                ],
+            ]);
+
+            $this->assertTrue(
+                $handler->hasErrorContaining('global.behind_proxy is true'),
+                'An asserted-but-unwired proxy should be reported at error level.'
+            );
+        } finally {
+            Request::setTrustedProxies($previous, $previousHeaderSet);
+        }
+    }
+
+    /**
+     * Regression for #99: `behind_proxy: true` combined with
+     * `require_trusted_proxies: true` still refuses to start.
+     */
+    public function testBehindProxyTrueStillThrowsWhenRequired(): void
+    {
+        $previous = Request::getTrustedProxies();
+        $previousHeaderSet = Request::getTrustedHeaderSet();
+        Request::setTrustedProxies([], 0);
+
+        try {
+            $this->expectException(ConfigurationException::class);
+            $this->expectExceptionMessage('global.behind_proxy is true');
+            Firewall::create([
+                [
+                    'global' => [
+                        'behind_proxy' => true,
+                        'require_trusted_proxies' => true,
+                    ],
+                ],
+            ]);
+        } finally {
+            Request::setTrustedProxies($previous, $previousHeaderSet);
+        }
+    }
+
+    /**
+     * Regression for #99: an unparseable `behind_proxy` must fail safe.
+     *
+     * Silencing a security warning is the dangerous direction, so a value
+     * that is neither truthy nor falsy is treated as "posture unknown" and
+     * still warns rather than being read as `false`.
+     *
+     */
+    #[DataProvider('provideUnparseableBehindProxyValues')]
+    public function testUnparseableBehindProxyStillWarns(mixed $value): void
+    {
+        $previous = Request::getTrustedProxies();
+        $previousHeaderSet = Request::getTrustedHeaderSet();
+        Request::setTrustedProxies([], 0);
+
+        try {
+            $handler = $this->captureLogger();
+            Firewall::create([
+                [
+                    'logger' => [['class' => $handler]],
+                    'global' => ['behind_proxy' => $value],
+                ],
+            ]);
+
+            $this->assertTrue(
+                $handler->hasWarningContaining('getTrustedProxies() is empty'),
+                'An unparseable behind_proxy must not be read as a false assertion.'
+            );
+        } finally {
+            Request::setTrustedProxies($previous, $previousHeaderSet);
+        }
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function provideUnparseableBehindProxyValues(): array
+    {
+        return [
+            'empty string' => [''],
+            'arbitrary string' => ['maybe'],
+            'array' => [['10.0.0.0/8']],
+        ];
+    }
+
+    /**
+     * Regression for #99: YAML-ish string booleans are honoured, so a value
+     * arriving from an `%env()%` token or a quoted YAML scalar behaves the
+     * same as a real boolean.
+     *
+     */
+    #[DataProvider('provideFalsyBehindProxyStrings')]
+    public function testStringFalsyBehindProxyIsHonoured(string $value): void
+    {
+        $previous = Request::getTrustedProxies();
+        $previousHeaderSet = Request::getTrustedHeaderSet();
+        Request::setTrustedProxies([], 0);
+
+        try {
+            $handler = $this->captureLogger();
+            Firewall::create([
+                [
+                    'logger' => [['class' => $handler]],
+                    'global' => ['behind_proxy' => $value],
+                ],
+            ]);
+
+            $this->assertFalse(
+                $handler->hasWarningContaining('getTrustedProxies() is empty'),
+                sprintf('behind_proxy: "%s" should read as a false assertion.', $value)
+            );
+        } finally {
+            Request::setTrustedProxies($previous, $previousHeaderSet);
+        }
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function provideFalsyBehindProxyStrings(): array
+    {
+        return [
+            'false' => ['false'],
+            'zero' => ['0'],
+            'no' => ['no'],
+            'off' => ['off'],
+        ];
     }
 
     /**


### PR DESCRIPTION
Fixes #99.

## Verdict: it's a real issue, not just a docs problem

The docblock is definitely wrong, but fixing only the comment would leave the actual defect in place.

**1. The wrong comment (certain).** `src/Firewall.php` in `create()` claimed:

> Operators who know they're not behind a proxy can silence the warning with `global.require_trusted_proxies: false` (the default).

`false` is the branch that *emits* the warning. Worth noting the method's own docblock and `docs/configuration/global.md:31` were both already accurate — so this was one wrong comment contradicting two correct ones, which is exactly how it went unnoticed.

**2. The functional gap (the reason this needed code).** Two settings covered three real postures, and none of them meant "there is no proxy here":

| `require_trusted_proxies` | Result |
|---|---|
| `false` / unset | `warning`, every request, forever |
| `true` | `ConfigurationException` at startup |

`create()` runs per request, so a deployment with nothing in front of it got a `warning` on 100% of requests, and the only escape was passing `Request::setTrustedProxies()` a value that wasn't true. I agree with the issue's reasoning that this is counterproductive for a security component: an unsilenceable warning teaches operators to stop reading the log, which costs more than the risk the message describes.

## The fix

Adds `global.behind_proxy`, which states the fact the library cannot observe for itself. It's orthogonal to `require_trusted_proxies` rather than overlapping with it, so nothing existing changes meaning:

| `behind_proxy` | Trusted proxies empty ⇒ |
|---|---|
| unset (default) | `warning` — unchanged 2.x behaviour |
| `false` | **silent** — nothing can spoof a forwarding header through a proxy that doesn't exist |
| `true` | `error` — an asserted proxy that isn't wired up is a definite misconfiguration, not an open question |

`require_trusted_proxies: true` still escalates to a startup `ConfigurationException`.

**`behind_proxy: false` wins over `require_trusted_proxies: true`.** An explicit assertion that there's no proxy makes the requirement moot, and throwing anyway would leave an operator who told the truth about their deployment with no way to start at all.

```yaml
# No proxy. Silent.
global:
  behind_proxy: false

# Behind a CDN, and a missing setTrustedProxies() should fail the deploy.
global:
  behind_proxy: true
  require_trusted_proxies: true
```

## Two things worth a reviewer's attention

**`behind_proxy` is resolved *before* `array_filter()`.** `create()` runs `array_filter($config['global'])`, which strips falsy values. Read any later, `behind_proxy: false` is deleted outright and becomes indistinguishable from unset — the setting's entire purpose silently gone. This mirrors how `require_config` is already handled, and the existing comment at that call site is what flagged it. **The tests caught this, not review** — the first implementation read it inside `checkTrustedProxiesPosture()` and the "silences the warning" test failed.

**An unparseable value fails safe.** `behind_proxy:` with nothing after it parses to `NULL`, and an `%env()%` token for an unset variable yields `''`. `filter_var()` reads *both* as `FALSE`, which would have silenced a security warning because someone left a key half-written. Both are treated as unknown so the warning stands. Also caught by a test rather than by inspection.

## Deliberately not done

**No per-process log deduplication** (the issue's option 3). It would add process-global mutable state to a security component in order to reduce the volume of a message that can now be switched off properly. The remaining per-request warning is the genuinely-unknown case, which is an unresolved security question and should keep asking until resolved — the difference is that it's now resolvable from config.

---

# How to test this

## 1. Automated

11 new tests in `tests/Unit/FirewallTest.php` cover every posture, the precedence rule, and the fail-safe paths:

```bash
vendor/bin/phpunit -c phpunit.xml --testsuite unit --no-coverage \
  --filter 'TrustedProxies|BehindProxy|Unparseable'
```

Expected: `OK (14 tests, 17 assertions)` — the 11 new ones plus the three pre-existing #58 regressions, which still pass unchanged.

Full gates:

```bash
composer test           # 845 unit + 49 integration
composer check          # phpcs + phpstan level max + rector --dry-run
```

## 2. Prove the reported bug is actually fixed

Drop this in a file and run it — it walks every posture with trusted proxies empty, which is the reported situation:

```php
<?php
require 'vendor/autoload.php';
use Kanopi\Firewall\Firewall;
use Symfony\Component\HttpFoundation\Request;
use Monolog\Handler\StreamHandler;

Request::setTrustedProxies([], 0);   // the reported situation
$logger = [['class' => new StreamHandler('php://stdout', \Monolog\Level::Debug)]];

foreach ([
    'unset (2.x behaviour)'  => [],
    'behind_proxy: false'    => ['behind_proxy' => false],
    'behind_proxy: true'     => ['behind_proxy' => true],
    'behind_proxy: (empty)'  => ['behind_proxy' => null],
    'false + require: true'  => ['behind_proxy' => false, 'require_trusted_proxies' => true],
] as $label => $global) {
    echo "\n=== {$label} ===\n";
    try {
        Firewall::create([['logger' => $logger, 'global' => $global]]);
        echo "  -> started\n";
    } catch (\Kanopi\Firewall\Exception\ConfigurationException) {
        echo "  -> THREW ConfigurationException\n";
    }
}
```

Expected (debug lines omitted):

```
=== unset (2.x behaviour) ===
firewall.WARNING: Symfony Request::getTrustedProxies() is empty [...]
  -> started
=== behind_proxy: false ===
  -> started                          <- silent, the fix
=== behind_proxy: true ===
firewall.ERROR: global.behind_proxy is true but Symfony Request::getTrustedProxies() is empty [...]
  -> started
=== behind_proxy: (empty) ===
firewall.WARNING: Symfony Request::getTrustedProxies() is empty [...]   <- fails safe
  -> started
=== false + require: true ===
  -> started                          <- assertion beats the requirement
```

## 3. Confirm nothing regressed for proxied deployments

```bash
vendor/bin/phpunit -c phpunit.xml --testsuite unit --no-coverage \
  --filter 'testCreateWarnsWhenTrustedProxiesNotConfigured|testCreateDoesNotWarnWhenTrustedProxiesConfigured|testCreateThrowsWhenTrustedProxiesRequiredButMissing'
```

These are the #58 regressions. They are unmodified and must still pass — with `behind_proxy` unset, behaviour is byte-for-byte what 2.x did.

## 4. Against your Drupal integration

The case from the issue — `reverse_proxy` unconfigured because there's no proxy:

```yaml
global:
  behind_proxy: false
```

The per-request warning should disappear entirely. Then, to confirm it isn't just blanket-suppressing, configure Drupal's `reverse_proxy` settings and flip to `behind_proxy: true` *without* wiring `setTrustedProxies()` — you should get a single `error` naming `global.behind_proxy` rather than the generic message.

## 5. Docs

```bash
mkdocs build --strict
```

`docs/configuration/global.md` gains a rewritten Trusted Proxies section splitting the two settings, and `behind_proxy` is added to the example block at the top.

## Backward compatibility

Fully compatible. `behind_proxy` unset reproduces current behaviour exactly, including log level and message text (the default message gains one sentence pointing at the new setting). No existing config changes meaning. New `error` level applies only to `behind_proxy: true`, a key nobody can already have set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
