### PR TITLE
Add bin/firewall-check to test a request against a config (Fixes #105)

### DIFF
--- a/bin/firewall-check
+++ b/bin/firewall-check
@@ -1,0 +1,507 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/*
+ * Ask whether a given request would be blocked, and by what (#105).
+ *
+ * Everything this needs already existed — `Firewall::evaluate()` takes a
+ * Request, and `PluginManager::evaluate()` already records every plugin's
+ * result and timing. What did not exist was a correct way to call it from a
+ * terminal, because assembling it by hand has three edges that fail *quietly*:
+ *
+ *   1. `evaluate()` returns TRUE immediately when PHP_SAPI is 'cli' unless the
+ *      mode is `exception`. Forget that and every request reports "allowed",
+ *      including ones that plainly block. A checker that always says "nothing
+ *      is blocked" is worse than no checker.
+ *
+ *   2. Overrides are PropertyAccess bracket paths, not nested arrays.
+ *      `['global' => ['mode' => 'exception']]` is silently ignored and lands
+ *      you back in (1).
+ *
+ *   3. A block has side effects: it writes to storage, records an offense and
+ *      applies `blocking_escalation`. Pointed at a production config, a naive
+ *      "check" bans the address it was asked about.
+ *
+ * This script handles all three. Storage is swapped for a throwaway by
+ * default, so a check cannot ban anyone; pass --live-storage when you
+ * deliberately want the durable blocklist consulted.
+ */
+
+use Kanopi\Firewall\Exception\ChallengeRequiredException;
+use Kanopi\Firewall\Exception\ChallengeSolvedException;
+use Kanopi\Firewall\Exception\FirewallBlockedException;
+use Kanopi\Firewall\Firewall;
+use Kanopi\Firewall\Storage\InMemoryStorage;
+use Kanopi\Firewall\Utility\PluginConfigNormalizer;
+use Monolog\Handler\TestHandler;
+use Monolog\Level;
+use Symfony\Component\HttpFoundation\Request;
+
+// Exit codes, chosen so the tool composes in scripts and CI. The verdict is
+// the exit status, which is why "blocked" is not lumped in with "error".
+const EXIT_ALLOWED = 0;
+const EXIT_BLOCKED = 1;
+const EXIT_CHALLENGED = 2;
+const EXIT_USAGE = 64;
+const EXIT_INTERNAL = 70;
+
+// Works both in this repository and when installed as a dependency, where the
+// script is symlinked into the consumer's vendor/bin.
+$autoloaders = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php',
+];
+
+$loaded = false;
+
+foreach ($autoloaders as $autoloader) {
+    if (is_file($autoloader)) {
+        require $autoloader;
+        $loaded = true;
+        break;
+    }
+}
+
+if (!$loaded) {
+    fwrite(STDERR, "Could not locate the composer autoloader. Run `composer install`.\n");
+    exit(EXIT_INTERNAL);
+}
+
+$options = getopt('h', [
+    'config:',
+    'ip::',
+    'url::',
+    'method::',
+    'header:',
+    'body::',
+    'explain',
+    'json',
+    'live-storage',
+    'help',
+]);
+
+if ($options === false || isset($options['help']) || isset($options['h'])) {
+    usage();
+    exit($options === false ? EXIT_USAGE : EXIT_ALLOWED);
+}
+
+/**
+ * Print usage.
+ */
+function usage(): void
+{
+    $script = basename(__FILE__);
+
+    echo <<<TXT
+    Check whether a request would be blocked by a firewall configuration.
+
+    USAGE
+      {$script} --config=FILE [options]
+
+    REQUIRED
+      --config=FILE      Firewall config file. Repeatable; merged in order,
+                         exactly as Firewall::create() merges them.
+
+    REQUEST
+      --ip=ADDRESS       Client IP (IPv4 or IPv6). Default 127.0.0.1
+      --url=URL          Path, with optional query string. Default /
+      --method=VERB      HTTP method. Default GET, or POST when --body is given
+      --header=NAME:VAL  Request header. Repeatable
+      --body=STRING      Request body
+
+    OUTPUT
+      --explain          Show every plugin that evaluated, with result and
+                         timing, plus the plugins that never ran
+      --json             Machine-readable output
+
+    BEHAVIOUR
+      --live-storage     Use the configured storage backend instead of a
+                         throwaway. The durable blocklist is then consulted —
+                         but a block will also be RECORDED, which can ban the
+                         address you are asking about. Off by default.
+
+    EXIT CODES
+      0  allowed          64  usage error
+      1  blocked          70  internal error
+      2  challenged
+
+    EXAMPLES
+      {$script} --config=firewall.yml --ip=203.0.113.5 --url=/wp-admin/
+      {$script} --config=firewall.yml --url='/search?q=1%27+UNION+SELECT' --explain
+      {$script} --config=firewall.yml --header='User-Agent: sqlmap/1.8' --json
+
+    TXT;
+}
+
+/**
+ * Normalise a repeatable option into a list.
+ *
+ * getopt() hands back a string for one occurrence and an array for several,
+ * which is a reliable source of "works with two headers, breaks with one".
+ *
+ * @param array<string, mixed> $options
+ * @param string $name
+ *
+ * @return array<int, string>
+ */
+function repeatable(array $options, string $name): array
+{
+    if (!isset($options[$name])) {
+        return [];
+    }
+
+    $value = $options[$name];
+
+    return array_values(array_map('strval', is_array($value) ? $value : [$value]));
+}
+
+/**
+ * Read a single-valued option.
+ *
+ * getopt() hands back an array when a flag is repeated, so a bare
+ * `(string) $options['ip']` emits "Array to string conversion" the moment
+ * someone passes `--ip` twice. Last occurrence wins, which is what a reader
+ * would assume from the command line they typed.
+ *
+ * @param array<string, mixed> $options
+ * @param string $name
+ * @param string|null $default
+ *
+ * @return string|null
+ */
+function single(array $options, string $name, ?string $default = null): ?string
+{
+    if (!array_key_exists($name, $options)) {
+        return $default;
+    }
+
+    $value = $options[$name];
+
+    if (is_array($value)) {
+        $value = end($value);
+    }
+
+    return is_scalar($value) ? (string) $value : $default;
+}
+
+$configs = repeatable($options, 'config');
+
+if ($configs === []) {
+    fwrite(STDERR, "Error: at least one --config=FILE is required.\n\n");
+    usage();
+    exit(EXIT_USAGE);
+}
+
+foreach ($configs as $config) {
+    if (!is_file($config) || !is_readable($config)) {
+        fwrite(STDERR, "Error: config file not readable: {$config}\n");
+        exit(EXIT_USAGE);
+    }
+}
+
+$ip = (string) single($options, 'ip', '127.0.0.1');
+
+if (filter_var($ip, FILTER_VALIDATE_IP) === false) {
+    fwrite(STDERR, "Error: --ip is not a valid address: {$ip}\n");
+    exit(EXIT_USAGE);
+}
+
+$url = (string) single($options, 'url', '/');
+$body = array_key_exists('body', $options) ? (string) single($options, 'body', '') : null;
+// A body without a method almost always means POST; defaulting to GET would
+// quietly test something the caller did not describe.
+$method = strtoupper((string) single($options, 'method', $body === null ? 'GET' : 'POST'));
+
+$server = ['REMOTE_ADDR' => $ip];
+
+foreach (repeatable($options, 'header') as $header) {
+    if (!str_contains($header, ':')) {
+        fwrite(STDERR, "Error: --header must be NAME:VALUE, got: {$header}\n");
+        exit(EXIT_USAGE);
+    }
+
+    [$name, $value] = explode(':', $header, 2);
+    $name = strtoupper(str_replace('-', '_', trim($name)));
+    $value = ltrim($value);
+
+    // Content-Type and Content-Length are CGI variables in their own right,
+    // not HTTP_ prefixed. Symfony reads them from those exact keys, so a
+    // --header='Content-Type: application/json' would otherwise be ignored and
+    // the body would parse as the wrong type.
+    $server[in_array($name, ['CONTENT_TYPE', 'CONTENT_LENGTH'], true) ? $name : 'HTTP_' . $name] = $value;
+}
+
+$handler = new TestHandler(Level::Debug);
+
+// The two overrides that make this work at all. Bracket paths, not nested
+// arrays — see the header comment.
+$overrides = [
+    // Without this, evaluate() short-circuits in CLI and reports everything as
+    // allowed.
+    '[global][mode]' => 'exception',
+];
+
+$liveStorage = isset($options['live-storage']);
+
+if ($liveStorage) {
+    // On stderr so it cannot corrupt --json on stdout. Worth saying out loud:
+    // the block path records an offense and applies blocking_escalation, so a
+    // "check" against live storage can ban the address being asked about.
+    fwrite(
+        STDERR,
+        "Warning: --live-storage is on. A blocked verdict will be RECORDED in the\n"
+        . "         configured backend, which can ban the address you are testing.\n",
+    );
+}
+
+if (!$liveStorage) {
+    // A check must not be able to ban anyone. The block path writes to
+    // storage, records an offense and escalates; swapping in a per-process
+    // store makes all of that inert.
+    $overrides['[storage][type]'] = InMemoryStorage::class;
+}
+
+try {
+    $inputs = $configs;
+    $inputs[] = ['logger' => [['class' => $handler]]];
+
+    $firewall = Firewall::create($inputs, $overrides);
+} catch (Throwable $exception) {
+    fwrite(STDERR, sprintf(
+        "Error: could not build the firewall from that configuration.\n  %s: %s\n",
+        $exception::class,
+        $exception->getMessage(),
+    ));
+    exit(EXIT_INTERNAL);
+}
+
+$request = Request::create($url, $method, [], [], [], $server, $body);
+
+$verdict = 'allowed';
+$status = null;
+$reason = null;
+
+try {
+    $firewall->evaluate($request);
+} catch (FirewallBlockedException $exception) {
+    $verdict = 'blocked';
+    $status = $exception->getCode();
+    $reason = $exception->getMessage();
+} catch (ChallengeRequiredException $exception) {
+    $verdict = 'challenged';
+    $reason = $exception->getMessage();
+} catch (ChallengeSolvedException) {
+    $verdict = 'allowed';
+    $reason = 'a challenge solution was accepted';
+} catch (Throwable $exception) {
+    fwrite(STDERR, sprintf(
+        "Error: evaluation threw unexpectedly.\n  %s: %s\n",
+        $exception::class,
+        $exception->getMessage(),
+    ));
+    exit(EXIT_INTERNAL);
+}
+
+// -----------------------------------------------------------------------
+// Attribution and per-plugin detail, read back out of the log.
+//
+// FirewallBlockedException carries only a message and a status code, so the
+// responsible plugin comes from the log line the block path already writes.
+// Reading the log rather than re-evaluating each plugin matters: a second pass
+// would repeat every side effect, including any outbound reputation lookup.
+// -----------------------------------------------------------------------
+
+$plugin = null;
+$pluginRole = null;
+$lastMatched = null;
+$evaluated = [];
+
+foreach ($handler->getRecords() as $record) {
+    $context = $record->context;
+
+    // Attribution is keyed on the firewall's own decision messages, NOT on the
+    // mere presence of a `plugin` context key. Individual plugins log their own
+    // debug lines carrying that key, so a looser match reports a "matched
+    // plugin" on requests where nothing matched at all.
+    $decision = match (true) {
+        str_contains($record->message, 'Request blocked by plugin') => 'blocked by',
+        str_contains($record->message, 'Request bypassed') => 'allowed by',
+        str_contains($record->message, 'would be blocked') => 'would be blocked by',
+        str_contains($record->message, 'would be challenged') => 'would be challenged by',
+        default => null,
+    };
+
+    if ($decision !== null && isset($context['plugin_name']) && is_string($context['plugin_name'])) {
+        $plugin = $context['plugin_name'];
+        $pluginRole = $decision;
+    }
+
+    // PluginManager logs this only when a plugin actually returns TRUE, so it
+    // is a safe fallback for paths that do not emit one of the messages above
+    // — the challenge flow among them.
+    if (str_contains($record->message, 'Plugin evaluation matched')
+        && isset($context['plugin'])
+        && is_string($context['plugin'])
+    ) {
+        $lastMatched = $context['plugin'];
+    }
+
+    if (isset($context['evaluated_plugins']) && is_array($context['evaluated_plugins'])) {
+        foreach ($context['evaluated_plugins'] as $entry) {
+            if (is_array($entry) && isset($entry['plugin'])) {
+                $evaluated[] = [
+                    'plugin' => (string) $entry['plugin'],
+                    'matched' => (bool) ($entry['result'] ?? false),
+                    'time_ms' => is_numeric($entry['time_ms'] ?? null) ? (float) $entry['time_ms'] : 0.0,
+                ];
+            }
+        }
+    }
+}
+
+// A verdict that is not "allowed" must have had something behind it; fall back
+// to the last confirmed plugin match rather than reporting no attribution.
+if ($plugin === null && $verdict !== 'allowed' && $lastMatched !== null) {
+    $plugin = $lastMatched;
+    $pluginRole = $verdict === 'challenged' ? 'challenged by' : 'blocked by';
+}
+
+// Configured inventory, so --explain can also show what never ran.
+$configured = [];
+
+try {
+    $merged = PluginConfigNormalizer::normalize(
+        \Kanopi\Firewall\Utility\Config::load(
+            array_merge([__DIR__ . '/../config/config.yml'], $configs),
+            $overrides,
+        )
+    );
+
+    foreach (PluginConfigNormalizer::partitionAndSort($merged['plugins'] ?? []) as $response => $plugins) {
+        foreach ($plugins as $entry) {
+            $class = is_string($entry['plugin'] ?? null) ? $entry['plugin'] : '';
+
+            if ($class !== '') {
+                $configured[] = [
+                    'response' => (string) $response,
+                    'class' => $class,
+                    'weight' => is_numeric($entry['weight'] ?? null) ? (int) $entry['weight'] : 0,
+                ];
+            }
+        }
+    }
+} catch (Throwable) {
+    // Inventory is a convenience for --explain; the verdict above stands
+    // regardless, and failing here must not change the exit code.
+    $configured = [];
+}
+
+$evaluatedNames = array_column($evaluated, 'plugin');
+
+$result = [
+    'verdict' => $verdict,
+    'plugin' => $plugin,
+    'status' => $status,
+    'reason' => $reason,
+    'request' => [
+        'ip' => $ip,
+        'method' => $request->getMethod(),
+        'path' => $request->getPathInfo(),
+        'query' => $request->getQueryString(),
+    ],
+    'storage' => $liveStorage ? 'configured backend' : 'throwaway (in-memory)',
+];
+
+if (isset($options['explain'])) {
+    $result['evaluated'] = $evaluated;
+    $result['configured'] = $configured;
+}
+
+// -----------------------------------------------------------------------
+// Output
+// -----------------------------------------------------------------------
+
+if (isset($options['json'])) {
+    echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), "\n";
+} else {
+    $label = ['allowed' => 'ALLOWED', 'blocked' => 'BLOCKED', 'challenged' => 'CHALLENGED'][$verdict];
+
+    printf("%s  %s %s\n", $label, $request->getMethod(), $url);
+    printf("  client            %s\n", $ip);
+
+    if ($plugin !== null) {
+        printf("  %-17s %s\n", $pluginRole ?? 'matched plugin', $plugin);
+    }
+
+    if ($status !== null) {
+        printf("  status            %d\n", $status);
+    }
+
+    if ($reason !== null && $reason !== '') {
+        printf("  reason            %s\n", $reason);
+    }
+
+    printf("  storage           %s\n", $result['storage']);
+
+    if (isset($options['explain'])) {
+        echo "\nPlugins evaluated, in order:\n";
+
+        if ($evaluated === []) {
+            echo "  (none — no plugins were reached)\n";
+        }
+
+        foreach ($evaluated as $entry) {
+            printf(
+                "  %-7s %-28s %6.2f ms\n",
+                $entry['matched'] ? 'MATCH' : 'pass',
+                $entry['plugin'],
+                $entry['time_ms'],
+            );
+        }
+
+        // What did not run is often the actual answer to "why wasn't this
+        // caught?" — an earlier plugin matched and short-circuited the chain.
+        //
+        // The log records a plugin's *display* name ("IP Address") while the
+        // config carries its FQCN (...\IpAddress), so both sides are reduced to
+        // lowercase alphanumerics before comparing. A case-sensitive match here
+        // reported every plugin as unreached, including ones that had visibly
+        // just run.
+        $fold = static fn(string $value): string
+            => strtolower((string) preg_replace('/[^A-Za-z0-9]/', '', $value));
+
+        $ran = array_map($fold, $evaluatedNames);
+
+        $skipped = array_values(array_filter(
+            $configured,
+            static fn(array $entry): bool => !in_array(
+                $fold(substr((string) strrchr('\\' . $entry['class'], '\\'), 1)),
+                $ran,
+                true,
+            ),
+        ));
+
+        if ($skipped !== []) {
+            echo "\nConfigured but not reached:\n";
+
+            foreach ($skipped as $entry) {
+                printf("  %-9s %-40s weight %d\n", $entry['response'], $entry['class'], $entry['weight']);
+            }
+        }
+    }
+}
+
+exit(match ($verdict) {
+    'blocked' => EXIT_BLOCKED,
+    'challenged' => EXIT_CHALLENGED,
+    default => EXIT_ALLOWED,
+});

