### PR TITLE
Describe presets/config.yml accurately (Fixes #102)

### DIFF
--- a/presets/README.md
+++ b/presets/README.md
@@ -26,7 +26,7 @@ malicious requests.
 | `wordpress.yml` | WordPress-specific hardening. |
 | `storage-pantheon.yml` | Storage wiring for Pantheon-hosted sites. |
 | `logging-pantheon.yml` | Logging wiring for Pantheon-hosted sites. |
-| `config.yml` | Composed preset that pulls in the recommended set. |
+| `config.yml` | Convenience bundle of the two URL-pattern presets (`malicious-urls.yml` + `wordpress.yml`). No rate limiting or vulnerability scoring. |
 | `example-*.yml` | Worked examples referenced from the docs. |
 
 ## Quick start


### PR DESCRIPTION
Fixes #102.

One line in `presets/README.md`. The table row described `config.yml` as pulling in "the recommended set"; it is `malicious-urls.yml` + `wordpress.yml` and deliberately excludes `malicious-requests.yml`, which the same table calls "The recommended starting point" six rows earlier.

The practical effect: anyone who read the table and included `config.yml` on that basis got URL-pattern blocking while believing they had the recommended configuration — no vulnerability scoring, no rate limiting.

```diff
-| `config.yml` | Composed preset that pulls in the recommended set. |
+| `config.yml` | Convenience bundle of the two URL-pattern presets (`malicious-urls.yml` + `wordpress.yml`). No rate limiting or vulnerability scoring. |
```

The new wording matches `docs/presets/available.md`, which already described the file correctly, and names the two omissions rather than implying coverage.

## Only this row was wrong

Worth stating, so nobody re-audits the rest of the table. Every other description checks out against the plugin each preset actually configures:

| Row | Claim | Actually configures |
|---|---|---|
| `malicious-requests.yml` | "Vulnerability-scoring rules" | `VulnerabilityScore` ✓ |
| `malicious-urls.yml` | "URL-pattern blocks" | `Url` ✓ |
| `rate-limiting.yml` | "Per-path rate limits" | `RateLimit` ✓ |
| `wordpress.yml` | "WordPress-specific hardening" | `IpAddress` + `Url` ✓ |
| `storage-pantheon.yml` | "Storage wiring" | top-level `storage:` ✓ |
| `logging-pantheon.yml` | "Logging wiring" | top-level `logger:` ✓ |

`presets/config.yml`'s own header comment and the README's Quick start section (which correctly includes `malicious-requests.yml`) were both already accurate as well.

## How to test

```bash
sed -n '20,31p' presets/README.md      # read the table
cat presets/config.yml                 # confirm it is the two URL presets only
sed -n '115,130p' docs/presets/available.md   # the wording this now matches
```

`presets/README.md` is a repo-level file and is not pulled into the MkDocs site (no `nav:` entry, no `--8<--` snippet reference), so nothing on the docs site changes. `mkdocs build --strict` still passes regardless.

## Context

Found while assessing #15 (Add Quick Start Configuration), closed as won't-do. The user need behind that issue — "what do I turn on first?" — is a documentation question, and this row was where it was being answered wrongly.

Not done here: `config.yml` is a confusing name for "the two URL presets" when the repository root has `config/config.yml` as the library's actual default config. Renaming it to something like `urls.yml` would remove the ambiguity but breaks anyone including it by path, so it belongs in a major release rather than a doc fix. Noted in #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
