### PR TITLE
Verify the user-agent cache actually persists (fixes a v2.11.0 defect)

### DIFF
--- a/docs/plugins/user-agent.md
+++ b/docs/plugins/user-agent.md
@@ -152,6 +152,16 @@ Detection is unchanged either way — only the speed differs.
 
 A cache that cannot be created never stops the plugin working: the failure is logged at `warning` and detection continues uncached. An optimisation should not be able to take a site down.
 
+!!! warning "Check the log if you suspect the cache is not working"
+
+    Constructing a cache proves nothing — a filesystem pool is created quite happily against an unwritable directory and only fails later, on each write. The plugin therefore writes and reads back a probe value before trusting a cache, and logs this when it cannot:
+
+    ```
+    User Agent regex cache is not writable - every request will re-parse the detection corpus
+    ```
+
+    That message means roughly **600 ms per request instead of ~20 ms**. Point `metadata.cache.dir` at a writable directory, define `KANOPI_FIREWALL_CACHE_DIR`, or set `metadata.cache: false` if you want to accept the cost deliberately and stop the warning.
+
 ### Only what your rules need
 
 Detection runs in four phases — bot, OS, client, then device (brand and model). Since the rules are known up front, the plugin stops at the deepest phase they actually read:

--- a/src/Plugins/UserAgent.php
+++ b/src/Plugins/UserAgent.php
@@ -405,11 +405,64 @@ class UserAgent extends AbstractPluginBase
             return null;
         }
 
+        // Constructing a pool proves nothing. FilesystemAdapter succeeds on an
+        // unwritable directory and only fails later, per write — so without
+        // this the plugin reported a healthy cache while every request paid
+        // the full uncached parse, ~645ms, forever and silently.
+        if (!$this->cacheIsUsable($pool)) {
+            $this->getLogger()->warning(
+                'User Agent regex cache is not writable - every request will re-parse the detection corpus',
+                [
+                    'pool' => $pool::class,
+                    'impact' => 'Roughly 600ms per request instead of ~20ms.',
+                    'hint' => 'Point metadata.cache.dir at a writable directory, define '
+                        . 'KANOPI_FIREWALL_CACHE_DIR, or set metadata.cache: false to accept the cost silently.',
+                ],
+            );
+
+            return null;
+        }
+
         $this->getLogger()->debug('User Agent regex cache initialized', [
             'pool' => $pool::class,
         ]);
 
         return new PSR6Bridge($pool);
+    }
+
+    /**
+     * Does this pool actually persist anything?
+     *
+     * A round trip rather than a permissions check: the pool may be a
+     * filesystem directory, Redis, APCu or something a consumer injected, and
+     * the only property that matters is whether a value written now can be
+     * read back. Cheap — sub-millisecond on every backend — and it runs once
+     * per plugin instance, not once per evaluation.
+     *
+     * @param CacheItemPoolInterface $cacheItemPool
+     *   The pool to probe.
+     *
+     * @return bool
+     *   TRUE when a written value came back.
+     */
+    protected function cacheIsUsable(CacheItemPoolInterface $cacheItemPool): bool
+    {
+        try {
+            $item = $cacheItemPool->getItem('kanopi_firewall_cache_probe');
+            $item->set(true);
+
+            if (!$cacheItemPool->save($item)) {
+                return false;
+            }
+
+            return $cacheItemPool->getItem('kanopi_firewall_cache_probe')->isHit();
+        } catch (\Throwable $throwable) {
+            $this->getLogger()->debug('User Agent regex cache probe threw', [
+                'error' => $throwable->getMessage(),
+            ]);
+
+            return false;
+        }
     }
 
     /**

--- a/tests/Unit/Plugins/UserAgentCacheTest.php
+++ b/tests/Unit/Plugins/UserAgentCacheTest.php
@@ -324,4 +324,57 @@ final class UserAgentCacheTest extends AbstractTestCase
     {
         $this->assertStringStartsWith(sys_get_temp_dir(), $this->plugin()->resolvedCacheDir());
     }
+
+    /**
+     * Regression for the defect shipped in v2.11.0.
+     *
+     * `FilesystemAdapter` constructs happily against an unwritable directory
+     * and only fails later, per write. The plugin therefore logged
+     * "cache initialized" at debug and every request paid the full uncached
+     * parse — roughly 645ms instead of ~20ms — silently, forever.
+     */
+    public function testUnwritableCacheIsDetectedAndWarnedAboutLoudly(): void
+    {
+        $handler = new TestLogHandler(\Monolog\Level::Debug);
+        LoggingFactory::setLogger(new Logger('test', [$handler]));
+
+        $plugin = $this->plugin(['cache' => ['dir' => '/proc/definitely-not-writable/nope']], ['bot:true']);
+
+        $this->assertNull(
+            $plugin->resolvedCache(),
+            'A cache that cannot persist must not be reported as usable.',
+        );
+        $this->assertTrue(
+            $handler->hasWarningContaining('not writable'),
+            'An unusable cache must warn, not pass silently at debug level.',
+        );
+    }
+
+    /**
+     * The probe must not reject a cache that works.
+     */
+    public function testUsableCacheIsNotRejectedByTheProbe(): void
+    {
+        $handler = new TestLogHandler(\Monolog\Level::Debug);
+        LoggingFactory::setLogger(new Logger('test', [$handler]));
+
+        $plugin = $this->plugin(['cache' => ['dir' => $this->tempDir()]], ['bot:true']);
+
+        $this->assertInstanceOf(CacheInterface::class, $plugin->resolvedCache());
+        $this->assertFalse($handler->hasWarningContaining('not writable'));
+    }
+
+    /**
+     * The probe leaves nothing behind that could be mistaken for corpus data.
+     */
+    public function testProbeDoesNotDisturbTheCachedCorpus(): void
+    {
+        $dir = $this->tempDir();
+
+        $first = $this->plugin(['cache' => ['dir' => $dir]], ['bot:true']);
+        $this->assertTrue($first->evaluate($this->request(self::GOOGLEBOT)));
+
+        $second = $this->plugin(['cache' => ['dir' => $dir]], ['bot:true']);
+        $this->assertTrue($second->evaluate($this->request(self::GOOGLEBOT)));
+    }
 }