--- a/bin/firewall-check
+++ b/bin/firewall-check
@@ -54,6 +54,18 @@ const EXIT_CHALLENGED = 2;
 const EXIT_USAGE = 64;
 const EXIT_INTERNAL = 70;
 
+// Keep stdout clean for --json.
+//
+// PHP's CLI SAPI sends diagnostics to STDOUT by default, so a notice raised
+// anywhere during evaluation — by a plugin, by a dependency — would be
+// interleaved with the JSON document and break `| jq`. Runtime diagnostics are
+// this script's business, so they are redirected here.
+//
+// Startup warnings emitted *before* this line (a duplicate `extension=` in
+// php.ini, for instance) cannot be caught from inside the script. If your PHP
+// prints those, run with `php -d display_errors=stderr`. See the guide.
+ini_set('display_errors', 'stderr');
+
 // Works both in this repository and when installed as a dependency, where the
 // script is symlinked into the consumer's vendor/bin.
 $autoloaders = [

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
         }
     ],
     "license": "MIT",
+    "bin": [
+        "bin/firewall-check"
+    ],
     "autoload": {
         "psr-4": {
             "Kanopi\\Firewall\\": "src/"
@@ -124,7 +127,8 @@
             "PERF_VUS=50 PERF_DURATION=15s PERF_RAMP=5s PERF_WARMUP=5 bash tests/Performance/bin/run.sh baseline bootstrap crs all-on"
         ],
         "perf:validate": "php tests/Performance/bin/validate-scenarios.php --skip-geoip",
-        "perf:down": "docker compose -f tests/Performance/docker-compose.yml down --volumes --remove-orphans"
+        "perf:down": "docker compose -f tests/Performance/docker-compose.yml down --volumes --remove-orphans",
+        "check:request": "php bin/firewall-check"
     },
     "scripts-descriptions": {
         "demo": "Run the demo on PHP's built-in server (single-process) at http://localhost:8000",
@@ -136,7 +140,8 @@
         "perf": "Run the full per-plugin performance benchmark (nginx + php-fpm + k6, ~20-40 min). Results in tests/Performance/results/",
         "perf:quick": "Short benchmark over baseline, bootstrap, crs and all-on — enough to sanity check a change in a couple of minutes",
         "perf:validate": "Check every performance scenario config loads and evaluates, in seconds. Run this before a full benchmark",
-        "perf:down": "Tear down the performance harness stack and drop its volumes (GeoIP databases and caches)"
+        "perf:down": "Tear down the performance harness stack and drop its volumes (GeoIP databases and caches)",
+        "check:request": "Ask whether a given request would be blocked, and by what. Pass options after `--`, e.g. `composer check:request -- --config=firewall.yml --ip=203.0.113.5 --url=/wp-admin/`"
     },
     "prefer-stable": true,
     "minimum-stability": "dev",

