### PR TITLE
Document reading a file from a literal path (Fixes #114)

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -93,7 +93,9 @@ app:
 
 ## Filesystem Processors (opt-in)
 
-The `file:` (read a file's contents) and `require:` (include a PHP file and use its return value) processors are **disabled by default**. Because their path comes from an environment variable, enabling them turns any env-var injection into a local file inclusion — or, for `require:`, remote code execution.
+The `file:` (read a file's contents) and `require:` (include a PHP file and use its return value) processors are **disabled by default**. Their path *typically* comes from an environment variable, and where it does, enabling them turns any env-var injection into a local file inclusion — or, for `require:`, remote code execution.
+
+The path does not have to come from a variable — see [Reading from a known path](#reading-from-a-known-path) below, which is the lower-risk form when you already know where the file is.
 
 Using either one without opting in raises `ConfigurationException` from `TokenSubstitute`. Note where that exception ends up:
 
@@ -120,6 +122,44 @@ global:
 - **Second argument** — absolute base directories. The resolved `realpath()` of the target must sit under one of them, otherwise loading fails. Passing an empty list disables the prefix check entirely and is **not recommended in production** — do it only if you have vetted every path your environment variables can produce.
 - Base directories must already exist; a directory that does not resolve throws `ConfigurationException`.
 - `TokenSubstitute::resetUnsafeProcessors()` clears the opt-in again. It exists for test suites, not for request-time use.
+
+### Reading from a known path
+
+When the path is known up front, you do not need an environment variable at all. `default:` supplies the path and `file:` reads it:
+
+```yaml
+challenge:
+  secret: '%env(file:default:/etc/firewall/hmac.key:UNUSED)%'
+```
+
+`UNUSED` is a variable name that must **never be defined**. The chain reads left to right: the variable is unset, so `default:` yields `/etc/firewall/hmac.key`, and `file:` reads that path.
+
+This is the safer of the two forms — an attacker who can influence the environment cannot redirect a path that is written in the config file. Two caveats before you rely on it:
+
+!!! warning "The named variable must stay undefined"
+
+    If anything ever defines `UNUSED` — a platform injecting variables, a `.env` file, a colleague reusing the name — the path silently becomes that value and the file read silently changes. Nothing in the config signals that dependency. Choose a name you are confident nothing else will use, and treat it as part of the configuration.
+
+    This is where the base-directory allowlist earns its keep. With `enableUnsafeProcessors(['file'], ['/etc/firewall'])` in place, a hijacked variable pointing at `/etc/passwd` fails loudly instead of being read:
+
+    ```
+    ConfigurationException: Path for file processor escapes the configured allowlist: /etc/passwd
+    ```
+
+    Do not pass an empty allowlist when using this form.
+
+!!! warning "A colon truncates the path"
+
+    Tokens are split on `:`, so a path containing one is cut short:
+
+    ```
+    %env(file:default:/tmp/sec:rets/key.txt:UNUSED)%
+      -> ConfigurationException: Path for file processor does not resolve: /tmp/sec
+    ```
+
+    This is the same limitation `raw_key:` exists to work around for keys, but there is no equivalent escape for paths. If your path contains a colon, use a [configuration override](overrides.md#reading-a-value-from-a-file) instead.
+
+If neither caveat sits well, reading the file in PHP and passing it as an [override](overrides.md#reading-a-value-from-a-file) avoids both.
 
 Prefer `file:` over `require:` whenever you can — reading a secret is far less dangerous than executing a path an attacker may influence.
 

--- a/docs/configuration/overrides.md
+++ b/docs/configuration/overrides.md
@@ -55,3 +55,21 @@ if (($config['storage']['config']['file'] ?? null) !== $expectedPath) {
     throw new \RuntimeException('Firewall storage override did not apply.');
 }
 ```
+
+## Reading a value from a file
+
+Overrides are ordinary PHP, so a value that lives in a file needs nothing more than `file_get_contents()`:
+
+```php
+<?php
+Firewall::create([__DIR__ . '/firewall.yml'], [
+    // Secrets mounted by the orchestrator, read at bootstrap.
+    '[challenge][secret]' => trim(file_get_contents('/run/secrets/firewall_hmac')),
+    '[global][banning_message]' => file_get_contents('/etc/firewall/banned.html'),
+]);
+```
+
+This is usually the better route for a secret from a known path. Compared with the [`file:` processor](environment-variables.md#filesystem-processors-opt-in) it needs no opt-in, no base-directory allowlist, and no environment variable — and it is not affected by the colon limitation that applies to tokens, so any path works.
+
+The `trim()` is worth keeping for keys and secrets: a file written by an editor or a secrets mount usually ends with a newline, and an HMAC secret with a stray `\n` fails in a way that is annoying to diagnose.
+


### PR DESCRIPTION
Fixes #114. Documentation only — no code changes.

Nothing showed how to get a file's contents into config when you have a **path** rather than an environment variable, even though it works today:

```yaml
challenge:
  secret: '%env(file:default:/etc/firewall/hmac.key:UNUSED)%'
```

The pieces were each documented separately — `default:` appears in the token examples — but nothing connected them, so anyone holding a path had no documented route.

## Four changes

**1. The literal-path form is now documented**, in a *Reading from a known path* section, with the two caveats that make it a judgement call rather than a free win.

**2. The opt-in rationale was overstated.** It read:

> Because their path comes from an environment variable, enabling them turns any env-var injection into a local file inclusion

It need not come from a variable, and the literal form is the *safer* one precisely because an attacker who controls the environment cannot redirect it. Now "typically", with a pointer to the literal form as the lower-risk option.

**3. A colon truncates the path, silently.** Tokens are split on `:`, so `/tmp/sec:rets/key.txt` resolves as `/tmp/sec`. The codebase already knows this class of problem — `raw_key:` exists for keys containing a colon — but it had never been carried across to paths. Documented beside the existing note, pointing at overrides for paths that need it.

**4. `overrides.md` never showed reading a file.** Its examples only read `$_ENV`, so the cleanest route for a secret from a known path was invisible:

```php
Firewall::create([__DIR__ . '/firewall.yml'], [
    '[challenge][secret]' => trim(file_get_contents('/run/secrets/firewall_hmac')),
]);
```

No opt-in, no allowlist, no colon limitation. The `trim()` is explained rather than just present — a key file usually ends with a newline, and an HMAC secret carrying a stray `\n` fails in a way that is annoying to diagnose.

## One thing I verified rather than asserted

The "keep the variable undefined" caveat now shows what saves you when that goes wrong. I tested it:

```
putenv('UNUSED=/etc/passwd')
  -> ConfigurationException: Path for file processor escapes the configured allowlist: /etc/passwd
```

Defining the variable really does redirect the read — and **only the base-directory allowlist stopped it**. That makes the allowlist load-bearing for this form rather than optional, so the docs now say not to pass an empty one when using it.

---

# How to test

## 1. Build the docs

```bash
mkdocs build --strict
```

Passes. Both new cross-links resolve — `environment-variables.md` → `overrides.md#reading-a-value-from-a-file` and back.

## 2. Confirm the documented snippets actually work

Every example added here was executed against the current code. To repeat:

```php
<?php
require 'vendor/autoload.php';
use Kanopi\Firewall\Utility\TokenSubstitute;

mkdir('/tmp/fw-etc');
file_put_contents('/tmp/fw-etc/hmac.key', "documented-secret-value\n");
TokenSubstitute::enableUnsafeProcessors(['file'], ['/tmp/fw-etc']);

// The token form the docs show.
var_dump(TokenSubstitute::substitute('%env(file:default:/tmp/fw-etc/hmac.key:UNUSED)%'));
// => "documented-secret-value\n"   (note the newline — hence trim() in the override example)

// The caveat, demonstrated.
putenv('UNUSED=/etc/passwd');
try {
    TokenSubstitute::substitute('%env(file:default:/tmp/fw-etc/hmac.key:UNUSED)%');
} catch (\Throwable $e) {
    echo $e->getMessage(), "\n";   // escapes the configured allowlist: /etc/passwd
}
```

## 3. Confirm the colon limitation is real

```php
TokenSubstitute::enableUnsafeProcessors(['file'], ['/tmp']);
mkdir('/tmp/sec:rets'); file_put_contents('/tmp/sec:rets/x.txt', 'v');
TokenSubstitute::substitute('%env(file:default:/tmp/sec:rets/x.txt:UNUSED2)%');
// ConfigurationException: Path for file processor does not resolve: /tmp/sec
```

## Related

#116 proposes a first-class `%file(/path)%` token, which would remove both caveats and make most of this section unnecessary. This PR documents the situation as it stands and is worth having either way — if #116 lands, this section shrinks to a pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
