### PR TITLE
Remove the unused amphp/dns and guzzlehttp/guzzle dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,8 @@
     },
     "require": {
         "php": ">=8.1",
-        "amphp/dns": "^2.4",
         "doctrine/dbal": "^4.2",
         "geoip2/geoip2": "~2 || ^3",
-        "guzzlehttp/guzzle": "^7.9",
         "jaybizzle/crawler-detect": "^1.4",
         "kanopi/crs-engine": "^1.0",
         "matomo/device-detector": "^6.4",


### PR DESCRIPTION
## Summary

`amphp/dns` and `guzzlehttp/guzzle` are declared in `composer.json` but neither is used anywhere in the package. Both are dropped from `require`. No code changes.

This is the same dependency audit that produced #122 (`symfony/uid`, fixed in #123) — these two turned up in the same pass.

## Evidence

Searched a full clone for each package's real autoload namespace (`Amp\Dns\`, `GuzzleHttp\`) across `src/`, `tests/`, `bin/`, `example/`, `config/`, `presets/` and `docs/`, plus the CI config, Docker files and the performance harness. Zero references — the only textual matches for `amp` were the substring in `timestamp`.

**The library does no DNS resolution.** No `gethostbyaddr`, `dns_get_record` or `checkdnsrr` call exists in `src/`.

**No HTTP client is used.** Both outbound call sites use native PHP streams:

| Call site | Mechanism |
| --- | --- |
| `src/Utility/Config.php:191` — remote config includes | `file_get_contents($url, false, $context)` with a `stream_context_create` timeout |
| `src/Plugins/AbuseIpdb.php:282` — AbuseIPDB API | `fopen($url, 'r', false, $context)` with the same approach |

Worth calling out explicitly since it is the natural objection: Guzzle is *not* what fetches remote config includes. That path is `Config::fileGetContents()`, and it is covered by tests that perform a real HTTPS fetch (`tests/Unit/Utility/ConfigTest.php:262`) — those pass with Guzzle uninstalled, so this is confirmed by execution rather than by grep alone.

## Impact of removing them

`composer why` shows nothing else requires either package, so removal actually drops them from a consumer's tree instead of just tidying the declaration. **19 packages removed:**

```
amphp/amp, amphp/byte-stream, amphp/cache, amphp/dns, amphp/parser,
amphp/pipeline, amphp/process, amphp/serialization, amphp/sync,
daverandom/libdns, revolt/event-loop,
guzzlehttp/guzzle, guzzlehttp/promises, guzzlehttp/psr7,
psr/http-client, psr/http-factory, psr/http-message,
ralouphie/getallheaders, symfony/polyfill-php80
```

Production dependencies drop from **49 to 30**.

## Verification

Run after `composer update` on this branch:

- `composer validate` — valid, lock in sync
- `composer test` — 1029 unit + 49 integration tests, **0 failures** (2 pre-existing deprecations, 12 pre-existing skips)
- `composer check:security` (PHPStan `--level max`) — **no errors**
- `composer check:code` (PHPCS PSR-1/2/12 + PHPCompatibility) — **clean**
- `composer check:rector` — **no changes suggested**

## Note

There is no dedicated issue for this one, so the commit carries no `Fixes #` line — happy to open one and amend if you would rather keep every change tracked to an issue.