--- a/docs/guides/checking-requests.md
+++ b/docs/guides/checking-requests.md
@@ -96,6 +96,12 @@ If that records a block you did not want, clearing it means removing the entry f
 vendor/bin/firewall-check --config=firewall.yml --ip=203.0.113.5 --json | jq -r .plugin
 ```
 
+The tool redirects its own diagnostics to stderr so stdout carries nothing but the JSON document. One case is outside its control: PHP's CLI SAPI prints **startup** warnings to stdout before any script runs, so a duplicate `extension=` line in your `php.ini` would land ahead of the JSON and break the pipe. If you hit that, run it as:
+
+```bash
+php -d display_errors=stderr vendor/bin/firewall-check --config=firewall.yml --json
+```
+
 ```json
 {
     "verdict": "blocked",

--- a/docs/guides/checking-requests.md
+++ b/docs/guides/checking-requests.md
@@ -1,0 +1,114 @@
+# Checking a Request
+
+`bin/firewall-check` answers one question from the terminal: **would this request be blocked, and by what?**
+
+It runs the real evaluation path against a config you name, without needing a running site and without touching your production data.
+
+```bash
+vendor/bin/firewall-check --config=firewall.yml --ip=203.0.113.5 --url=/wp-admin/
+```
+
+```
+BLOCKED  GET /wp-admin/
+  client            203.0.113.5
+  blocked by        IP Address
+  status            400
+  reason            blocked
+  storage           throwaway (in-memory)
+```
+
+## Options
+
+| Option | Purpose |
+|---|---|
+| `--config=FILE` | Config file. **Repeatable**, merged in order exactly as `Firewall::create()` merges them |
+| `--ip=ADDRESS` | Client IP, IPv4 or IPv6. Default `127.0.0.1` |
+| `--url=URL` | Path with optional query string. Default `/` |
+| `--method=VERB` | HTTP method. Default `GET`, or `POST` when `--body` is given |
+| `--header=NAME:VAL` | Request header. **Repeatable** |
+| `--body=STRING` | Request body |
+| `--explain` | Show every plugin that evaluated, plus the ones that never ran |
+| `--json` | Machine-readable output |
+| `--live-storage` | Use the configured storage instead of a throwaway — see [Safety](#safety) |
+
+## Exit codes
+
+Designed to compose in scripts and CI, so the verdict *is* the exit status:
+
+| Code | Meaning |
+|---|---|
+| `0` | allowed |
+| `1` | blocked |
+| `2` | challenged |
+| `64` | usage error |
+| `70` | internal error |
+
+```bash
+if vendor/bin/firewall-check --config=firewall.yml --url=/wp-admin/ >/dev/null; then
+  echo "Not blocked — the WordPress preset is not doing its job."
+  exit 1
+fi
+```
+
+## Understanding why
+
+`--explain` lists every plugin that ran, with its result and timing, and then the plugins that never ran because something earlier matched. That second list is usually the answer to *"why wasn't this caught?"*:
+
+```console
+$ vendor/bin/firewall-check --config=firewall.yml --ip=203.0.113.5 --url=/wp-admin/ --explain
+
+BLOCKED  GET /wp-admin/
+  client            203.0.113.5
+  blocked by        IP Address
+  ...
+
+Plugins evaluated, in order:
+  MATCH   IP Address                     0.06 ms
+
+Configured but not reached:
+  block     Kanopi\Firewall\Plugins\Url              weight -10
+  block     Kanopi\Firewall\Plugins\UserAgent        weight 0
+```
+
+The IP list matched first, so nothing else was consulted. If you were testing whether your URL rules catch `/wp-admin/`, this tells you the test never reached them.
+
+The timings are real and occasionally revealing — `matomo/device-detector` is markedly more expensive on a cold call than the pattern-matching plugins.
+
+## Safety
+
+**Storage is replaced with a throwaway by default, and this matters.** A block is not a read-only event: it writes to storage, records an offense, and applies [`blocking_escalation`](../configuration/global.md#multiple-offenses-defense). A checker wired straight to a production config would **ban the address it was asked about**.
+
+So by default the durable blocklist is *not* consulted and *not* written. The output says which mode you are in on the `storage` line.
+
+`--live-storage` restores the configured backend when you genuinely need the repeat-offender state considered — for instance to confirm an address is currently banned rather than merely matching a rule. It prints a warning to stderr, and a blocked verdict **will** be recorded:
+
+```bash
+vendor/bin/firewall-check --config=firewall.yml --ip=203.0.113.5 --live-storage
+```
+
+If that records a block you did not want, clearing it means removing the entry from your [storage backend](../configuration/storage.md) directly — which is the reason the throwaway is the default.
+
+## Scripting
+
+`--json` writes a single object to stdout; warnings go to stderr, so the output stays parseable even with `--live-storage`.
+
+```bash
+vendor/bin/firewall-check --config=firewall.yml --ip=203.0.113.5 --json | jq -r .plugin
+```
+
+```json
+{
+    "verdict": "blocked",
+    "plugin": "IP Address",
+    "status": 400,
+    "reason": "blocked",
+    "request": { "ip": "203.0.113.5", "method": "GET", "path": "/", "query": null },
+    "storage": "throwaway (in-memory)"
+}
+```
+
+## Notes
+
+- **Mode is forced to `exception`** regardless of what the config says. `Firewall::evaluate()` returns early in CLI under any other mode, which would report every request as allowed — so this is not optional, and it is why hand-rolled checking scripts so often appear to work while telling you nothing.
+- **Plugins that reach the network still do so.** `AbuseIpdb` will consult its cache and, on a miss, call the API and spend quota. Nothing here suppresses that.
+- **Attribution comes from the firewall's own decision log**, not from re-running each plugin — a second pass would repeat every side effect.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -208,6 +208,7 @@ nav:
   - Guides:
       - guides/index.md
       - Error Handling: guides/error-handling.md
+      - Checking a Request: guides/checking-requests.md
       - Custom Plugins: guides/custom-plugins.md
       - Custom Storage: guides/custom-storage.md
       - Advanced Examples: guides/advanced-examples.md

--- a/tests/Unit/FirewallCheckCommandTest.php
+++ b/tests/Unit/FirewallCheckCommandTest.php
@@ -60,7 +60,16 @@ final class FirewallCheckCommandTest extends AbstractTestCase
      */
     private function runCheck(array $args): array
     {
-        $command = array_merge([PHP_BINARY, $this->script()], $args);
+        // -d display_errors=stderr isolates the subprocess from the host's
+        // own PHP startup diagnostics, which the CLI SAPI otherwise prints to
+        // STDOUT. CI installs pdo_mysql/mysqli/pdo_pgsql over an image that
+        // already has them, so every run emits 'Module "..." is already
+        // loaded' — which would land ahead of the JSON document and make these
+        // assertions measure the environment rather than the tool.
+        $command = array_merge(
+            [PHP_BINARY, '-d', 'display_errors=stderr', $this->script()],
+            $args,
+        );
         $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
         $process = proc_open($command, $descriptors, $pipes);
 
@@ -302,7 +311,8 @@ final class FirewallCheckCommandTest extends AbstractTestCase
         ]);
 
         $this->assertStringContainsString('Warning', $result['stderr']);
-        $this->assertStringNotContainsString('Warning', $result['stdout']);
+        // stdout must be the JSON document and nothing else, or `| jq` breaks.
+        $this->assertStringStartsWith('{', ltrim($result['stdout']));
         $this->assertIsArray(json_decode($result['stdout'], true, 512, JSON_THROW_ON_ERROR));
     }
 
@@ -319,6 +329,9 @@ final class FirewallCheckCommandTest extends AbstractTestCase
             '--json',
         ]);
 
