### PR TITLE
Support Symfony 8.1 components (Fixes #121)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,15 +116,22 @@ jobs:
             curl -fsSL https://github.com/benibela/xidel/releases/download/Xidel_0.9.8/xidel-0.9.8.linux64.tar.gz | tar xvz -C /tmp/
             chmod +x /tmp/xidel && sudo mv /tmp/xidel /usr/sbin/
             cp .circleci/phpunit.env ./.env
+      # Keyed per PHP version: composer.lock is not committed, so each PHP
+      # version resolves a different Symfony line (8.1 -> 6.4, 8.2/8.3 -> 7.4,
+      # 8.4/8.5 -> 8.1). One shared key would restore a vendor/ built against
+      # the wrong line.
       - restore_cache:
           keys:
-            - composer-cache-{{ checksum "composer.json" }}
-            - composer-cache-
+            - composer-cache-<<parameters.php>>-{{ checksum "composer.json" }}
+            - composer-cache-<<parameters.php>>-
       - run:
           name: build assets
-          command: composer install --optimize-autoloader
+          command: |
+            composer install --optimize-autoloader
+            # Record which Symfony line this run actually exercised.
+            composer show symfony/http-foundation | grep -E '^versions'
       - save_cache:
-          key: composer-cache-{{ checksum "composer.json" }}
+          key: composer-cache-<<parameters.php>>-{{ checksum "composer.json" }}
           paths:
             - vendor
       - run:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ to contribute a change.
 
 - PHP 8.1 or higher
 - Composer
+- Symfony components 6.4, 7.3, or 8.1 (Composer picks whichever line your PHP version and application allow)
 - Optional: MaxMind GeoIP2 databases for geolocation features
 - Optional: Redis for distributed rate limiting
 

--- a/composer.json
+++ b/composer.json
@@ -36,11 +36,10 @@
         "kanopi/crs-engine": "^1.0",
         "matomo/device-detector": "^6.4",
         "monolog/monolog": "^3.9",
-        "symfony/cache": "~6.4 || ~7.3",
-        "symfony/http-foundation": "~6.4 || ~7.3",
-        "symfony/property-access": "~6.4 || ~7.3",
-        "symfony/uid": "~6.4 || ~7.3",
-        "symfony/yaml": "~6.4 || ~7.3"
+        "symfony/cache": "~6.4 || ~7.3 || ~8.1",
+        "symfony/http-foundation": "~6.4 || ~7.3 || ~8.1",
+        "symfony/property-access": "~6.4 || ~7.3 || ~8.1",
+        "symfony/yaml": "~6.4 || ~7.3 || ~8.1"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
@@ -50,8 +49,8 @@
         "phpunit/phpunit": "^10.5 || ^11.5",
         "rector/rector": "^2.0",
         "squizlabs/php_codesniffer": "^3.13",
-        "symfony/dotenv": "~6.4 || ~7.3",
-        "symfony/var-dumper": "~6.4 || ~7.3"
+        "symfony/dotenv": "~6.4 || ~7.3 || ~8.1",
+        "symfony/var-dumper": "~6.4 || ~7.3 || ~8.1"
     },
     "suggest": {
         "ext-redis": "Required only by Kanopi\\Firewall\\RateLimitStorage\\RedisRateLimitStorage, for distributed rate limiting. Every other rate-limit backend (memory, file, database, PSR-6 cache) works without it."

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -4,6 +4,7 @@
 
 - PHP 8.1 or higher
 - Composer
+- Symfony components 6.4, 7.3, or 8.1 (Composer picks whichever line your PHP version and application allow)
 - Optional: MaxMind GeoIP2 databases for geolocation features
 - Optional: Redis for distributed rate limiting
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,6 +116,7 @@ challenge bucket but never suppresses a block. See
 
 - PHP 8.1 or higher
 - Composer
+- Symfony components 6.4, 7.3, or 8.1 (Composer picks whichever line your PHP version and application allow)
 - Optional: MaxMind GeoIP2 databases for geolocation features
 - Optional: Redis for distributed rate limiting
 


### PR DESCRIPTION
## Description

Widens the Symfony component constraints from `~6.4 || ~7.3` to `~6.4 || ~7.3 || ~8.1` so `kanopi/firewall` — and therefore `drupal/basic_firewall` — can be installed on Drupal 12, which requires `symfony/* ^8.1`.

No source changes were needed. This is a constraint change plus a CI cache fix.

## Related Issue

Fixes #121

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Security fix

## Changes Made

- Widened `symfony/cache`, `symfony/http-foundation`, `symfony/property-access` and `symfony/yaml` in `require`, and `symfony/dotenv` and `symfony/var-dumper` in `require-dev`, to `~6.4 || ~7.3 || ~8.1`.
- Removed `symfony/uid` instead of widening it — nothing in `src/`, `tests/`, `bin/` or `example/` references it, and `composer why symfony/uid` reports no installed package depending on it.
- Left the PHP floor at `>=8.1`. Each Symfony line carries its own PHP floor, so Composer picks whichever the runtime allows.
- Added the PHP version to the CircleCI composer cache key, and a line logging the resolved `symfony/http-foundation` version in each job.
- Noted the supported Symfony lines in the Requirements lists in `README.md`, `docs/index.md` and `docs/getting-started/index.md`.

## Testing

### How to Test

1. On PHP 8.4 or newer, `rm -f composer.lock && composer update` — Symfony resolves to 8.1.x.
2. `composer test` — 1029 unit tests pass.
3. `composer stan` and `composer cs` — both clean against Symfony 8.1.

### Test Configuration

No configuration changes — existing `firewall.yml` files work unchanged.

## Checklist

### Code Quality

- [x] My code follows the project's code style (`composer cs` passes)
- [x] Static analysis passes (`composer stan` passes)
- [x] I have added appropriate code comments explaining complex logic
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors

### Testing

- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] I have added integration tests if necessary
- [x] New and existing tests pass locally (`composer test` passes)
- [ ] I have achieved 100% test coverage for new code
- [x] I have tested edge cases and error conditions

