### PR TITLE
Add an automated: rule variable for the wider bot list (Refs #109)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "doctrine/dbal": "^4.2",
         "geoip2/geoip2": "~2 || ^3",
         "guzzlehttp/guzzle": "^7.9",
+        "jaybizzle/crawler-detect": "^1.4",
         "kanopi/crs-engine": "^1.0",
         "matomo/device-detector": "^6.4",
         "monolog/monolog": "^3.9",

--- a/docs/plugins/user-agent.md
+++ b/docs/plugins/user-agent.md
@@ -42,6 +42,55 @@ plugins:
           - "client.version@less_than:80"
 ```
 
+## Catching automated traffic
+
+`bot:true` is backed by `matomo/device-detector`'s curated bot database, which has a blind spot — it does **not** classify a good deal of the tooling a firewall exists to stop.
+
+`automated:true` is the union of that database and a broader crawler list, and catches them:
+
+| | `bot:true` | `automated:true` |
+|---|---|---|
+| sqlmap, nikto | — | **matched** |
+| curl, python-requests, Go-http-client | — | **matched** |
+| masscan, nmap, zgrab, wpscan, nuclei, dirbuster | matched | matched |
+| Googlebot, bingbot, AhrefsBot, GPTBot | matched | matched |
+| real browsers | — | — |
+
+If you wrote `bot:true` expecting scanners to be stopped, **sqlmap is getting through today**. One line changes that:
+
+```yaml
+- plugin: "Kanopi\\Firewall\\Plugins\\UserAgent"
+  response: block
+  enable: true
+  config:
+    - "automated:true"
+```
+
+It is an ordinary rule variable, so it composes like any other:
+
+```yaml
+config:
+  # Anything automated except your own monitoring.
+  - type: AND
+    rules:
+      - "automated:true"
+      - "!client.name@contains:StatusCake"
+```
+
+### Why not just widen `bot:`
+
+The broader list deliberately counts generic HTTP client libraries as automated. That is usually what a firewall wants — but if a partner integration, a mobile app, or your own monitoring runs on `python-requests` or `Go-http-client`, `automated:true` **will block traffic that `bot:true` let through**.
+
+Redefining `bot:true` would apply that to rules people wrote long ago and have not touched. As a separate variable it is one line to opt into, and one line to leave alone. `bot:` keeps exactly the meaning it always had.
+
+### `bot.name` and the other sub-keys
+
+`bot.name`, `bot.category` and `bot.producer` come from the curated database only. An agent that solely the wider list recognises will satisfy `automated:true` while exposing no name to match on — the wider list yields a matched pattern, not an identity.
+
+### Interaction with `client.*` rules
+
+Worth knowing if you use `client.name@contains:sqlmap`: it keeps working alongside `automated:true`. Detection stops as soon as an agent is identified as a bot, and a stopped parse exposes no client at all — so the wider list is deliberately kept out of that decision. Folding it in would have silently broken exactly that rule.
+
 ## Caching
 
 The plugin's detection is backed by `matomo/device-detector`, which compiles a 1.7&nbsp;MB corpus of regex files on the first parse in each PHP process. That costs **110–637&nbsp;ms** depending on the user agent — ordinary mobile browsers are among the worst cases, because brand and model detection walks the largest part of the corpus. Once warm it is roughly 4&nbsp;ms.

--- a/src/Plugins/UserAgent.php
+++ b/src/Plugins/UserAgent.php
@@ -58,6 +58,45 @@ class UserAgent extends AbstractPluginBase
     private ?string $requiredPhase = null;
 
     /**
+     * Is this request automated, by any source we have (#109)?
+     *
+     * `bot:true` is device-detector's curated bot database, and it does not
+     * classify a good deal of the tooling a firewall exists to stop:
+     *
+     *   missed:  sqlmap, nikto, curl, python-requests, Go-http-client
+     *   caught:  masscan, nmap, zgrab, wpscan, nuclei, dirbuster,
+     *            googlebot, bingbot, ahrefs, gptbot
+     *
+     * `automated:true` is the union of that database and a broader crawler
+     * list which does catch them.
+     *
+     * WHY A SECOND VARIABLE RATHER THAN WIDENING `bot`:
+     *
+     * The wider list deliberately counts generic HTTP client libraries as
+     * automated. Redefining `bot:true` to include them would start blocking a
+     * partner integration or mobile app built on python-requests, on a rule
+     * the operator wrote long ago and has not touched — a behaviour change to
+     * a blocking rule, arriving in a minor release. As a distinct variable it
+     * is one line to opt into, and one line to leave alone.
+     *
+     * It is also why this is not a `metadata` setting: the plugin's vocabulary
+     * is its rules, and a rule reads better than a config knob that silently
+     * changes what an existing rule means.
+     *
+     * @return bool
+     *   Whether any source considers the agent automated.
+     */
+    protected function isAutomated(): bool
+    {
+        if ($this->deviceDetector->isBot()) {
+            return true;
+        }
+
+        return $this->deviceDetector instanceof SelectiveDeviceDetector
+            && $this->deviceDetector->isCrawler();
+    }
+
+    /**
      * Which parse phase produces each rule variable.
      *
      * Mirrors the switch in `getValue()`. Kept beside it deliberately: if a
@@ -66,6 +105,7 @@ class UserAgent extends AbstractPluginBase
      */
     private const VARIABLE_PHASES = [
         'bot' => SelectiveDeviceDetector::PHASE_BOT,
+        'automated' => SelectiveDeviceDetector::PHASE_BOT,
         'os' => SelectiveDeviceDetector::PHASE_OS,
         'client' => SelectiveDeviceDetector::PHASE_CLIENT,
         'device' => SelectiveDeviceDetector::PHASE_DEVICE,
@@ -486,6 +526,10 @@ class UserAgent extends AbstractPluginBase
         ]));
 
         switch (strtolower((string) $segments[0])) {
+            case 'automated':
+                // Any source. See the constant's docblock for why this is a
+                // separate variable rather than a redefinition of `bot`.
+                return $this->isAutomated() ? 'true' : 'false';
             case 'bot':
                 if (count($segments) === 1) {
                     return $this->deviceDetector->isBot() ? 'true' : 'false';

--- a/src/Utility/SelectiveDeviceDetector.php
+++ b/src/Utility/SelectiveDeviceDetector.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Kanopi\Firewall\Utility;
 
 use DeviceDetector\DeviceDetector;
+use Jaybizzle\CrawlerDetect\CrawlerDetect;
 
 /**
  * A DeviceDetector that stops once it has parsed as much as was asked for (#108).
@@ -142,6 +143,51 @@ class SelectiveDeviceDetector extends DeviceDetector
         }
 
         $this->parseDevice();
+    }
+
+    /**
+     * Shared crawler matcher (#109).
+     *
+     * Static because it is stateless for this use and constructing it costs
+     * ~0.4ms plus ~1.9ms on its first match, against ~0.05ms once warm. A
+     * fresh instance per request would hand back a noticeable slice of what
+     * #108 just saved on a `bot:`-only config.
+     */
+    private static ?CrawlerDetect $crawlerDetect = null;
+
+    /**
+     * Does a broader crawler list consider this agent automated?
+     *
+     * DELIBERATELY NOT AN OVERRIDE OF isBot(), AND THIS MATTERS:
+     *
+     * `parseUpTo()` — like `DeviceDetector::parse()` — stops as soon as
+     * `isBot()` is true, because a bot has no client or device worth parsing.
+     * Widening `isBot()` to include this list would therefore suppress client
+     * parsing for everything the broader list catches, and `getClient()`
+     * returns NULL once that happens. Verified:
+     *
+     *   masscan  (device-detector calls it a bot)  client = null
+     *   sqlmap   (it does not)                     client = {"name":"sqlmap",…}
+     *
+     * So folding this into `isBot()` would silently break
+     * `client.name@contains:sqlmap` — which is both the rule in the shipped
+     * example config and the documented workaround for the very gap this
+     * addresses. It stays a separate signal that no parse decision reads.
+     *
+     * @return bool
+     *   TRUE when the crawler list matches the user agent.
+     */
+    public function isCrawler(): bool
+    {
+        $userAgent = $this->getUserAgent();
+
+        if ($userAgent === '') {
+            return false;
+        }
+
+        self::$crawlerDetect ??= new CrawlerDetect();
+
+        return self::$crawlerDetect->isCrawler($userAgent);
     }
 
     /**

--- a/tests/Unit/Plugins/UserAgentAutomatedTest.php
+++ b/tests/Unit/Plugins/UserAgentAutomatedTest.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Plugins;
+
+use Kanopi\Firewall\Plugins\UserAgent;
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use Kanopi\Firewall\Utility\SelectiveDeviceDetector;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * The `automated:` rule variable (#109).
+ *
+ * `bot:true` is device-detector's curated bot database, and it misses sqlmap,
+ * nikto, curl, python-requests and Go-http-client. `automated:true` is the
+ * union of that database and a broader crawler list which catches them.
+ *
+ * A separate variable rather than a redefinition of `bot:`, because the wider
+ * list counts generic HTTP client libraries as automated. Changing what
+ * `bot:true` matches would start blocking traffic on a rule an operator wrote
+ * long ago and has not touched.
+ */
+final class UserAgentAutomatedTest extends AbstractTestCase
+{
+    private const SQLMAP = 'sqlmap/1.8.3#stable (https://sqlmap.org)';
+    private const NIKTO = 'Mozilla/5.00 (Nikto/2.5.0) (Evasions:None) (Test:Port Check)';
+    private const CURL = 'curl/8.4.0';
+    private const PYTHON = 'python-requests/2.31.0';
+    private const GO = 'Go-http-client/1.1';
+    private const MASSCAN = 'masscan/1.3.2 (https://github.com/robertdavidgraham/masscan)';
+    private const GOOGLEBOT = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+    private const CHROME = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+        . '(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+    private const IPHONE = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) '
+        . 'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1';
+
+    /**
+     * @param array<int, mixed> $config
+     */
+    private function evaluate(array $config, string $userAgent): bool
+    {
+        // Caching off so this suite is not coupled to #107's cache directory.
+        $plugin = new UserAgent(['cache' => false], $config);
+
+        return $plugin->evaluate(Request::create('/', 'GET', [], [], [], [
+            'REMOTE_ADDR' => '1.1.1.1',
+            'HTTP_USER_AGENT' => $userAgent,
+        ]));
+    }
+
+    // -----------------------------------------------------------------------
+    // `bot:` must not move
+    // -----------------------------------------------------------------------
+
+    /**
+     * Pins `bot:true` exactly as it behaves today. Anything that widens it
+     * without the operator asking is a breaking change to a blocking rule,
+     * and this is the test that should stop it.
+     */
+    #[DataProvider('provideBotBehaviour')]
+    public function testBotVariableIsUnchanged(string $userAgent, bool $expected): void
+    {
+        $this->assertSame($expected, $this->evaluate(['bot:true'], $userAgent));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: bool}>
+     */
+    public static function provideBotBehaviour(): array
+    {
+        return [
+            // In device-detector's database.
+            'masscan' => [self::MASSCAN, true],
+            'googlebot' => [self::GOOGLEBOT, true],
+            // The gap `automated:` exists to cover — still open for `bot:`.
+            'sqlmap' => [self::SQLMAP, false],
+            'nikto' => [self::NIKTO, false],
+            'curl' => [self::CURL, false],
+            'python-requests' => [self::PYTHON, false],
+            'go-http-client' => [self::GO, false],
+            // Never, under either variable.
+            'chrome' => [self::CHROME, false],
+            'iphone' => [self::IPHONE, false],
+        ];
+    }
+
+    // -----------------------------------------------------------------------
+    // `automated:` closes the gap
+    // -----------------------------------------------------------------------
+
+    #[DataProvider('provideToolingBotMisses')]
+    public function testAutomatedCatchesWhatBotMisses(string $userAgent): void
+    {
+        $this->assertFalse(
+            $this->evaluate(['bot:true'], $userAgent),
+            'Precondition: bot:true should not catch this agent.',
+        );
+        $this->assertTrue(
+            $this->evaluate(['automated:true'], $userAgent),
+            'automated:true should catch it.',
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function provideToolingBotMisses(): array
+    {
+        return [
+            'sqlmap' => [self::SQLMAP],
+            'nikto' => [self::NIKTO],
+            'curl' => [self::CURL],
+            'python-requests' => [self::PYTHON],
+            'go-http-client' => [self::GO],
+        ];
+    }
+
+    /**
+     * The union must not lose what device-detector already caught.
+     */
+    #[DataProvider('provideKnownBots')]
+    public function testAutomatedKeepsWhatBotAlreadyCaught(string $userAgent): void
+    {
+        $this->assertTrue($this->evaluate(['automated:true'], $userAgent));
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function provideKnownBots(): array
+    {
+        return ['masscan' => [self::MASSCAN], 'googlebot' => [self::GOOGLEBOT]];
+    }
+
+    /**
+     * Wider coverage is only useful if it does not start blocking people.
+     */
+    #[DataProvider('provideBrowsers')]
+    public function testBrowsersAreNeverAutomated(string $userAgent): void
+    {
+        $this->assertFalse($this->evaluate(['bot:true'], $userAgent));
+        $this->assertFalse($this->evaluate(['automated:true'], $userAgent));
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function provideBrowsers(): array
+    {
+        return ['chrome' => [self::CHROME], 'iphone' => [self::IPHONE]];
+    }
+
+    public function testAutomatedFalseMatchesRealBrowsers(): void
+    {
+        $this->assertTrue($this->evaluate(['automated:false'], self::CHROME));
+        $this->assertFalse($this->evaluate(['automated:false'], self::SQLMAP));
+    }
+
+    public function testEmptyUserAgentIsNotAutomated(): void
+    {
+        $this->assertFalse($this->evaluate(['automated:true'], ''));
+    }
+
+    // -----------------------------------------------------------------------
+    // The regression that widening isBot() would have caused
+    // -----------------------------------------------------------------------
+
+    /**
+     * The reason the crawler list is a separate signal rather than a wider
+     * `isBot()`.
+     *
+     * Parsing stops as soon as `isBot()` is true, and `getClient()` returns
+     * NULL once it has. Had the wider list fed `isBot()`, sqlmap would
+     * short-circuit and `client.name@contains:sqlmap` would stop matching —
+     * both the rule in the shipped example config and the documented
+     * workaround for this very gap.
+     */
+    public function testClientRulesStillMatchForAgentsTheWiderListCatches(): void
+    {
+        $this->assertTrue($this->evaluate(['client.name@contains:sqlmap'], self::SQLMAP));
+
+        // And still so when the same config also asks the wider question.
+        $this->assertTrue(
+            $this->evaluate(['automated:true', 'client.name@contains:sqlmap'], self::SQLMAP),
+        );
+    }
+
+    /**
+     * The detector's own bot flag drives the parse short-circuit, so it must
+     * stay device-detector's alone.
+     */
+    public function testDetectorIsBotIsNotWidened(): void
+    {
+        $detector = new SelectiveDeviceDetector(self::SQLMAP);
+        $detector->parseUpTo(SelectiveDeviceDetector::PHASE_CLIENT);
+
+        $this->assertFalse($detector->isBot(), 'isBot() must remain device-detector only.');
+        $this->assertTrue($detector->isCrawler(), 'The wider list should recognise sqlmap.');
+        $this->assertNotEmpty($detector->getClient(), 'Client parsing must not have been short-circuited.');
+    }
+
+    public function testDetectorCrawlerCheckIgnoresAnEmptyAgent(): void
+    {
+        $detector = new SelectiveDeviceDetector('');
+        $detector->parseUpTo(SelectiveDeviceDetector::PHASE_CLIENT);
+
+        $this->assertFalse($detector->isCrawler());
+    }
+
+    // -----------------------------------------------------------------------
+    // Sub-keys and composition
+    // -----------------------------------------------------------------------
+
+    /**
+     * `bot.name` and friends come from the curated database. The wider list
+     * yields a matched pattern rather than an identity, so an agent only it
+     * recognises satisfies `automated:true` while exposing no name.
+     */
+    public function testBotSubKeysRemainDeviceDetectorOnly(): void
+    {
+        $this->assertTrue($this->evaluate(['bot.name:Googlebot'], self::GOOGLEBOT));
+        $this->assertFalse($this->evaluate(['bot.name@contains:sqlmap'], self::SQLMAP));
+    }
+
+    /**
+     * Being a normal rule variable, it composes with the rest of the syntax
+     * rather than needing its own configuration section.
+     */
+    public function testAutomatedComposesWithGroupedRules(): void
+    {
+        $config = [[
+            'type' => 'AND',
+            'rules' => ['automated:true', 'client.name@contains:sqlmap'],
+        ]];
+
+        $this->assertTrue($this->evaluate($config, self::SQLMAP));
+        // Googlebot is automated but is not sqlmap, so the AND fails.
+        $this->assertFalse($this->evaluate($config, self::GOOGLEBOT));
+    }
+
+    public function testAutomatedComposesWithNegation(): void
+    {
+        $this->assertTrue($this->evaluate(['!automated:true'], self::CHROME));
+        $this->assertFalse($this->evaluate(['!automated:true'], self::SQLMAP));
+    }
+
+    /**
+     * The wider list reads the raw user agent, so it needs no parse beyond the
+     * bot phase — an `automated:`-only config stays as cheap as a `bot:`-only
+     * one (#108).
+     */
+    public function testAutomatedDoesNotDeepenTheParse(): void
+    {
+        $plugin = new class (['cache' => false], ['automated:true']) extends UserAgent {
+            public function phase(): string
+            {
+                return $this->requiredPhase();
+            }
+        };
+
+        $this->assertSame(SelectiveDeviceDetector::PHASE_BOT, $plugin->phase());
+    }
+}


### PR DESCRIPTION
Refs #109. Adds the opt-in; changing what `bot:` itself means stays 3.x.

`bot:true` is device-detector's curated bot database, which does **not** classify sqlmap, nikto, curl, python-requests or Go-http-client as bots. Anyone who wrote that rule expecting scanners to be stopped is not getting them.

`automated:true` is the union of that database and a broader crawler list:

```yaml
config:
  - "automated:true"
```

| | `bot:true` | `automated:true` |
|---|---|---|
| sqlmap, nikto | — | **matched** |
| curl, python-requests, Go-http-client | — | **matched** |
| masscan, nmap, zgrab, wpscan, nuclei, dirbuster | matched | matched |
| Googlebot, bingbot, AhrefsBot, GPTBot | matched | matched |
| Chrome, Safari iOS | — | — |

## A rule variable, not a config setting

First cut of this used `metadata.bot_detector: both`. That was the wrong shape: the plugin's vocabulary is its rules, and it asked operators to open a `metadata:` section to answer a question the rule list already expresses. It also read worse — the config reconfigured what an existing rule silently meant, instead of saying what was being matched.

As an ordinary variable it composes like any other:

```yaml
config:
  # Anything automated except your own monitoring.
  - type: AND
    rules:
      - "automated:true"
      - "!client.name@contains:StatusCake"
```

## Why not simply widen `bot:`

The wider list deliberately counts generic HTTP client libraries as automated. Redefining `bot:true` would start blocking a partner integration or mobile app on `python-requests` — on a rule the operator wrote long ago and has not touched. One line to opt into, one line to leave alone.

A regression test pins all nine reference agents against today's `bot:` behaviour, so nothing widens it by accident.

## Why the wider list is a separate signal, not a wider `isBot()`

The part most worth reviewing. The obvious implementation — override `isBot()` in `SelectiveDeviceDetector` so everything downstream sees the combined answer — **silently breaks existing configs**.

Parsing stops as soon as `isBot()` is true, and `getClient()` returns `NULL` once it has:

```
masscan  (device-detector calls it a bot)   client = null
sqlmap   (it does not)                      client = {"type":"library","name":"sqlmap","version":"1.8"}
```

So widening `isBot()` would make sqlmap short-circuit, and **`client.name@contains:sqlmap` would stop matching** — both the rule in the shipped example config and the documented workaround for this very gap. `isCrawler()` therefore sits *alongside* `isBot()`, and no parse decision reads it.

## Other decisions

- **Sub-keys stay device-detector's.** `bot.name`, `.category`, `.producer` come from a curated database; the wider list yields a matched pattern, not an identity.
- **`automated` maps to the bot parse phase**, so an `automated:`-only config stays as cheap as a `bot:`-only one (#108) — the wider list reads the raw user agent and needs nothing parsed.
- **`CrawlerDetect` is a shared static instance** — ~0.4 ms to construct plus ~1.9 ms on its first match, against ~0.05 ms once warm.
- **`jaybizzle/crawler-detect` is 156 KB, MIT, no dependencies** beyond PHP ≥7.2, released two weeks ago.

---

# How to test

## 1. Automated

```bash
vendor/bin/phpunit -c phpunit.xml --testsuite unit --no-coverage --filter UserAgentAutomatedTest
```

Expected `OK (27 tests, 41 assertions)`.

Two groups matter more than the rest:

- **`testBotVariableIsUnchanged`** — pins all nine reference agents against today's `bot:` behaviour. This is what should fail if anyone widens it by accident.
- **`testClientRulesStillMatchForAgentsTheWiderListCatches`** and **`testDetectorIsBotIsNotWidened`** — the regression that overriding `isBot()` would have caused.

```bash
composer test    # 1012 unit + 49 integration
composer check   # phpcs + phpstan level max + rector
```

## 2. By hand

```bash
cat > /tmp/bot.yml <<'YAML'
global: { mode: block }
storage: { type: 'Kanopi\Firewall\Storage\InMemoryStorage' }
plugins:
  - plugin: "Kanopi\\Firewall\\Plugins\\UserAgent"
    response: block
    enable: true
    config:
      - "automated:true"
YAML

sed 's/automated:true/bot:true/' /tmp/bot.yml > /tmp/bot-narrow.yml

for ua in 'sqlmap/1.8.3' 'curl/8.4.0' 'python-requests/2.31.0' \
          'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' \
          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'; do
  bin/firewall-check --config=/tmp/bot-narrow.yml --header="User-Agent: $ua" >/dev/null 2>&1; a=$?
  bin/firewall-check --config=/tmp/bot.yml --header="User-Agent: $ua" >/dev/null 2>&1; b=$?
  printf '%-30s bot=%s  automated=%s\n' "${ua:0:28}" \
    "$([ $a -eq 1 ] && echo BLOCK || echo allow)" "$([ $b -eq 1 ] && echo BLOCK || echo allow)"
done
```

Browsers must stay `allow` in both columns.

## 3. Confirm the workaround still works

```bash
vendor/bin/phpunit -c phpunit.xml --testsuite unit --no-coverage \
  --filter 'testClientRulesStillMatchForAgentsTheWiderListCatches|testDetectorIsBotIsNotWidened'
```

## 4. Docs

```bash
mkdocs build --strict
```

New **Catching automated traffic** section in `docs/plugins/user-agent.md`.

## What is left for 3.x

Whether `bot:` itself should become the union, and whether `bot.*` sub-keys should ever be populated from the wider list. #109 stays open for both.

## Follow-up not taken here

For an `automated:`-only config, device-detector is not strictly needed at all — the wider list could answer without parsing anything. That would compound with #108 but adds a second short-circuit path, so it is worth its own change rather than riding along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