+        // Assert the whole of stdout parses, not merely that it contains JSON
+        // somewhere — anything printed alongside would break a `| jq` pipeline.
+        $this->assertStringStartsWith('{', ltrim($result['stdout']));
         $decoded = json_decode($result['stdout'], true, 512, JSON_THROW_ON_ERROR);
 
         $this->assertSame('blocked', $decoded['verdict']);

--- a/tests/Unit/FirewallCheckCommandTest.php
+++ b/tests/Unit/FirewallCheckCommandTest.php
@@ -1,0 +1,420 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * `bin/firewall-check` (#105).
+ *
+ * Driven as a real subprocess rather than by including the script. The exit
+ * code is part of the contract — it is how the tool composes in CI — and so is
+ * the stdout/stderr split that keeps `--json` parseable. Neither can be
+ * asserted honestly from inside the same process.
+ */
+final class FirewallCheckCommandTest extends AbstractTestCase
+{
+    private const EXIT_ALLOWED = 0;
+    private const EXIT_BLOCKED = 1;
+    private const EXIT_CHALLENGED = 2;
+    private const EXIT_USAGE = 64;
+
+    /**
+     * @var array<int, string>
+     */
+    private array $tempFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $file) {
+            @unlink($file);
+        }
+
+        $this->tempFiles = [];
+
+        parent::tearDown();
+    }
+
+    private function script(): string
+    {
+        return dirname(__DIR__, 2) . '/bin/firewall-check';
+    }
+
+    private function writeConfig(string $yaml): string
+    {
+        $path = sys_get_temp_dir() . '/fw-check-' . uniqid('', true) . '.yml';
+        file_put_contents($path, $yaml);
+        $this->tempFiles[] = $path;
+
+        return $path;
+    }
+
+    /**
+     * Run the script and capture stdout, stderr and the exit code separately.
+     *
+     * @param array<int, string> $args
+     *
+     * @return array{stdout: string, stderr: string, code: int}
+     */
+    private function runCheck(array $args): array
+    {
+        $command = array_merge([PHP_BINARY, $this->script()], $args);
+        $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $process = proc_open($command, $descriptors, $pipes);
+
+        $this->assertIsResource($process, 'Could not start bin/firewall-check');
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return ['stdout' => $stdout, 'stderr' => $stderr, 'code' => proc_close($process)];
+    }
+
+    /**
+     * A config with one plugin per bucket so attribution can be told apart.
+     */
+    private function standardConfig(): string
+    {
+        return $this->writeConfig(<<<'YML'
+        global:
+          mode: block
+          banning_message: "blocked"
+        storage:
+          type: 'Kanopi\Firewall\Storage\InMemoryStorage'
+        plugins:
+          - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+            response: block
+            weight: -100
+            enable: true
+            config:
+              - 203.0.113.0/24
+          - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+            response: block
+            weight: -10
+            enable: true
+            config:
+              - "path@starts_with:/wp-admin"
+        YML);
+    }
+
+    // -----------------------------------------------------------------------
+    // Verdicts and exit codes
+    // -----------------------------------------------------------------------
+
+    public function testAllowedRequestExitsZero(): void
+    {
+        $result = $this->runCheck(['--config=' . $this->standardConfig(), '--ip=1.1.1.1', '--url=/']);
+
+        $this->assertSame(self::EXIT_ALLOWED, $result['code']);
+        $this->assertStringContainsString('ALLOWED', $result['stdout']);
+    }
+
+    /**
+     * The regression that matters most. `Firewall::evaluate()` returns TRUE
+     * immediately in CLI unless the mode is `exception`, so a tool that fails
+     * to force it reports "allowed" for everything — including this request,
+     * which is squarely inside a blocked CIDR.
+     */
+    public function testBlockedRequestIsNotSilentlyAllowedInCli(): void
+    {
+        $result = $this->runCheck(['--config=' . $this->standardConfig(), '--ip=203.0.113.5', '--url=/']);
+
+        $this->assertSame(self::EXIT_BLOCKED, $result['code']);
+        $this->assertStringContainsString('BLOCKED', $result['stdout']);
+    }
+
+    public function testBlockedRequestNamesTheResponsiblePlugin(): void
+    {
+        $result = $this->runCheck(['--config=' . $this->standardConfig(), '--ip=1.1.1.1', '--url=/wp-admin/']);
+
+        $this->assertSame(self::EXIT_BLOCKED, $result['code']);
+        $this->assertStringContainsString('blocked by', $result['stdout']);
+        $this->assertStringContainsString('URL', $result['stdout']);
+    }
+
+    /**
+     * Attribution must come from the firewall's decision, not from any plugin
+     * that happened to log. An allowed request has no responsible plugin, and
+     * claiming one sends the reader hunting for a rule that did not fire.
+     */
+    public function testAllowedRequestReportsNoResponsiblePlugin(): void
+    {
+        $result = $this->runCheck(['--config=' . $this->standardConfig(), '--ip=1.1.1.1', '--url=/']);
+
+        $this->assertStringNotContainsString('blocked by', $result['stdout']);
+        $this->assertStringNotContainsString('matched plugin', $result['stdout']);
+    }
+
+    public function testChallengedRequestExitsTwo(): void
+    {
+        $config = $this->writeConfig(<<<'YML'
+        global:
+          mode: block
+        storage:
+          type: 'Kanopi\Firewall\Storage\InMemoryStorage'
+        challenge:
+          provider: math
+          secret: 'test-secret-for-the-cli-check'
+        plugins:
+          - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+            response: challenge
+            enable: true
+            config:
+              - "path@starts_with:/secure"
+        YML);
+
+        $result = $this->runCheck(['--config=' . $config, '--ip=1.1.1.1', '--url=/secure']);
+
+        $this->assertSame(self::EXIT_CHALLENGED, $result['code']);
+        $this->assertStringContainsString('CHALLENGED', $result['stdout']);
+    }
+
+    // -----------------------------------------------------------------------
+    // Request construction
+    // -----------------------------------------------------------------------
+
+    public function testHeadersReachThePlugins(): void
+    {
+        $config = $this->writeConfig(<<<'YML'
+        global:
+          mode: block
+        storage:
+          type: 'Kanopi\Firewall\Storage\InMemoryStorage'
+        plugins:
+          - plugin: "Kanopi\\Firewall\\Plugins\\UserAgent"
+            response: block
+            enable: true
+            config:
+              - "client.name@contains:sqlmap"
+        YML);
+
+        $blocked = $this->runCheck(['--config=' . $config, '--header=User-Agent: sqlmap/1.8.3']);
+        $allowed = $this->runCheck(['--config=' . $config, '--header=User-Agent: Mozilla/5.0 (Macintosh) Safari/605']);
+
+        $this->assertSame(self::EXIT_BLOCKED, $blocked['code']);
+        $this->assertSame(self::EXIT_ALLOWED, $allowed['code']);
+    }
+
+    /**
+     * Later configs merge over earlier ones, exactly as Firewall::create()
+     * treats them, so a base ruleset plus an overlay can be checked together.
+     */
+    public function testMultipleConfigsAreMerged(): void
+    {
+        $base = $this->writeConfig(<<<'YML'
+        global:
+          mode: block
+        storage:
+          type: 'Kanopi\Firewall\Storage\InMemoryStorage'
+        plugins:
+          - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+            response: block
+            enable: true
+            config:
+              - 10.0.0.0/8
+        YML);
+
+        $overlay = $this->writeConfig(<<<'YML'
+        plugins:
+          - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+            response: block
+            enable: true
+            config:
+              - "path@starts_with:/admin"
+        YML);
+
+        $baseOnly = $this->runCheck(['--config=' . $base, '--ip=1.1.1.1', '--url=/admin']);
+        $merged = $this->runCheck(['--config=' . $base, '--config=' . $overlay, '--ip=1.1.1.1', '--url=/admin']);
+
+        $this->assertSame(self::EXIT_ALLOWED, $baseOnly['code'], 'The overlay rule should not apply yet.');
+        $this->assertSame(self::EXIT_BLOCKED, $merged['code'], 'The overlay rule should apply once merged.');
+    }
+
+    /**
+     * getopt() returns a string for one occurrence and an array for several —
+     * a reliable source of "works with two headers, breaks with one".
+     */
+    public function testASingleHeaderIsHandledLikeSeveral(): void
+    {
+        $config = $this->standardConfig();
+
+        $one = $this->runCheck(['--config=' . $config, '--header=X-One: 1']);
+        $two = $this->runCheck(['--config=' . $config, '--header=X-One: 1', '--header=X-Two: 2']);
+
+        $this->assertSame(self::EXIT_ALLOWED, $one['code']);
+        $this->assertSame(self::EXIT_ALLOWED, $two['code']);
+    }
+
+    // -----------------------------------------------------------------------
+    // Safety
+    // -----------------------------------------------------------------------
+
+    /**
+     * A check must not be able to ban anyone. The block path writes to
+     * storage, records an offense and applies `blocking_escalation`, so
+     * without the throwaway default a "check" against production config would
+     * ban the address it was asked about.
+     */
+    public function testCheckingABlockedAddressDoesNotWriteToConfiguredStorage(): void
+    {
+        $storageFile = sys_get_temp_dir() . '/fw-check-must-not-exist-' . uniqid('', true) . '.json';
+        $this->tempFiles[] = $storageFile;
+
+        $config = $this->writeConfig(sprintf(
+            <<<'YML'
+            global:
+              mode: block
+            storage:
+              type: 'Kanopi\Firewall\Storage\FileStorage'
+              config:
+                storage_file: %s
+            plugins:
+              - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
+                response: block
+                enable: true
+                config:
+                  - 203.0.113.0/24
+            YML,
+            $storageFile,
+        ));
+
+        $result = $this->runCheck(['--config=' . $config, '--ip=203.0.113.5']);
+
+        $this->assertSame(self::EXIT_BLOCKED, $result['code']);
+        $this->assertFileDoesNotExist($storageFile, 'A check must never write to the configured storage backend.');
+        $this->assertStringContainsString('throwaway', $result['stdout']);
+    }
+
+    /**
+     * The warning must go to stderr, or it would corrupt --json on stdout.
+     */
+    public function testLiveStorageWarnsOnStderrOnly(): void
+    {
+        $result = $this->runCheck([
+            '--config=' . $this->standardConfig(),
+            '--ip=203.0.113.5',
+            '--live-storage',
+            '--json',
+        ]);
+
+        $this->assertStringContainsString('Warning', $result['stderr']);
+        $this->assertStringNotContainsString('Warning', $result['stdout']);
+        $this->assertIsArray(json_decode($result['stdout'], true, 512, JSON_THROW_ON_ERROR));
+    }
+
+    // -----------------------------------------------------------------------
+    // Output modes
+    // -----------------------------------------------------------------------
+
+    public function testJsonOutputIsParseable(): void
+    {
+        $result = $this->runCheck([
+            '--config=' . $this->standardConfig(),
+            '--ip=203.0.113.5',
+            '--url=/search?q=test',
+            '--json',
+        ]);
+
+        $decoded = json_decode($result['stdout'], true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('blocked', $decoded['verdict']);
+        $this->assertSame('203.0.113.5', $decoded['request']['ip']);
+        $this->assertSame('/search', $decoded['request']['path']);
+    }
+
+    /**
+     * `--explain` must show the plugins that ran AND the ones an earlier match
+     * short-circuited past. "Why wasn't this caught?" is usually answered by
+     * the second list.
+     */
+    public function testExplainListsEvaluatedAndUnreachedPlugins(): void
+    {
+        $result = $this->runCheck([
+            '--config=' . $this->standardConfig(),
+            '--ip=203.0.113.5',
+            '--url=/wp-admin/',
+            '--explain',
+        ]);
+
+        $this->assertStringContainsString('Plugins evaluated', $result['stdout']);
+        $this->assertStringContainsString('MATCH', $result['stdout']);
+        // IpAddress matches first, so the URL plugin never runs.
+        $this->assertStringContainsString('not reached', $result['stdout']);
+        $this->assertStringContainsString('Url', $result['stdout']);
+    }
+
+    /**
+     * When nothing short-circuits, every configured plugin runs and there is
+     * no unreached list to print.
+     */
+    public function testExplainOmitsUnreachedSectionWhenEverythingRan(): void
+    {
+        $result = $this->runCheck([
+            '--config=' . $this->standardConfig(),
+            '--ip=1.1.1.1',
+            '--url=/',
+            '--explain',
+        ]);
+
+        $this->assertStringContainsString('IP Address', $result['stdout']);
+        $this->assertStringContainsString('URL', $result['stdout']);
+        $this->assertStringNotContainsString('not reached', $result['stdout']);
+    }
+
+    // -----------------------------------------------------------------------
+    // Usage errors
+    // -----------------------------------------------------------------------
+
+    /**
+     * @param array<int, string> $args
+     */
+    #[DataProvider('provideUsageErrors')]
+    public function testUsageErrorsExitSixtyFour(array $args, string $expected): void
+    {
+        $result = $this->runCheck($args);
+
+        $this->assertSame(self::EXIT_USAGE, $result['code']);
+        $this->assertStringContainsString($expected, $result['stderr']);
+    }
+
+    /**
+     * @return array<string, array{0: array<int, string>, 1: string}>
+     */
+    public static function provideUsageErrors(): array
+    {
+        return [
+            'no config' => [['--ip=1.1.1.1'], '--config'],
+            'unreadable config' => [['--config=/nonexistent/nope.yml'], 'not readable'],
+        ];
+    }
+
+    public function testInvalidIpIsRejected(): void
+    {
+        $result = $this->runCheck(['--config=' . $this->standardConfig(), '--ip=999.999.999.999']);
+
+        $this->assertSame(self::EXIT_USAGE, $result['code']);
+        $this->assertStringContainsString('not a valid address', $result['stderr']);
+    }
+
+    public function testMalformedHeaderIsRejected(): void
+    {
+        $result = $this->runCheck(['--config=' . $this->standardConfig(), '--header=NoColonHere']);
+
+        $this->assertSame(self::EXIT_USAGE, $result['code']);
+        $this->assertStringContainsString('NAME:VALUE', $result['stderr']);
+    }
+
+    public function testHelpExitsZeroAndDescribesTheOptions(): void
+    {
+        $result = $this->runCheck(['--help']);
+
+        $this->assertSame(self::EXIT_ALLOWED, $result['code']);
+        $this->assertStringContainsString('--config', $result['stdout']);
+        $this->assertStringContainsString('--explain', $result['stdout']);
+        $this->assertStringContainsString('EXIT CODES', $result['stdout']);
+    }
+}


