### PR TITLE
Add a %file(/path)% token for literal paths (Fixes #116)

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -125,41 +125,49 @@ global:
 
 ### Reading from a known path
 
-When the path is known up front, you do not need an environment variable at all. `default:` supplies the path and `file:` reads it:
+When you already know the path, use `%file(...)%` rather than an environment variable:
 
 ```yaml
 challenge:
-  secret: '%env(file:default:/etc/firewall/hmac.key:UNUSED)%'
+  secret: '%file(/etc/firewall/hmac.key)%'
+
+global:
+  banning_message: '%file(/etc/firewall/banned.html)%'
 ```
 
-`UNUSED` is a variable name that must **never be defined**. The chain reads left to right: the variable is unset, so `default:` yields `/etc/firewall/hmac.key`, and `file:` reads that path.
+The token content is the whole path, so unlike the `file:` processor there is **no colon limitation** — `%file(/tmp/sec:rets/key.txt)%` works. There is also no environment variable involved, so nothing in the environment can redirect the read.
 
-This is the safer of the two forms — an attacker who can influence the environment cannot redirect a path that is written in the config file. Two caveats before you rely on it:
+The same opt-in and base-directory allowlist apply:
 
-!!! warning "The named variable must stay undefined"
+```php
+TokenSubstitute::enableUnsafeProcessors(['file'], ['/etc/firewall']);
+```
 
-    If anything ever defines `UNUSED` — a platform injecting variables, a `.env` file, a colleague reusing the name — the path silently becomes that value and the file read silently changes. Nothing in the config signals that dependency. Choose a name you are confident nothing else will use, and treat it as part of the configuration.
+A literal path in a config file is only as trustworthy as that file, so this form is lower risk than the env-var one — but it is held to the same controls so there is a single mental model, and the allowlist still limits the blast radius if a config file is ever compromised.
 
-    This is where the base-directory allowlist earns its keep. With `enableUnsafeProcessors(['file'], ['/etc/firewall'])` in place, a hijacked variable pointing at `/etc/passwd` fails loudly instead of being read:
+Contents come back **verbatim**, newline included, exactly as `file:` returns them. A key file written by an editor usually ends with `\n`, and an HMAC secret carrying a stray newline fails in a way that is annoying to diagnose — if that matters, read it through a [configuration override](overrides.md#reading-a-value-from-a-file) where you can `trim()` it.
+
+`%file(...)%` interpolates inside a larger string and resolves inside nested arrays, like `%env(...)%`.
+
+!!! note "The older workaround, and why to move off it"
+
+    Before this token existed, the only way to use a literal path was to chain `default:` into `file:`:
+
+    ```yaml
+    secret: '%env(file:default:/etc/firewall/hmac.key:UNUSED)%'
+    ```
+
+    It still works, and you will meet it in existing configs, but it carries two hazards that `%file(...)%` does not.
+
+    **`UNUSED` must never be defined by anything.** Define it — a platform injecting variables, a `.env` file, a colleague reusing the name — and the path silently becomes that value. Nothing in the config file signals the dependency. This is where the base-directory allowlist earns its keep: with `enableUnsafeProcessors(['file'], ['/etc/firewall'])` in place, a hijacked variable pointing at `/etc/passwd` fails loudly rather than being read:
 
     ```
     ConfigurationException: Path for file processor escapes the configured allowlist: /etc/passwd
     ```
 
-    Do not pass an empty allowlist when using this form.
+    Never pass an empty allowlist when using that form.
 
-!!! warning "A colon truncates the path"
-
-    Tokens are split on `:`, so a path containing one is cut short:
-
-    ```
-    %env(file:default:/tmp/sec:rets/key.txt:UNUSED)%
-      -> ConfigurationException: Path for file processor does not resolve: /tmp/sec
-    ```
-
-    This is the same limitation `raw_key:` exists to work around for keys, but there is no equivalent escape for paths. If your path contains a colon, use a [configuration override](overrides.md#reading-a-value-from-a-file) instead.
-
-If neither caveat sits well, reading the file in PHP and passing it as an [override](overrides.md#reading-a-value-from-a-file) avoids both.
+    **A colon truncates the path.** Tokens are split on `:`, so `%env(file:default:/tmp/sec:rets/key.txt:UNUSED)%` resolves the path as `/tmp/sec`. This is the same limitation `raw_key:` exists to work around for keys; there is no equivalent escape for paths.
 
 Prefer `file:` over `require:` whenever you can — reading a secret is far less dangerous than executing a path an attacker may influence.
 

--- a/src/Utility/TokenSubstitute.php
+++ b/src/Utility/TokenSubstitute.php
@@ -210,12 +210,78 @@ final class TokenSubstitute
             return self::resolveEnvTokenTyped($m[1]);
         }
 
+        if (\preg_match('/^%file\((.+)\)%$/', $value, $m)) {
+            return self::readLiteralPath($m[1]);
+        }
+
         // Interpolate within string → cast to string
+        $value = \preg_replace_callback(
+            '/%file\((.+?)\)%/',
+            fn(array $m): string => self::readLiteralPath($m[1]),
+            $value
+        );
+
         return \preg_replace_callback(
             '/%env\(([^)]+)\)%/',
             fn(array $m): string => (string) self::resolveEnvTokenTyped($m[1]),
-            $value
+            (string) $value
         );
+    }
+
+    /**
+     * Read a file named by a literal path (#116).
+     *
+     * `%file(/etc/firewall/hmac.key)%` exists because every other route to a
+     * file's contents runs through an environment variable — `$var` in an
+     * `%env(...)%` chain is always the last colon-separated segment — which
+     * left two poor options for a path known up front:
+     *
+     *   %env(file:default:/etc/firewall/hmac.key:UNUSED)%
+     *
+     * That works, and is what the documentation had to recommend, but it
+     * depends on `UNUSED` never being defined by anything, ever. Define it and
+     * the path silently becomes that value. It also truncates on any path
+     * containing a colon, because the chain is split on `:`.
+     *
+     * Neither applies here: the token content is the whole path, and there is
+     * no variable to keep undefined.
+     *
+     * The same opt-in and base-directory allowlist as the `file:` processor
+     * still apply. A literal path in a config file is only as trustworthy as
+     * that file — and if an attacker can edit your firewall config the file
+     * read is the least of it — but keeping one mental model is worth more
+     * than the small convenience of exempting this form, and the allowlist is
+     * cheap insurance in a security package.
+     *
+     * Contents are returned verbatim, newline included, matching `file:`.
+     *
+     * @param string $path
+     *   The path to read.
+     *
+     * @return string
+     *   The file's contents.
+     *
+     * @throws ConfigurationException
+     *   When the processor is disabled, the path escapes the allowlist, or the
+     *   file cannot be read.
+     */
+    private static function readLiteralPath(string $path): string
+    {
+        $path = \trim($path);
+
+        self::assertUnsafePathAllowed('file', $path);
+
+        if (!\is_file($path) || !\is_readable($path)) {
+            throw new ConfigurationException(\sprintf('%%file(%s)%% not found or unreadable', $path));
+        }
+
+        $contents = \file_get_contents($path);
+
+        if ($contents === false) {
+            throw new ConfigurationException(\sprintf('Failed reading %%file(%s)%%', $path));
+        }
+
+        return $contents;
     }
 
     /**

--- a/tests/Unit/Utility/FileTokenTest.php
+++ b/tests/Unit/Utility/FileTokenTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Utility;
+
+use Kanopi\Firewall\Exception\ConfigurationException;
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use Kanopi\Firewall\Utility\TokenSubstitute;
+
+/**
+ * The `%file(/path)%` token (#116).
+ *
+ * Every other route to a file's contents runs through an environment variable,
+ * because `$var` in an `%env(...)%` chain is always the last colon-separated
+ * segment. That left `%env(file:default:/path:UNUSED)%` as the only way to use
+ * a path known up front — a form that depends on a variable never being
+ * defined, and truncates on any path containing a colon.
+ *
+ * These tests cover the new token, and pin the two hazards it removes.
+ */
+final class FileTokenTest extends AbstractTestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dir = sys_get_temp_dir() . '/fw-file-token-' . uniqid('', true);
+        mkdir($this->dir, 0777, true);
+        mkdir($this->dir . '/sec:rets', 0777, true);
+
+        file_put_contents($this->dir . '/hmac.key', "literal-secret\n");
+        file_put_contents($this->dir . '/sec:rets/x.txt', 'colon-ok');
+
+        TokenSubstitute::resetUnsafeProcessors();
+    }
+
+    protected function tearDown(): void
+    {
+        TokenSubstitute::resetUnsafeProcessors();
+
+        foreach ([$this->dir . '/sec:rets/x.txt', $this->dir . '/hmac.key'] as $file) {
+            @unlink($file);
+        }
+
+        @rmdir($this->dir . '/sec:rets');
+        @rmdir($this->dir);
+
+        parent::tearDown();
+    }
+
+    private function optIn(): void
+    {
+        TokenSubstitute::enableUnsafeProcessors(['file'], [$this->dir]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Safety
+    // -----------------------------------------------------------------------
+
+    /**
+     * The new form must not be a way around the opt-in.
+     */
+    public function testReadingIsRefusedWithoutOptingIn(): void
+    {
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage('disabled');
+
+        TokenSubstitute::substitute('%file(' . $this->dir . '/hmac.key)%');
+    }
+
+    public function testPathOutsideTheAllowlistIsRefused(): void
+    {
+        $this->optIn();
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessage('escapes the configured allowlist');
+
+        TokenSubstitute::substitute('%file(/etc/passwd)%');
+    }
+
+    public function testTraversalOutOfTheAllowlistIsRefused(): void
+    {
+        $this->optIn();
+
+        $this->expectException(ConfigurationException::class);
+
+        TokenSubstitute::substitute('%file(' . $this->dir . '/../../../../etc/passwd)%');
+    }
+
+    public function testMissingFileRaisesRatherThanReturningEmpty(): void
+    {
+        $this->optIn();
+
+        $this->expectException(ConfigurationException::class);
+
+        TokenSubstitute::substitute('%file(' . $this->dir . '/nope.key)%');
+    }
+
+    // -----------------------------------------------------------------------
+    // Reading
+    // -----------------------------------------------------------------------
+
+    public function testReadsAFileFromALiteralPath(): void
+    {
+        $this->optIn();
+
+        $this->assertSame(
+            "literal-secret\n",
+            TokenSubstitute::substitute('%file(' . $this->dir . '/hmac.key)%'),
+        );
+    }
+
+    /**
+     * Contents come back verbatim, newline included, matching the `file:`
+     * processor. Documented because a secret carrying a stray newline fails in
+     * a way that is annoying to diagnose.
+     */
+    public function testContentsAreReturnedVerbatim(): void
+    {
+        $this->optIn();
+
+        $value = TokenSubstitute::substitute('%file(' . $this->dir . '/hmac.key)%');
+
+        $this->assertStringEndsWith("\n", is_string($value) ? $value : '');
+    }
+
+    /**
+     * The hazard this token exists to remove. `%env(file:default:…)%` splits on
+     * `:` and truncates the path; the whole token content is the path here.
+     */
+    public function testAPathContainingAColonWorks(): void
+    {
+        $this->optIn();
+
+        $this->assertSame(
+            'colon-ok',
+            TokenSubstitute::substitute('%file(' . $this->dir . '/sec:rets/x.txt)%'),
+        );
+    }
+
+    /**
+     * And the same path through the old form still fails, so the test is
+     * measuring a real difference rather than a coincidence.
+     */
+    public function testTheOldFormStillTruncatesOnAColon(): void
+    {
+        $this->optIn();
+
+        $this->expectException(ConfigurationException::class);
+
+        TokenSubstitute::substitute('%env(file:default:' . $this->dir . '/sec:rets/x.txt:UNSET_VAR_FOR_TEST)%');
+    }
+
+    /**
+     * There is no variable to keep undefined, so nothing in the environment can
+     * redirect the read.
+     */
+    public function testNoEnvironmentVariableCanRedirectTheRead(): void
+    {
+        $this->optIn();
+        putenv('UNUSED=/etc/passwd');
+
+        try {
+            $this->assertSame(
+                "literal-secret\n",
+                TokenSubstitute::substitute('%file(' . $this->dir . '/hmac.key)%'),
+            );
+        } finally {
+            putenv('UNUSED');
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Interpolation and coexistence
+    // -----------------------------------------------------------------------
+
+    public function testInterpolatesWithinALargerString(): void
+    {
+        $this->optIn();
+
+        $this->assertSame(
+            "key=[literal-secret\n]",
+            TokenSubstitute::substitute('key=[%file(' . $this->dir . '/hmac.key)%]'),
+        );
+    }
+
+    public function testResolvesInsideNestedArrays(): void
+    {
+        $this->optIn();
+
+        $resolved = TokenSubstitute::substitute([
+            'challenge' => ['secret' => '%file(' . $this->dir . '/hmac.key)%'],
+        ]);
+
+        $this->assertSame("literal-secret\n", $resolved['challenge']['secret']);
+    }
+
+    /**
+     * The existing token form must be untouched by the new one.
+     */
+    public function testEnvTokensStillResolveAlongside(): void
+    {
+        $this->optIn();
+        putenv('FW_TOKEN_TEST_PATH=' . $this->dir . '/hmac.key');
+
+        try {
+            $this->assertSame(
+                "literal-secret\n",
+                TokenSubstitute::substitute('%env(file:FW_TOKEN_TEST_PATH)%'),
+            );
+            $this->assertSame(
+                'x-' . $this->dir . '/hmac.key',
+                TokenSubstitute::substitute('x-%env(FW_TOKEN_TEST_PATH)%'),
+            );
+        } finally {
+            putenv('FW_TOKEN_TEST_PATH');
+        }
+    }
+
+    public function testBothTokenFormsCanAppearInOneString(): void
+    {
+        $this->optIn();
+        putenv('FW_TOKEN_TEST_NAME=alpha');
+
+        try {
+            $this->assertSame(
+                "alpha:literal-secret\n",
+                TokenSubstitute::substitute(
+                    '%env(FW_TOKEN_TEST_NAME)%:%file(' . $this->dir . '/hmac.key)%',
+                ),
+            );
+        } finally {
+            putenv('FW_TOKEN_TEST_NAME');
+        }
+    }
+
+    /**
+     * A string with no tokens must come back untouched — including one that
+     * merely looks tokenish.
+     */
+    public function testUnrelatedStringsAreLeftAlone(): void
+    {
+        $this->optIn();
+
+        $this->assertSame('100%', TokenSubstitute::substitute('100%'));
+        $this->assertSame('%file%', TokenSubstitute::substitute('%file%'));
+        $this->assertSame('file(/x)', TokenSubstitute::substitute('file(/x)'));
+    }
+}


### PR DESCRIPTION
Fixes #116.

Every route to a file's contents ran through an environment variable, because `$var` in an `%env(...)%` chain is always the last colon-separated segment:

```php
$parts = \explode(':', $token);
$var   = \array_pop($parts);
```

So a path known up front had exactly one option, and it was a workaround:

```yaml
secret: '%env(file:default:/etc/firewall/hmac.key:UNUSED)%'
```

Now:

```yaml
secret: '%file(/etc/firewall/hmac.key)%'
```

## The two hazards this removes

**A variable that must never exist.** The old form depends on `UNUSED` staying undefined forever. Define it — a platform injecting variables, a `.env` file, a colleague reusing the name — and the path silently becomes that value, with nothing in the config signalling the dependency.

**A colon truncates the path.** The chain is split on `:`, so `/tmp/sec:rets/key.txt` resolves as `/tmp/sec`.

Both are pinned by tests, so the improvement is measured against real behaviour rather than asserted:

- `testAPathContainingAColonWorks` — the new form
- `testTheOldFormStillTruncatesOnAColon` — the old one still fails, so the first test is measuring a genuine difference
- `testNoEnvironmentVariableCanRedirectTheRead` — sets `UNUSED=/etc/passwd` and confirms the read is unaffected

## Security posture is unchanged

Held to the same `enableUnsafeProcessors(['file'], [...])` opt-in and base-directory allowlist as the `file:` processor.

I considered exempting it — a literal path in a config file is only as trustworthy as that file, and an attacker who can edit your firewall config has better options than a file read. Decided against: one mental model is worth more than the convenience, and the allowlist still limits the blast radius if a config file is ever compromised. Raised as an open question in #116 and settled deliberately rather than by omission.

Covered by tests: refusal without the opt-in, a path outside the allowlist, and traversal out of it.

## Other decisions

- **Contents come back verbatim**, newline included, matching `file:`. Documented, since an HMAC secret carrying a stray `\n` fails in a way that is annoying to diagnose. The override route remains the place to `trim()`.
- **No `%require(...)%` counterpart.** Executing a literal path is still executing a path, and the docs already advise preferring `file:` over `require:`.
- **`%env(...)%` is untouched.** A test resolves both forms in the same string.

---

# How to test

## 1. Automated

```bash
vendor/bin/phpunit -c phpunit.xml --testsuite unit --no-coverage --filter FileTokenTest
```

Expected `OK (14 tests, 19 assertions)`.

```bash
composer test    # 1029 unit + 49 integration
composer check   # phpcs + phpstan level max + rector
```

## 2. By hand

```php
<?php
require 'vendor/autoload.php';
use Kanopi\Firewall\Utility\TokenSubstitute;

$dir = '/tmp/fw-file-token';
@mkdir($dir); @mkdir("$dir/sec:rets");
file_put_contents("$dir/hmac.key", "literal-secret\n");
file_put_contents("$dir/sec:rets/x.txt", 'colon-ok');

// Refused until you opt in.
try { TokenSubstitute::substitute("%file($dir/hmac.key)%"); }
catch (Throwable $e) { echo "refused: ", $e->getMessage(), "\n"; }

TokenSubstitute::enableUnsafeProcessors(['file'], [$dir]);

var_dump(TokenSubstitute::substitute("%file($dir/hmac.key)%"));        // "literal-secret\n"
var_dump(TokenSubstitute::substitute("%file($dir/sec:rets/x.txt)%"));  // "colon-ok"  <- colon works
var_dump(TokenSubstitute::substitute("key=[%file($dir/hmac.key)%]"));  // interpolates

// Outside the allowlist.
try { TokenSubstitute::substitute('%file(/etc/passwd)%'); }
catch (Throwable $e) { echo "blocked: ", $e->getMessage(), "\n"; }

// The old form, same colon path — still truncates.
try { TokenSubstitute::substitute("%env(file:default:$dir/sec:rets/x.txt:UNUSED)%"); }
catch (Throwable $e) { echo "old form: ", $e->getMessage(), "\n"; }
```

## 3. In a real config

```yaml
challenge:
  provider: math
  secret: '%file(/etc/firewall/hmac.key)%'
```

with `TokenSubstitute::enableUnsafeProcessors(['file'], ['/etc/firewall']);` before `Firewall::create()`.

## 4. Docs

```bash
mkdocs build --strict
```

New *Reading from a known path* section in `docs/configuration/environment-variables.md`, with a note explaining the old form for anyone who meets it in an existing config.

## Relationship to #117

#117 documents the workaround as the current state. This makes the workaround unnecessary. They touch the same section, so **whichever merges second will need a small rebase** — if this lands first, #117's *Reading from a known path* section collapses to the `!!! note` block already included here.

I kept them separate as asked, but they are worth reviewing together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
