### PR TITLE
Cache the device-detector regex corpus (Fixes #107)

### DIFF
--- a/docs/plugins/user-agent.md
+++ b/docs/plugins/user-agent.md
@@ -42,6 +42,67 @@ plugins:
           - "client.version@less_than:80"
 ```
 
+## Caching
+
+The plugin's detection is backed by `matomo/device-detector`, which compiles a 1.7&nbsp;MB corpus of regex files on the first parse in each PHP process. That costs **110–637&nbsp;ms** depending on the user agent — ordinary mobile browsers are among the worst cases, because brand and model detection walks the largest part of the corpus. Once warm it is roughly 4&nbsp;ms.
+
+Under PHP-FPM every worker pays that on its first request, and again after each `pm.max_requests` recycle. The plugin therefore caches the compiled corpus **by default**:
+
+```
+618 ms   first request (populating the cache)
+ 23 ms   every subsequent process
+618 ms   with caching disabled, every time
+```
+
+No configuration is needed. The cache is written to `KANOPI_FIREWALL_CACHE_DIR` when that constant is defined, otherwise to a `kanopi-firewall-device-detector` directory inside the system temp directory — the same convention the [AbuseIPDB plugin](abuseipdb.md) uses for its verdict cache.
+
+### Pointing it somewhere else
+
+```yaml
+- plugin: "Kanopi\\Firewall\\Plugins\\UserAgent"
+  response: block
+  enable: true
+  metadata:
+    cache:
+      dir: /var/cache/firewall
+  config:
+    - "bot:true"
+```
+
+### Using a different backend
+
+Any PSR-6 pool works. The shape matches the one [rate limiting](rate-limit.md) already accepts, so there is a single convention to learn:
+
+```yaml
+    metadata:
+      cache:
+        adaptor: "Symfony\\Component\\Cache\\Adapter\\ApcuAdapter"
+        args: ['device-detector', 0]
+```
+
+An already-constructed pool can be injected through [configuration overrides](../configuration/overrides.md), since YAML cannot carry an object:
+
+```php
+Firewall::create([__DIR__ . '/firewall.yml'], [
+    '[plugins][0][metadata][cache][adaptor]' => $myCachePool,
+]);
+```
+
+### Turning it off
+
+```yaml
+    metadata:
+      cache: false
+```
+
+Detection is unchanged either way — only the speed differs.
+
+!!! note "Upgrades invalidate the cache automatically"
+
+    `device-detector` keys its cache entries by its own version, so a `composer update` that bumps the package produces new keys and the stale entries simply age out. There is nothing to clear by hand.
+
+A cache that cannot be created never stops the plugin working: the failure is logged at `warning` and detection continues uncached. An optimisation should not be able to take a site down.
+
 ## Available Variables
 
 - `bot` - Whether the user agent is a bot ("true" or "false")

--- a/src/Plugins/UserAgent.php
+++ b/src/Plugins/UserAgent.php
@@ -11,10 +11,14 @@ declare(strict_types=1);
 
 namespace Kanopi\Firewall\Plugins;
 
+use DeviceDetector\Cache\CacheInterface;
+use DeviceDetector\Cache\PSR6Bridge;
 use DeviceDetector\ClientHints;
 use DeviceDetector\DeviceDetector;
 use DeviceDetector\Parser\Device\AbstractDeviceParser;
 use Kanopi\Firewall\Traits\EvaluateTrait;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -28,6 +32,24 @@ class UserAgent extends AbstractPluginBase
      * Device Detector for the current request.
      */
     protected DeviceDetector $deviceDetector;
+
+    /**
+     * Regex-corpus cache handed to every DeviceDetector instance (#107).
+     *
+     * NULL when caching is switched off, or when the configured adaptor could
+     * not be built — in which case the plugin still works, just slowly.
+     */
+    protected ?CacheInterface $cache = null;
+
+    /**
+     * Whether the cache has been resolved yet.
+     *
+     * Resolution is deferred to the first evaluation rather than done in the
+     * constructor: plugins are instantiated lazily by `PluginManager`, but a
+     * config can still declare a plugin that never runs, and building a cache
+     * adaptor is not free — it creates directories.
+     */
+    private bool $cacheResolved = false;
 
     /**
      * {@inheritdoc}
@@ -86,8 +108,165 @@ class UserAgent extends AbstractPluginBase
         $clientHints = ClientHints::factory($_SERVER);
 
         $deviceDetector = new DeviceDetector($userAgent, $clientHints);
+
+        // Without this, device-detector recompiles its regex corpus — 20 YAML
+        // files, 1.7MB — on the first parse of every PHP process. That costs
+        // 110-637ms depending on the user agent, against ~4ms once warm, and
+        // under PHP-FPM every worker pays it on its first request and again
+        // after each `pm.max_requests` recycle (#107).
+        $cache = $this->cache();
+
+        if ($cache instanceof CacheInterface) {
+            $deviceDetector->setCache($cache);
+        }
+
         $deviceDetector->parse();
         return $deviceDetector;
+    }
+
+    /**
+     * The regex-corpus cache, built once per plugin instance.
+     *
+     * @return CacheInterface|null
+     *   NULL when caching is disabled or the adaptor could not be built.
+     */
+    protected function cache(): ?CacheInterface
+    {
+        if ($this->cacheResolved) {
+            return $this->cache;
+        }
+
+        $this->cacheResolved = true;
+        $this->cache = $this->buildCache();
+
+        return $this->cache;
+    }
+
+    /**
+     * Resolve `metadata.cache` into a device-detector cache.
+     *
+     * Accepts, in order of precedence:
+     *   - `false` — caching off.
+     *   - An already-constructed PSR-6 pool, for callers wiring this from a
+     *     framework container via config overrides.
+     *   - `['adaptor' => class-string, 'args' => [...]]`, matching the shape
+     *     `CacheRateLimitStorage` already uses so there is one convention
+     *     rather than two.
+     *   - Nothing — a filesystem cache under the shared firewall cache
+     *     directory, following the `AbuseIpdb` precedent.
+     *
+     * Never throws. A cache is an optimisation, and a security plugin that
+     * refuses to start because a cache directory is unwritable would be a
+     * worse outcome than one that runs slowly.
+     */
+    protected function buildCache(): ?CacheInterface
+    {
+        $configured = $this->metadata['cache'] ?? null;
+
+        // Explicit opt-out. Checked before the empty-ish cases below because
+        // `false` and "not configured" mean different things here.
+        if ($configured === false) {
+            $this->getLogger()->debug('User Agent regex cache disabled by config');
+            return null;
+        }
+
+        try {
+            $pool = $this->cachePool($configured);
+        } catch (\Throwable $throwable) {
+            $this->getLogger()->warning('User Agent regex cache could not be created - detection will be slower', [
+                'error' => $throwable->getMessage(),
+                'hint'  => 'Point metadata.cache.args at a writable directory, or set metadata.cache: false to silence this.',
+            ]);
+            return null;
+        }
+
+        if (!$pool instanceof CacheItemPoolInterface) {
+            return null;
+        }
+
+        $this->getLogger()->debug('User Agent regex cache initialized', [
+            'pool' => $pool::class,
+        ]);
+
+        return new PSR6Bridge($pool);
+    }
+
+    /**
+     * Build the PSR-6 pool backing the cache.
+     *
+     * @param mixed $configured
+     *   The raw `metadata.cache` value.
+     *
+     * @return CacheItemPoolInterface|null
+     *   The pool, or NULL when the configuration names something unusable.
+     */
+    protected function cachePool(mixed $configured): ?CacheItemPoolInterface
+    {
+        if ($configured instanceof CacheItemPoolInterface) {
+            return $configured;
+        }
+
+        $adaptor = is_array($configured) ? ($configured['adaptor'] ?? null) : null;
+
+        if ($adaptor instanceof CacheItemPoolInterface) {
+            return $adaptor;
+        }
+
+        if (is_string($adaptor) && $adaptor !== '') {
+            if (!class_exists($adaptor) || !is_subclass_of($adaptor, CacheItemPoolInterface::class)) {
+                $this->getLogger()->warning('User Agent cache adaptor is not a PSR-6 pool - falling back to the default', [
+                    'adaptor' => $adaptor,
+                ]);
+
+                return $this->defaultPool();
+            }
+
+            $args = is_array($configured['args'] ?? null) ? $configured['args'] : [];
+
+            return new $adaptor(...$args);
+        }
+
+        return $this->defaultPool();
+    }
+
+    /**
+     * Filesystem cache under the shared firewall cache directory.
+     *
+     * On by default. The alternative — off unless configured — would mean
+     * almost nobody gets the improvement, because the cost is invisible
+     * without profiling. Writing to the system temp directory follows what
+     * `AbuseIpdb` already does for its verdict cache.
+     *
+     * The namespace carries no version of its own: device-detector already
+     * keys its entries by `DeviceDetector::VERSION`, so an upgrade
+     * invalidates them without help from us.
+     */
+    protected function defaultPool(): CacheItemPoolInterface
+    {
+        return new FilesystemAdapter('device-detector', 0, $this->cacheDir());
+    }
+
+    /**
+     * Directory holding the cached regex corpus.
+     *
+     * Mirrors `AbuseIpdb::cacheDir()` so a deployment that already sets
+     * KANOPI_FIREWALL_CACHE_DIR does not have to say it twice.
+     */
+    protected function cacheDir(): string
+    {
+        $configured = is_array($this->metadata['cache'] ?? null)
+            ? ($this->metadata['cache']['dir'] ?? null)
+            : null;
+
+        if (is_string($configured) && trim($configured) !== '') {
+            return trim($configured);
+        }
+
+        if (defined('KANOPI_FIREWALL_CACHE_DIR')) {
+            return (string) constant('KANOPI_FIREWALL_CACHE_DIR');
+        }
+
+        return sys_get_temp_dir() . '/kanopi-firewall-device-detector';
     }
 
     /**

--- a/tests/Unit/Plugins/UserAgentCacheTest.php
+++ b/tests/Unit/Plugins/UserAgentCacheTest.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Plugins;
+
+use DeviceDetector\Cache\CacheInterface;
+use Kanopi\Firewall\Plugins\UserAgent;
+use Kanopi\Firewall\Tests\Logging\TestLogHandler;
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use Kanopi\Firewall\Logging\LoggingFactory;
+use Monolog\Logger;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Caching of the device-detector regex corpus (#107).
+ *
+ * device-detector recompiles 20 YAML files totalling 1.7MB on the first parse
+ * of every PHP process — 110-637ms depending on the user agent, against ~4ms
+ * once warm. Under PHP-FPM each worker pays that on its first request.
+ *
+ * These tests assert the wiring and, more importantly, that caching does not
+ * change what the plugin detects. A cache that quietly altered a verdict would
+ * be far worse than a slow one.
+ */
+final class UserAgentCacheTest extends AbstractTestCase
+{
+    private const IPHONE = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) '
+        . 'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1';
+    private const GOOGLEBOT = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+    private const SQLMAP = 'sqlmap/1.8.3#stable (https://sqlmap.org)';
+
+    /**
+     * @var array<int, string>
+     */
+    private array $tempDirs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempDirs as $dir) {
+            $this->removeDirectory($dir);
+        }
+
+        $this->tempDirs = [];
+
+        parent::tearDown();
+    }
+
+    private function tempDir(): string
+    {
+        $dir = sys_get_temp_dir() . '/fw-ua-cache-' . uniqid('', true);
+        $this->tempDirs[] = $dir;
+
+        return $dir;
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() ? @rmdir($item->getPathname()) : @unlink($item->getPathname());
+        }
+
+        @rmdir($dir);
+    }
+
+    private function request(string $userAgent): Request
+    {
+        return Request::create('/', 'GET', [], [], [], [
+            'REMOTE_ADDR' => '1.1.1.1',
+            'HTTP_USER_AGENT' => $userAgent,
+        ]);
+    }
+
+    /**
+     * Expose the resolved cache without reaching through reflection at every
+     * call site.
+     *
+     * @param array<string, mixed> $metadata
+     * @param array<int, mixed> $config
+     */
+    private function plugin(array $metadata = [], array $config = ['bot:true']): UserAgent
+    {
+        return new class ($metadata, $config) extends UserAgent {
+            public function resolvedCache(): ?CacheInterface
+            {
+                return $this->cache();
+            }
+
+            public function resolvedCacheDir(): string
+            {
+                return $this->cacheDir();
+            }
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // Correctness: caching must not change detection
+    // -----------------------------------------------------------------------
+
+    /**
+     * The property that matters most. A cache that altered a verdict would be
+     * a security regression dressed as an optimisation.
+     *
+     * @param string $userAgent
+     * @param string $variable
+     */
+    #[DataProvider('provideDetectionCases')]
+    public function testCachingDoesNotChangeDetection(string $userAgent, string $variable, string $expected): void
+    {
+        $dir = $this->tempDir();
+
+        $uncached = $this->plugin(['cache' => false], [$variable . ':' . $expected]);
+        $cached = $this->plugin(['cache' => ['dir' => $dir]], [$variable . ':' . $expected]);
+
+        $request = $this->request($userAgent);
+
+        // Run the cached one twice: once cold (populating), once warm (reading
+        // back). A cache that round-trips incorrectly would differ on the
+        // second call, not the first.
+        $uncachedResult = $uncached->evaluate($request);
+        $cachedCold = $cached->evaluate($request);
+
+        $warm = $this->plugin(['cache' => ['dir' => $dir]], [$variable . ':' . $expected]);
+        $cachedWarm = $warm->evaluate($request);
+
+        $this->assertSame($uncachedResult, $cachedCold, 'Cold cache changed the verdict.');
+        $this->assertSame($uncachedResult, $cachedWarm, 'Warm cache changed the verdict.');
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function provideDetectionCases(): array
+    {
+        return [
+            'bot is detected' => [self::GOOGLEBOT, 'bot', 'true'],
+            'browser is not a bot' => [self::IPHONE, 'bot', 'false'],
+            'device type' => [self::IPHONE, 'device.type', 'smartphone'],
+            'os name' => [self::IPHONE, 'os.name', 'iOS'],
+            'client name' => [self::SQLMAP, 'client.name', 'sqlmap'],
+        ];
+    }
+
+    /**
+     * Reading a populated cache must reproduce the same rich bot metadata, not
+     * merely the same boolean.
+     */
+    public function testWarmCacheReproducesBotMetadata(): void
+    {
+        $dir = $this->tempDir();
+        $request = $this->request(self::GOOGLEBOT);
+
+        $cold = $this->plugin(['cache' => ['dir' => $dir]], ['bot.name:Googlebot']);
+        $this->assertTrue($cold->evaluate($request), 'Cold cache failed to match bot.name.');
+
+        $warm = $this->plugin(['cache' => ['dir' => $dir]], ['bot.name:Googlebot']);
+        $this->assertTrue($warm->evaluate($request), 'Warm cache failed to match bot.name.');
+    }
+
+    // -----------------------------------------------------------------------
+    // Wiring
+    // -----------------------------------------------------------------------
+
+    public function testCachingIsOnByDefault(): void
+    {
+        $this->assertInstanceOf(CacheInterface::class, $this->plugin()->resolvedCache());
+    }
+
+    /**
+     * Off by default would mean almost nobody benefits, since the cost is
+     * invisible without profiling — but it must remain switchable.
+     */
+    public function testCachingCanBeDisabled(): void
+    {
+        $this->assertNull($this->plugin(['cache' => false])->resolvedCache());
+    }
+
+    public function testDisabledCacheStillEvaluatesCorrectly(): void
+    {
+        $plugin = $this->plugin(['cache' => false], ['bot:true']);
+
+        $this->assertTrue($plugin->evaluate($this->request(self::GOOGLEBOT)));
+        $this->assertFalse($plugin->evaluate($this->request(self::IPHONE)));
+    }
+
+    public function testDefaultCacheDirectoryIsCreatedAndUsed(): void
+    {
+        $dir = $this->tempDir();
+        $plugin = $this->plugin(['cache' => ['dir' => $dir]], ['bot:true']);
+
+        $plugin->evaluate($this->request(self::GOOGLEBOT));
+
+        $this->assertDirectoryExists($dir, 'The cache directory should have been created.');
+        $this->assertNotEmpty(glob($dir . '/*'), 'The cache directory should have been populated.');
+    }
+
+    public function testNothingIsWrittenWhenCachingIsDisabled(): void
+    {
+        $dir = $this->tempDir();
+        $plugin = $this->plugin(['cache' => false], ['bot:true']);
+
+        $plugin->evaluate($this->request(self::GOOGLEBOT));
+
+        $this->assertDirectoryDoesNotExist($dir);
+    }
+
+    /**
+     * The `['adaptor' => ..., 'args' => [...]]` shape matches what
+     * CacheRateLimitStorage already accepts, so there is one convention in the
+     * codebase rather than two.
+     */
+    public function testAdaptorClassAndArgsAreHonoured(): void
+    {
+        $dir = $this->tempDir();
+
+        $plugin = $this->plugin([
+            'cache' => [
+                'adaptor' => FilesystemAdapter::class,
+                'args' => ['device-detector', 0, $dir],
+            ],
+        ], ['bot:true']);
+
+        $this->assertTrue($plugin->evaluate($this->request(self::GOOGLEBOT)));
+        $this->assertDirectoryExists($dir);
+    }
+
+    /**
+     * An already-constructed pool is how a framework container would inject
+     * one, since YAML cannot carry an object.
+     */
+    public function testAnAlreadyConstructedPoolIsAccepted(): void
+    {
+        $pool = new ArrayAdapter();
+        $plugin = $this->plugin(['cache' => ['adaptor' => $pool]], ['bot:true']);
+
+        $this->assertInstanceOf(CacheInterface::class, $plugin->resolvedCache());
+        $this->assertTrue($plugin->evaluate($this->request(self::GOOGLEBOT)));
+        $this->assertNotSame([], $pool->getValues(), 'The injected pool should have been written to.');
+    }
+
+    public function testPoolPassedDirectlyWithoutTheAdaptorKeyIsAccepted(): void
+    {
+        $pool = new ArrayAdapter();
+        $plugin = $this->plugin(['cache' => $pool], ['bot:true']);
+
+        $this->assertInstanceOf(CacheInterface::class, $plugin->resolvedCache());
+    }
+
+    // -----------------------------------------------------------------------
+    // Degrading safely
+    // -----------------------------------------------------------------------
+
+    /**
+     * A typo in a YAML file must not take a site down. It degrades to the
+     * default cache and says so, following the precedent set by Crs and
+     * AbuseIpdb for bad config.
+     */
+    public function testUnusableAdaptorFallsBackAndWarns(): void
+    {
+        $handler = new TestLogHandler(\Monolog\Level::Debug);
+        LoggingFactory::setLogger(new Logger('test', [$handler]));
+
+        $plugin = $this->plugin(['cache' => ['adaptor' => 'Totally\\Not\\A\\Class']], ['bot:true']);
+
+        $this->assertInstanceOf(CacheInterface::class, $plugin->resolvedCache());
+        $this->assertTrue(
+            $handler->hasWarningContaining('not a PSR-6 pool'),
+            'A bad adaptor should warn rather than fail silently.',
+        );
+        // And the plugin still works.
+        $this->assertTrue($plugin->evaluate($this->request(self::GOOGLEBOT)));
+    }
+
+    /**
+     * A class that exists but is not a cache pool must be rejected on the same
+     * path — `class_exists()` alone would let it through to a fatal.
+     */
+    public function testNonPoolClassIsRejected(): void
+    {
+        $plugin = $this->plugin(['cache' => ['adaptor' => \stdClass::class]], ['bot:true']);
+
+        $this->assertInstanceOf(CacheInterface::class, $plugin->resolvedCache());
+        $this->assertTrue($plugin->evaluate($this->request(self::GOOGLEBOT)));
+    }
+
+    /**
+     * An unwritable cache location must leave a working, if slower, plugin.
+     * Refusing to evaluate would turn an optimisation into an outage.
+     */
+    public function testUnwritableCacheDirectoryDoesNotBreakEvaluation(): void
+    {
+        $plugin = $this->plugin([
+            'cache' => ['adaptor' => FilesystemAdapter::class, 'args' => ['dd', 0, '/proc/nope/definitely-not-writable']],
+        ], ['bot:true']);
+
+        $this->assertTrue($plugin->evaluate($this->request(self::GOOGLEBOT)));
+        $this->assertFalse($plugin->evaluate($this->request(self::IPHONE)));
+    }
+
+    // -----------------------------------------------------------------------
+    // Cache directory resolution
+    // -----------------------------------------------------------------------
+
+    public function testExplicitDirWins(): void
+    {
+        $dir = $this->tempDir();
+
+        $this->assertSame($dir, $this->plugin(['cache' => ['dir' => $dir]])->resolvedCacheDir());
+    }
+
+    public function testDefaultDirectoryLivesUnderTheSystemTempDir(): void
+    {
+        $this->assertStringStartsWith(sys_get_temp_dir(), $this->plugin()->resolvedCacheDir());
+    }
+}


### PR DESCRIPTION
Fixes #107.

`matomo/device-detector` compiles 20 YAML files totalling 1.7 MB on the first parse in each PHP process. Nothing ever called `setCache()`, so **every process paid it**.

Measured end to end through `bin/firewall-check` against an iPhone Safari agent:

```
618 ms   first request (populating the cache)
 23 ms   every subsequent process
618 ms   with caching disabled, every time
```

Under PHP-FPM each worker paid that on its first request, and again after every `pm.max_requests` recycle.

## The cost is not a scanner problem

This issue originally assumed scanners were the expensive case. They are the **cheap** one — `parse()` returns early once `parseBot()` matches:

| User agent | cold | `isBot()` |
|---|---|---|
| googlebot | **48 ms** | true |
| chrome desktop | 110 ms | false |
| **iphone safari** | **596 ms** | false |
| sqlmap | 628 ms | false |
| unrecognised string | 637 ms | false |

Ordinary mobile browsers are among the worst cases, because brand and model detection walks the largest part of the corpus. This hits real traffic hardest, which makes it more worth fixing than the original framing suggested.

It also explains the #100 benchmark's `user-agent` scenario: ~1,095 ms p95 and 18 MB peak against 2 MB elsewhere. The harness recreates the container per scenario, so all 64 workers start cold and a large share of requests are some worker's first.

## Configuration

On by default, no configuration required. `metadata.cache` accepts:

| Value | Effect |
|---|---|
| *(omitted)* | Filesystem cache in `KANOPI_FIREWALL_CACHE_DIR`, else the system temp directory |
| `false` | Caching off |
| `{dir: /path}` | Same default backend, different location |
| `{adaptor: FQCN, args: [...]}` | Any PSR-6 pool |
| an object | An already-constructed pool, injected via config overrides |

The `['adaptor', 'args']` shape is the one `CacheRateLimitStorage` already accepts, so there is one convention rather than two. The temp-directory default follows what `AbuseIpdb` already does for its verdict cache.

**On by default** because off-unless-configured would mean almost nobody benefits — the cost is invisible without profiling.

## Nothing here can take a site down

- An unusable adaptor (missing class, or a class that is not a PSR-6 pool) falls back to the default and warns.
- An unwritable directory logs at `warning` and continues **uncached**.

A plugin that refused to evaluate because a cache directory was read-only would turn an optimisation into an outage.

## Cache invalidation needs no handling

`device-detector` keys its entries by `DeviceDetector::VERSION` (`Parser/AbstractParser.php:284`), so a `composer update` that bumps the package produces new keys and the stale ones age out. Nothing to clear by hand.

---

# How to test

## 1. Automated

```bash
vendor/bin/phpunit -c phpunit.xml --testsuite unit --no-coverage --filter UserAgentCacheTest
```

Expected `OK (19 tests, 34 assertions)`.

The wiring tests are the boring ones. **The tests that matter assert caching does not change detection** — cold and warm verdicts compared against an uncached run across `bot`, `device.type`, `os.name`, `client.name` and `bot.name`. A cache that quietly altered a verdict would be a security regression dressed as an optimisation.

```bash
composer test    # 931 unit + 49 integration
composer check   # phpcs + phpstan level max + rector
```

## 2. See the improvement yourself

```bash
cat > /tmp/ua.yml <<'YAML'
global: { mode: block }
storage: { type: 'Kanopi\Firewall\Storage\InMemoryStorage' }
plugins:
  - plugin: "Kanopi\\Firewall\\Plugins\\UserAgent"
    response: block
    enable: true
    config:
      - "client.name@contains:sqlmap"
YAML

UA='User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1'

# Clear the cache. NOTE: sys_get_temp_dir() is not /tmp on macOS.
rm -rf "$(php -r 'echo sys_get_temp_dir();')/kanopi-firewall-device-detector"

bin/firewall-check --config=/tmp/ua.yml --header="$UA" --explain | grep 'User Agent'   # ~618 ms, cold
bin/firewall-check --config=/tmp/ua.yml --header="$UA" --explain | grep 'User Agent'   # ~23 ms
bin/firewall-check --config=/tmp/ua.yml --header="$UA" --explain | grep 'User Agent'   # ~23 ms
```

Then add `metadata: {cache: false}` to the plugin entry and confirm it returns to ~618 ms on every run.

> Worth flagging because it cost me a wrong measurement: on macOS `sys_get_temp_dir()` is `/var/folders/…/T`, not `/tmp`. Clearing `/tmp/kanopi-firewall-device-detector` silently clears nothing, and a "cold" run then reports ~40 ms because the real cache was still warm.

## 3. Confirm it degrades safely

```bash
# Unwritable cache location — must still evaluate, just slowly.
vendor/bin/phpunit -c phpunit.xml --testsuite unit --no-coverage \
  --filter 'testUnwritableCacheDirectoryDoesNotBreakEvaluation|testUnusableAdaptorFallsBackAndWarns|testNonPoolClassIsRejected'
```

## 4. Docs

```bash
mkdocs build --strict
```

New **Caching** section in `docs/plugins/user-agent.md`.

## Follow-ups, unchanged by this

- **#108** — skipping the parse phases the configured rules never reference. Independent: this removes the corpus *compile*, that removes the corpus *walk*. `parseDevice()` is ~85% of the remaining cost, so the two compound.
- **#109** — 3.x, the `bot:true` coverage gap. Detection quality, not speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