### PR DESCRIPTION
Fixes #105.

Answers **"would this request be blocked, and by what?"** from a terminal, against a config file, with no running site.

```console
$ vendor/bin/firewall-check --config=firewall.yml --ip=203.0.113.5 --url=/wp-admin/
BLOCKED  GET /wp-admin/
  client            203.0.113.5
  blocked by        IP Address
  status            400
  reason            blocked
  storage           throwaway (in-memory)
```

Everything needed already existed — `Firewall::evaluate()` takes a `Request`, and `PluginManager::evaluate()` already records each plugin's result and timing. What did not exist was a *correct* way to call it, because three things fail **silently**.

## The three traps this exists to close

**1. `evaluate()` bypasses in CLI.** It returns `true` immediately when `PHP_SAPI === 'cli'` unless the mode is `exception`. A checker that misses this reports "allowed" for every request, including ones plainly inside a blocked CIDR — worse than no checker, because it looks like it works. Mode is forced, and a test asserts a known-blocked address is not reported as allowed.

**2. Overrides are bracket paths, not nested arrays.** `['global' => ['mode' => 'exception']]` is silently ignored; it has to be `['[global][mode]' => 'exception']`. Not hypothetical — it's exactly what happened on my first throwaway script, which cheerfully reported ALLOW for four requests that all block.