### PR DESCRIPTION
Fixes a defect shipped in v2.11.0 (#107 / #110).

**Constructing a cache pool proves nothing.** Symfony's `FilesystemAdapter` is created quite happily against an unwritable directory and only fails later, on each individual write. So the plugin logged `[DEBUG] User Agent regex cache initialized` — reporting success — and then re-parsed the full 1.7 MB detection corpus on **every request**, silently, forever.

Measured against an unwritable cache directory, before this change:

```
645 ms per request
  logged: [DEBUG] User Agent regex cache initialized
```

That is precisely the pathology #107 existed to remove, reached by nothing more exotic than a read-only temp directory or a cache path owned by the wrong user — neither unusual in a container.

After:

```
  logged: [WARNING] User Agent regex cache is not writable - every request
          will re-parse the detection corpus
```

## What changed

The plugin now writes and reads back a probe value before trusting a pool. If the value does not come back, it warns at `warning` level with the impact and the three ways out, and continues uncached.

Falling back to no cache is still correct — an optimisation must not be able to take a site down — but it has to be **visible**. A 30× slowdown that reports itself as healthy is worse than one that reports nothing at all.

A round trip rather than an `is_writable()` check, deliberately: the pool may be a filesystem directory, Redis, APCu, or something a consumer injected through config overrides, and the only property that matters is whether a value written now reads back. It costs a fraction of a millisecond and runs **once per plugin instance**, not once per evaluation.

## How this was found

From the question *"every page request is going to create a new class object and having it take 500 ms+ will cause issues"*.

The general case was already fine — with a working cache a brand-new object in a brand-new process costs ~25 ms, because the cache lives on disk and survives process death:

```
process 1   25.06 ms      # fresh object, fresh process
process 2   25.69 ms
caching off 635.12 ms
```

But the question was right that *a* path existed where every request pays the full cost. This was it, and it was invisible.

---

# How to test

## 1. Automated

```bash
vendor/bin/phpunit -c phpunit.xml --testsuite unit --no-coverage --filter UserAgentCacheTest
```

Expected `OK (22 tests, 40 assertions)` — 19 existing plus 3 new:

- **`testUnwritableCacheIsDetectedAndWarnedAboutLoudly`** — the regression itself.
- `testUsableCacheIsNotRejectedByTheProbe` — the probe must not reject a working cache.
- `testProbeDoesNotDisturbTheCachedCorpus` — the probe leaves nothing that could be mistaken for corpus data.

```bash
composer test    # 1015 unit + 49 integration
composer check   # phpcs + phpstan level max + rector
```

## 2. Reproduce it by hand

```php
<?php
require 'vendor/autoload.php';
use Kanopi\Firewall\Plugins\UserAgent;
use Kanopi\Firewall\Logging\LoggingFactory;
use Monolog\{Logger, Handler\TestHandler};
use Symfony\Component\HttpFoundation\Request;

$h = new TestHandler(\Monolog\Level::Debug);
LoggingFactory::setLogger(new Logger('t', [$h]));

$req = Request::create('/', 'GET', [], [], [], [
    'REMOTE_ADDR' => '1.1.1.1',
    'HTTP_USER_AGENT' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) '
        . 'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
]);

$s = hrtime(true);
(new UserAgent(['cache' => ['dir' => '/proc/nope/not-writable']], ['device.type:smartphone']))->evaluate($req);
printf("%.2f ms\n", (hrtime(true) - $s) / 1e6);

foreach ($h->getRecords() as $r) {
    if (stripos($r->message, 'cache') !== false) {
        printf("[%s] %s\n", $r->level->getName(), $r->message);
    }
}
```

Before: `~645 ms` and a `DEBUG` line claiming the cache initialised.
After: `~645 ms` and a `WARNING` naming the problem.

## 3. Confirm a healthy cache is unaffected

```bash
vendor/bin/phpunit -c phpunit.xml --testsuite unit --no-coverage \
  --filter 'testUsableCacheIsNotRejectedByTheProbe|testDefaultCacheDirectoryIsCreatedAndUsed'
```

## 4. Docs

```bash
mkdocs build --strict
```

An admonition in `docs/plugins/user-agent.md` telling operators what the warning means and what to do about it.

## Note

`ConfigTest::testFileGetContentsSuccessSameProcess` fetches `https://example.com` and is flaky on a cold network — it failed once during this work and passes in isolation. Unrelated to this change, but worth knowing if CI trips on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