No new tests — there is no new code to cover. The verification that matters is that the existing 1029 unit tests pass against every Symfony line the widened constraint permits; see the table below.

### Security Considerations

- [x] I have considered the security implications of my changes
- [x] Input validation is properly implemented
- [x] No sensitive information is logged or exposed
- [x] Rate limiting is considered for new endpoints/features
- [x] Changes don't introduce new attack vectors

The one area worth a look was the trusted-proxy code, since `getClientIp()` spoofing protection depends on it and the `$trustedHeaderSet` argument shifted across 6.x/7.x. In Symfony 8.1 the signature is still `setTrustedProxies(array $proxies, int $trustedHeaderSet): void` with the second argument required, matching how `src/Firewall.php` and `tests/Unit/FirewallTest.php` already call it. `checkTrustedProxiesPosture()` behaves identically on 8.1, and its tests pass unchanged.

### Documentation

- [x] I have updated the README.md if needed
- [ ] I have added/updated configuration examples
- [ ] I have documented any new plugin variables or options
- [x] I have updated inline documentation/comments

## Breaking Changes

- [ ] This PR introduces breaking changes

Dropping `symfony/uid` from `require` is worth calling out even though it is not a break for this library: any downstream project that was relying on it arriving transitively via `kanopi/firewall` would need to require it directly. Nothing in this package used it.

## Performance Impact

- [ ] This change has performance implications

## Additional Context

### Symfony API surface audited

Every Symfony API this library touches is unchanged in 8.1:

- `HttpFoundation\Request` — `getClientIp()`, `getMethod()`, `getPathInfo()`, `getRequestUri()`, `getQueryString()`, `getHost()`, `getContent()`, `getUri()`, `getScheme()`, `getPort()`, `createFromGlobals()`, `setTrustedProxies()`, `getTrustedProxies()`, `getTrustedHeaderSet()`
- `HttpFoundation\IpUtils::checkIp()`
- `HttpFoundation\File\UploadedFile`
- `PropertyAccess::createPropertyAccessorBuilder()` — `src/Utility/Config.php`
- `Cache\Adapter\FilesystemAdapter` — `src/Plugins/UserAgent.php`
- `Yaml\Yaml`

### The existing CI matrix already covers all three Symfony lines

`composer.lock` is not committed, so every CI job resolves fresh, and each Symfony line has its own PHP floor. Resolving `composer.json` against each platform in the matrix (via `composer config platform.php`) gives:

| CI job | `symfony/http-foundation` resolved | Line covered |
| --- | --- | --- |
| `phpunit 8.1` | 6.4.43 | `~6.4` |
| `phpunit 8.2` | 7.4.15 | `~7.3` |
| `phpunit 8.3` | 7.4.15 | `~7.3` |
| `phpunit 8.4` | 8.1.2 | `~8.1` |
| `phpunit 8.5` | 8.1.2 | `~8.1` |

Symfony 6.4 requires `php >=8.1`, 7.x requires `>=8.2`, and 8.1 requires `>=8.4.1`. PHP 8.1 therefore *cannot* resolve anything but 6.4 — the floor of the constraint stays exercised by the matrix as it already exists, with no new job and no `--prefer-lowest` run needed.

Each job now logs its resolved `symfony/http-foundation` version so this stays visible rather than implied.

Worth knowing for future dependency work: a blanket `--prefer-lowest` job would be red on `2.x` today for reasons unrelated to Symfony. It resolves `geoip2/geoip2` to the `~2` line, where `GeoIp2\Model\Asn` does not exist (10 errors across `AsnTest` and `VulnerabilityScoreTest`), and a `jaybizzle/crawler-detect` old enough to miss `sqlmap` (`UserAgentAutomatedTest`) — 19 failures in total. Raising those floors is separate work.

### Verified locally on PHP 8.4.20

| Resolution | Result |
| --- | --- |
| Symfony 8.1.2 | 1029 tests, 2063 assertions, OK; phpstan level max clean |
| Symfony 7.4.x (current baseline) | 1029 tests, 2063 assertions, OK |
| Symfony floors (6.4.41 http-foundation, 6.4.40 yaml) | 1029 tests, 2063 assertions, OK |

The 2 reported deprecations are pre-existing `ReflectionProperty::setValue()` notices in `tests/Unit/Plugins/AbstractPluginBaseTest.php` under PHP 8.4, unrelated to Symfony, and present on `2.x` today.

### Not covered

Integration tests were not run locally — they need MariaDB, PostgreSQL, Redis and the GeoIP databases. CI will run them on every PHP version in the matrix.

## Reviewer Notes

Two things worth your attention:

1. **The `~8.1` floor choice.** I followed the issue and used `~8.1` rather than `~8.0`. Drupal 12 wants `^8.1`, so `~8.0` would buy nothing for the motivating use case, but say the word if you would rather accept the 8.0 line too.
2. **The CI cache key change.** It invalidates the existing composer cache once, so the first run on each PHP version will be slower. Worth it: without the PHP version in the key, the `phpunit 8.5` job's Symfony 8.1 `vendor/` could be restored into the `phpunit 8.1` job, which is meant to be testing Symfony 6.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