**3. A block is not read-only.** It writes to storage, records an offense, and applies `blocking_escalation`. Pointed at a production config, a naive "check" **bans the address it was asked about**.

## Safety

Storage is swapped for a throwaway by default, so a check cannot ban anyone. A test asserts the configured backend's file is never created even on a blocked verdict.

`--live-storage` opts back in when you genuinely need the durable blocklist consulted, warns on stderr, and keeps stdout parseable so `--json` still works.

## `--explain`

Shows what ran, and — from the parsed config — what an earlier match short-circuited past. The second list is usually the real answer to *"why wasn't this caught?"*:

```console
$ vendor/bin/firewall-check --config=firewall.yml --ip=203.0.113.5 --url=/wp-admin/ --explain
...
Plugins evaluated, in order:
  MATCH   IP Address                     0.06 ms

Configured but not reached:
  block     Kanopi\Firewall\Plugins\Url              weight -10
  block     Kanopi\Firewall\Plugins\UserAgent        weight 0
```

Attribution is read from the firewall's own decision log rather than by re-running plugins — a second pass would repeat every side effect, including any outbound reputation lookup.

## Exit codes

`0` allowed · `1` blocked · `2` challenged · `64` usage · `70` internal. The verdict *is* the exit status, so it composes:

```bash
if vendor/bin/firewall-check --config=firewall.yml --url=/wp-admin/ >/dev/null; then
  echo "Not blocked — the WordPress preset isn't doing its job."; exit 1
fi
```

Registered under composer `bin`, so consumers get `vendor/bin/firewall-check`.

---

# How to test

## 1. Automated

```bash
vendor/bin/phpunit -c phpunit.xml --testsuite unit --no-coverage --filter FirewallCheckCommandTest
```

Expected `OK (18 tests, 66 assertions)`. They drive the real script via `proc_open` rather than including it, because the exit code and the stdout/stderr split are both part of the contract and neither can be asserted honestly in-process.

```bash
composer test    # 863 unit (+18) + 49 integration
composer check   # phpcs + phpstan level max + rector
```

## 2. By hand

Save this as `firewall.yml`. It needs no external databases and no API keys — in-memory storage, and CRS ships with the package — so it runs anywhere the library installs.

```yaml
# firewall.yml — a small config for exercising bin/firewall-check.
global:
  mode: block
  banning_message: "Request {{request.id}} blocked."

storage:
  type: "Kanopi\\Firewall\\Storage\\InMemoryStorage"

plugins:
  # Trusted addresses bypass everything below.
  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
    response: allow
    weight: -200
    enable: true
    config:
      - 198.51.100.10

  # Known-bad addresses.
  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
    response: block
    weight: -100
    enable: true
    config:
      - 203.0.113.0/24

  # Paths that should never be reachable.
  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
    response: block
    weight: -50
    enable: true
    config:
      - "path@starts_with:/wp-admin"
      - "path:/.env"

  # Scanners and crawlers.
  - plugin: "Kanopi\\Firewall\\Plugins\\UserAgent"
    response: block
    weight: -10
    enable: true
    config:
      - "bot:true"
      - "client.name@contains:sqlmap"

  # OWASP Core Rule Set. No external data needed.
  - plugin: "Kanopi\\Firewall\\Plugins\\Crs"
    response: block
    weight: 50
    enable: true
    config:
      paranoia: 1
      mode: block
```

Every line below was run against exactly that file; the exit code is in the comment.

```bash
php bin/firewall-check --config=firewall.yml --ip=1.1.1.1 --url=/                      # ALLOWED     0
php bin/firewall-check --config=firewall.yml --ip=203.0.113.5 --url=/                  # IP Address  1
php bin/firewall-check --config=firewall.yml --ip=1.1.1.1 --url=/wp-admin/             # URL         1
php bin/firewall-check --config=firewall.yml --ip=1.1.1.1 --url=/.env                  # URL         1
php bin/firewall-check --config=firewall.yml --header='User-Agent: sqlmap/1.8'         # User Agent  1
php bin/firewall-check --config=firewall.yml --header='User-Agent: Googlebot/2.1'      # User Agent  1
php bin/firewall-check --config=firewall.yml --url="/search?q=1'+UNION+SELECT+1,2,3--" # CRS         1

# The allow bucket runs first, so a trusted address is let through a path
# that would otherwise be blocked:
php bin/firewall-check --config=firewall.yml --ip=198.51.100.10 --url=/wp-admin/       # ALLOWED     0
```

### `--explain` on a request that reaches the end of the chain

```console
$ php bin/firewall-check --config=firewall.yml --url="/search?q=1'+UNION+SELECT+1,2,3--" --explain

BLOCKED  GET /search?q=1'+UNION+SELECT+1,2,3--
  client            127.0.0.1
  blocked by        CRS
  status            403
  reason            Request 63284AE5F8F8F2FC006ACC7E1BD32A16 blocked.
  storage           throwaway (in-memory)

Plugins evaluated, in order:
  pass    IP Address                     0.05 ms
  pass    IP Address                     0.05 ms
  pass    URL                            0.30 ms
  pass    User Agent                   659.65 ms
  MATCH   CRS                           29.91 ms
```

Both `IpAddress` entries appear because the allow and block buckets each hold one. The timings are real: `matomo/device-detector` dominates on a cold call, which lines up with what the #100 benchmark found.

### `--explain` when something short-circuits

```console
$ php bin/firewall-check --config=firewall.yml --ip=203.0.113.5 --url=/wp-admin/ --explain

BLOCKED  GET /wp-admin/
  client            203.0.113.5
  blocked by        IP Address
  status            400
  ...

Plugins evaluated, in order:
  pass    IP Address                     0.05 ms
  MATCH   IP Address                     0.06 ms

Configured but not reached:
  block     Kanopi\Firewall\Plugins\Url              weight -50
  block     Kanopi\Firewall\Plugins\UserAgent        weight -10
  block     Kanopi\Firewall\Plugins\Crs              weight 50
```

If you were testing whether the URL rules catch `/wp-admin/`, this says the test never reached them — the IP list matched first.

### `--json`

```console
$ php bin/firewall-check --config=firewall.yml --ip=203.0.113.5 --url=/wp-admin/ --json
{
    "verdict": "blocked",
    "plugin": "IP Address",
    "status": 400,
    "reason": "Request 77D0FB0963139578FCAA37E31F35FCF2 blocked.",
    "request": {
        "ip": "203.0.113.5",
        "method": "GET",
        "path": "/wp-admin/",
        "query": null
    },
    "storage": "throwaway (in-memory)"
}
```

## 3. Verify the safety property

The most important behaviour. Point it at a config using `FileStorage` and confirm the file is never created:

```bash
cat > /tmp/fw-live.yml <<'YAML'
global: { mode: block }
storage:
  type: 'Kanopi\Firewall\Storage\FileStorage'
  config: { storage_file: /tmp/must-not-exist.json }
plugins:
  - plugin: "Kanopi\\Firewall\\Plugins\\IpAddress"
    response: block
    enable: true
    config: [203.0.113.0/24]
YAML

rm -f /tmp/must-not-exist.json
php bin/firewall-check --config=/tmp/fw-live.yml --ip=203.0.113.5   # BLOCKED
test -f /tmp/must-not-exist.json && echo "LEAKED (bug)" || echo "clean — storage untouched"

# And confirm the opt-in really does write:
php bin/firewall-check --config=/tmp/fw-live.yml --ip=203.0.113.5 --live-storage
test -f /tmp/must-not-exist.json && echo "written, as documented"
```

## 4. Confirm the CLI-bypass trap is actually closed

If mode-forcing ever regresses, everything reports allowed. This is the canary:

```bash
vendor/bin/phpunit -c phpunit.xml --testsuite unit --no-coverage \
  --filter testBlockedRequestIsNotSilentlyAllowedInCli
```

## 5. Docs

```bash
mkdocs build --strict
```

New page: **Guides → Checking a Request**.

## Note for reviewers

`check:code` and `check:security` target `src/` only, so `bin/firewall-check` sits outside the standard gates. I ran both against it manually and it is clean, including **PHPStan at level max** — that run is what surfaced a real bug where `getopt()` returns an array for a repeated flag and `(string)` cast emitted "Array to string conversion" (`--ip=a --ip=b` now takes the last value). Worth a closer read than usual since CI is not backing you up on this file.

Whether these paths should be added to the `check:*` scripts is a reasonable follow-up, but it would pull `tests/Performance/bin/*` in too and is a bigger change than this PR should make.

## Follow-up

#104 (now merged) added `find()` / `deleteMatching()` for "who is blocked?"; this answers "would this be blocked, and by what?". This branch was cut before that landed, so the guide deliberately does **not** link to the Searching and Un-blocking section — `mkdocs --strict` correctly rejected the dangling anchor at the time. Worth adding that cross-link in a follow-up now the anchor exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

