### PR TITLE
Add a built-in Cloudflare Turnstile challenge provider (Fixes #125)

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -14,8 +14,10 @@ plugins: []
 # are configured this section is ignored.
 #   secret:      HMAC key for signing pass tokens. REQUIRED when challenge
 #                plugins are active. Use a long random string, typically
-#                injected from an env var (Config supports `${VAR}`).
-#   provider:    Built-in short name (`math`) or a FQCN that implements
+#                injected from an env var (`%env(VAR)%`). Unrelated to any
+#                third-party challenge service's secret key.
+#   provider:    Built-in short name (`math`, `altcha`, `turnstile`) or a
+#                FQCN that implements
 #                Kanopi\Firewall\Challenge\ChallengeProviderInterface.
 #   path:        URL the interstitial form POSTs to.
 #   cookie_name: Cookie that carries the pass token after a successful
@@ -26,7 +28,8 @@ plugins: []
 #   provider_options:
 #                Optional per-provider settings forwarded to the provider
 #                constructor. `altcha` accepts `widget_src` and
-#                `widget_integrity`; see example/config.notes.yml.
+#                `widget_integrity`; `turnstile` REQUIRES `site_key` and
+#                `secret_key`. See example/config.notes.yml.
 #   audience:    Scopes pass tokens to this instance so two firewalls
 #                sharing a secret do not accept each other's tokens.
 #                Defaults to the provider name when left empty.

--- a/docs/guides/demo.md
+++ b/docs/guides/demo.md
@@ -1,6 +1,6 @@
 # Lite Firewall local demo
 
-A throwaway harness for poking at the firewall in a browser. Demonstrates all three response modes (`allow`, `block`, `challenge`) and both built-in challenge providers (`math` and `altcha`) side by side, and ships a production-shaped nginx → php-fpm stack so you can run perf experiments against something that looks like a real deployment.
+A throwaway harness for poking at the firewall in a browser. Demonstrates all three response modes (`allow`, `block`, `challenge`) and all three built-in challenge providers (`math`, `altcha` and `turnstile`) side by side, and ships a production-shaped nginx → php-fpm stack so you can run perf experiments against something that looks like a real deployment.
 
 ## TL;DR — composer shortcuts
 
@@ -24,6 +24,7 @@ The config keys rules off the URL so behavior is identical on any networking set
 | `/admin`          | Blocked — a `response: block` URL plugin returns 400 with the configured banning message.       |
 | `/secure`         | Challenged via the **math** provider. Solve "What is A + B?" → 60s pass cookie (`fw_challenge_pass`). |
 | `/secure-altcha`  | Challenged via the **ALTCHA** provider. The widget solves a SHA-256 proof-of-work automatically → 60s pass cookie (`fw_challenge_altcha_pass`). |
+| `/secure-turnstile` | Challenged via the **Cloudflare Turnstile** provider, using Cloudflare's always-passes [test keys](https://developers.cloudflare.com/turnstile/troubleshooting/testing/) → 60s pass cookie (`fw_challenge_turnstile_pass`). Unlike the other routes this one needs outbound network access: the widget loads from Cloudflare and the token is verified against their siteverify API. |
 
 ### What each route looks like
 
@@ -54,7 +55,7 @@ The config keys rules off the URL so behavior is identical on any networking set
     request to any route is rejected by the blocklist before plugins run. Run
     `composer demo:reset` between experiments to start clean.
 
-Only one `challenge.provider` is configurable per Firewall instance, so the demo ships two configs (`config.yml` for math, `config.altcha.yml` for ALTCHA) and `index.php` dispatches between them based on the request path. The two pass tokens live in distinct cookies and submit paths so they coexist in one browser session.
+Only one `challenge.provider` is configurable per Firewall instance, so the demo ships three configs (`config.yml` for math, `config.altcha.yml` for ALTCHA, `config.turnstile.yml` for Turnstile) and `index.php` dispatches between them based on the request path. Each pass token lives in its own cookie and submit path so they coexist in one browser session.
 
 Note that the distinct cookie names are ergonomics, not a security boundary. The two instances share a `challenge.secret`, so what actually stops a token earned on the easy math challenge from opening `/secure-altcha` is the `aud` claim, which defaults to the provider name — see [Scoping tokens across instances](../plugins/challenges.md#scoping-tokens-across-instances). Try it: solve `/secure`, copy `fw_challenge_pass` into `fw_challenge_altcha_pass`, and `/secure-altcha` still challenges you.
 

--- a/docs/plugins/challenges.md
+++ b/docs/plugins/challenges.md
@@ -14,8 +14,8 @@ The pass token is:
 
 ```yaml
 challenge:
-  provider: math                # 'math' is the built-in; or a FQCN that implements ChallengeProviderInterface
-  secret: "${FIREWALL_SECRET}"  # REQUIRED. Long random string, ideally from an env var.
+  provider: math                # 'math', 'altcha' or 'turnstile'; or a FQCN implementing ChallengeProviderInterface
+  secret: '%env(FIREWALL_CHALLENGE_SECRET)%'   # REQUIRED. Long random string, ideally from an env var.
   cookie_name: fw_challenge_pass
   header_name: X-Firewall-Challenge
   path: /_firewall/challenge    # The URL the interstitial POSTs to
@@ -57,7 +57,7 @@ If you run **the same provider** in several places with the same secret — say 
 ```yaml
 challenge:
   provider: altcha
-  secret: "${FIREWALL_SECRET}"
+  secret: '%env(FIREWALL_CHALLENGE_SECRET)%'
   audience: admin-portal   # defaults to the provider name
 ```
 
@@ -67,7 +67,7 @@ The alternative is to give each instance its own `challenge.secret`, which isola
 
 ## Built-in providers
 
-Two providers ship with the firewall — set `challenge.provider` to either short name:
+Three providers ship with the firewall — set `challenge.provider` to a short name:
 
 === "math"
 
@@ -84,8 +84,24 @@ Two providers ship with the firewall — set `challenge.provider` to either shor
     **Continue** on its own. The visitor clicks nothing; a bot pays CPU for
     every solve.
 
-Both screenshots come from the [demo application](../guides/demo.md), which
-serves each provider on its own route.
+=== "turnstile"
+
+    Cloudflare's Turnstile widget, verified server-side against their
+    siteverify API. The strongest bot resistance of the three, and the only
+    one that depends on a third party being reachable — from the visitor's
+    browser *and* from your server.
+
+The math and ALTCHA screenshots come from the [demo application](../guides/demo.md), which serves each provider on its own route.
+
+Which to pick is mostly a question of what you are willing to depend on:
+
+| | `math` | `altcha` | `turnstile` |
+|---|---|---|---|
+| Third-party script | none | CDN (self-hostable) | Cloudflare only |
+| Outbound call from your server | none | none | one per submission |
+| Subresource Integrity | n/a | yes, pinned | not possible |
+| Bot resistance | lowest | CPU cost per solve | highest |
+| Fails if the third party is down | n/a | interstitial degrades | nobody can pass (default) |
 
 - **`math`** — asks "What is A + B?" with single-digit operands. Low-friction proof-of-effort, no JS bundle, no external script load. Defeats the laziest bots; trivial for a human.
 - **`altcha`** — embeds the [ALTCHA](https://altcha.org/docs/v2/) v2 widget with a pre-computed challenge (no server round-trip to fetch one). The visitor's browser brute-forces `SHA-256(salt + N) == challenge`; the salt embeds an expiry and the challenge is HMAC-signed with `challenge.secret`, so the server stays stateless. Privacy-respecting, and imposes a per-solve CPU cost on bots. Solved challenges are single-use — see [Single-use solutions](#single-use-solutions).
@@ -102,7 +118,49 @@ serves each provider on its own route.
 
   The bundle is an ES module, so it is loaded with `<script type="module">`. If you host it yourself, keep that in mind: a classic script tag fails with `Unexpected token 'export'`.
 
-For stronger bot resistance (Turnstile, hCaptcha, reCAPTCHA, etc.), implement `Kanopi\Firewall\Challenge\ChallengeProviderInterface` and set `challenge.provider` to its FQCN.
+- **`turnstile`** — renders the [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/) widget and verifies the token it produces against Cloudflare's siteverify API. Free and unmetered, and the widget adapts on its own from an invisible check to an interactive one based on how suspicious the client looks.
+
+  Create a widget in the **Turnstile** section of the Cloudflare dashboard, add the hostnames it may run on, and configure both keys:
+
+  ```yaml
+  challenge:
+    provider: turnstile
+    secret: '%env(FIREWALL_CHALLENGE_SECRET)%'     # pass-token HMAC key — NOT a Turnstile key
+    provider_options:
+      site_key: '%env(TURNSTILE_SITE_KEY)%'        # public; rendered into the page
+      secret_key: '%env(TURNSTILE_SECRET_KEY)%'    # private; only ever sent to Cloudflare
+  ```
+
+  Two names worth reading twice. `challenge.secret` signs pass tokens and has nothing to do with Cloudflare — it is still required. And despite looking like a pair, `site_key` is public while `secret_key` must never reach the browser; the provider never renders it.
+
+  Both keys are required. Omitting either throws `ConfigurationException` at startup rather than serving a widget every visitor would fail.
+
+  Optional settings:
+
+  | Option | Default | Purpose |
+  |---|---|---|
+  | `theme` | `auto` | Widget colour scheme: `auto`, `light` or `dark`. |
+  | `timeout` | `2` | Seconds to wait for siteverify, clamped to 1–10. |
+  | `on_error` | `block` | What happens when siteverify cannot be reached — see below. |
+  | `send_remoteip` | `false` | Forward the visitor's IP to Cloudflare. |
+  | `widget_src` | Cloudflare's URL | Override to serve the bundle through a first-party proxy. |
+
+  **When Cloudflare cannot be reached, the default is to refuse the submission.** A verdict you could not obtain is not a pass, and failing open would turn any disruption of siteverify — an outage, a DNS failure, egress filtering on your host — into a bypass for every challenged route, available to anyone who can cause it. The cost of that choice is real, though: while siteverify is unreachable, challenged routes are impassable. Set `on_error: allow` if you would rather absorb the risk than lock visitors out. It only governs unreachability — a token Cloudflare actively rejects is always refused.
+
+  **`send_remoteip` is off for a reason.** Forwarding the client IP sharpens Cloudflare's signal, but `getClientIp()` is only trustworthy when [`global.require_trusted_proxies`](../configuration/global.md) is configured. Behind an unconfigured proxy it returns whatever `X-Forwarded-For` claimed, so a spoofed header sends Cloudflare an address unrelated to the visitor and can fail verification for legitimate people. Turn it on only once your proxy configuration is right.
+
+  **Two limitations to plan around.** Cloudflare serves the widget from an unversioned, mutable URL, so unlike `altcha` there is no Subresource Integrity digest to pin — a digest would block the script the first time Cloudflare ships a change. And your Content-Security-Policy needs Cloudflare in two directives:
+
+  ```
+  script-src https://challenges.cloudflare.com;
+  frame-src  https://challenges.cloudflare.com;
+  ```
+
+  Replay needs no configuration: Cloudflare answers `timeout-or-duplicate` to a token that has already been validated, so a solve cannot be redistributed. That is why this provider does not implement [`SingleUseSolutionInterface`](#single-use-solutions) or touch storage at all.
+
+  For local development, Cloudflare publishes [dummy keys](https://developers.cloudflare.com/turnstile/troubleshooting/testing/) — `1x00000000000000000000AA` with secret `1x0000000000000000000000000000000AA` always passes. The siteverify call still goes over the network, so they do not make the flow work offline.
+
+For hCaptcha, reCAPTCHA, or anything else, implement `Kanopi\Firewall\Challenge\ChallengeProviderInterface` and set `challenge.provider` to its FQCN.
 
 ## Writing a custom provider
 
@@ -114,20 +172,20 @@ A provider owns both halves of the round-trip: rendering the interstitial, and v
 namespace App\Firewall;
 
 use Kanopi\Firewall\Challenge\ChallengeProviderInterface;
-use Kanopi\Firewall\Challenge\TokenManager;
 use Symfony\Component\HttpFoundation\Request;
 
-class TurnstileProvider implements ChallengeProviderInterface
+class HCaptchaProvider implements ChallengeProviderInterface
 {
-    // The factory passes the shared TokenManager to every provider. Use it
-    // to sign your own per-challenge state; ignore it if you don't need to.
-    public function __construct(private readonly TokenManager $tokenManager)
+    // Parameters are matched by declared type: a TokenManager parameter
+    // receives the shared HMAC manager, an array parameter receives
+    // challenge.provider_options. Declare only what you need.
+    public function __construct(private readonly array $options = [])
     {
     }
 
     public function getName(): string
     {
-        return 'turnstile';
+        return 'hcaptcha';
     }
 
     public function renderInterstitial(Request $request, array $context): string
@@ -135,46 +193,59 @@ class TurnstileProvider implements ChallengeProviderInterface
         // $context carries: submit_url, redirect_to, ttl, cookie_name, header_name.
         // Echo redirect_to and ttl back as hidden fields — the Firewall reads
         // them off the POST to size and target the pass token.
+        $siteKey = htmlspecialchars($this->options['site_key'], ENT_QUOTES, 'UTF-8');
+        $submitUrl = htmlspecialchars($context['submit_url'], ENT_QUOTES, 'UTF-8');
+        $redirectTo = htmlspecialchars($context['redirect_to'], ENT_QUOTES, 'UTF-8');
+        $ttl = htmlspecialchars($context['ttl'], ENT_QUOTES, 'UTF-8');
+
         return <<<HTML
         <!DOCTYPE html>
         <html lang="en"><body>
-          <form method="post" action="{$context['submit_url']}">
-            <div class="cf-turnstile" data-sitekey="YOUR_SITE_KEY"></div>
-            <input type="hidden" name="redirect_to" value="{$context['redirect_to']}">
-            <input type="hidden" name="ttl" value="{$context['ttl']}">
+          <form method="post" action="{$submitUrl}">
+            <div class="h-captcha" data-sitekey="{$siteKey}"></div>
+            <input type="hidden" name="redirect_to" value="{$redirectTo}">
+            <input type="hidden" name="ttl" value="{$ttl}">
             <button type="submit">Continue</button>
           </form>
-          <script src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>
+          <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
         </body></html>
         HTML;
     }
 
     public function verifySolution(Request $request): bool
     {
-        $token = (string) $request->request->get('cf-turnstile-response', '');
+        // Read from the raw bag: InputBag::get() throws on a non-scalar, and
+        // this method runs on attacker-controlled input.
+        $token = $request->request->all()['h-captcha-response'] ?? '';
 
         // Verify server-side against the provider's siteverify endpoint.
         // Return FALSE on any failure — never throw.
-        return $token !== '' && $this->verifyWithCloudflare($token, $request);
+        return is_string($token) && $token !== '' && $this->verifyWithHCaptcha($token);
     }
 }
 ```
 
 ```yaml
 challenge:
-  provider: "App\\Firewall\\TurnstileProvider"
-  secret: "${FIREWALL_SECRET}"
+  provider: "App\\Firewall\\HCaptchaProvider"
+  secret: '%env(FIREWALL_CHALLENGE_SECRET)%'
   path: /_firewall/challenge
+  provider_options:
+    site_key: '%env(HCAPTCHA_SITE_KEY)%'
+    secret_key: '%env(HCAPTCHA_SECRET_KEY)%'
 ```
+
+For a fuller worked example of this shape — widget rendering, server-side verification, timeouts, and what to do when the remote service is unreachable — read [`TurnstileChallengeProvider`](https://github.com/kanopi/firewall/blob/2.x/src/Challenge/TurnstileChallengeProvider.php).
 
 Requirements and gotchas:
 
-- **Escape everything you interpolate.** `redirect_to` originates from the request URI. The built-in `MathChallengeProvider` runs every substitution through `htmlspecialchars()`; do the same.
+- **Escape everything you interpolate.** `redirect_to` originates from the request URI. The built-in providers run every substitution through `InterstitialRenderer::escapeHtml()`; do the same. Values landing inside a `<script>` block need `escapeJs()` instead — HTML entities are not decoded there.
 - **Echo back `redirect_to` and `ttl`** as form fields named exactly that. The Firewall reads them from the POST to decide where to send the visitor and how long to mint the pass token for. Omit them and you get `/` and 3600s.
-- **`verifySolution()` must never throw.** It runs on attacker-controlled input; return `false` for anything you don't like.
-- **Register via FQCN**, not a short name. `challenge.provider` only resolves `math` as a built-in; everything else must be a loadable class implementing the interface, or `create()` throws `ConfigurationException`.
-- **The constructor signature is fixed** — `ChallengeProviderFactory` always calls `new $class($tokenManager)`. Read any further configuration from your own environment or constants.
-- Use `$this->tokenManager->sign()` / `verifySignature()` if you need tamper-proof state in the form. You do **not** need to mint the pass token — the Firewall does that once `verifySolution()` returns `true`.
+- **`verifySolution()` must never throw.** It runs on attacker-controlled input; return `false` for anything you don't like. Note that `$request->request->get()` raises `BadRequestException` on an array value, so read hostile fields off `->all()` instead.
+- **Register via FQCN**, not a short name. `challenge.provider` resolves `math`, `altcha` and `turnstile` as built-ins; everything else must be a loadable class implementing the interface, or `create()` throws `ConfigurationException`.
+- **Declare the collaborators you want.** `ChallengeProviderFactory` matches constructor parameters by declared type — a `TokenManager` parameter gets the shared manager, an `array` parameter gets `challenge.provider_options`, and a provider needing neither can declare no constructor at all. Untyped parameters receive the `TokenManager`, so providers written against the older fixed `new $class($tokenManager)` signature keep working unchanged.
+- Use `$tokenManager->sign()` / `verifySignature()` if you need tamper-proof state in the form. You do **not** need to mint the pass token — the Firewall does that once `verifySolution()` returns `true`.
+- **Reuse the shared interstitial** via `InterstitialRenderer::render()` rather than hand-rolling a document. It owns the submit JS, the two token-delivery paths, and the escaping rules those depend on. Providers whose challenge token is spent by a failed attempt can pass a `submit_failure` snippet to reset the widget.
 
 ## How dispatch interacts with allow / block
 

--- a/example/config.notes.yml
+++ b/example/config.notes.yml
@@ -72,15 +72,23 @@ storage:
 # plugin does, `secret` is REQUIRED — startup throws ConfigurationException
 # if it is empty.
 challenge:
-  # Short name of a built-in provider ("math", "altcha") or FQCN of a class
-  # that implements Kanopi\Firewall\Challenge\ChallengeProviderInterface.
-  #   math   — "What is A + B?" with single-digit operands. Low-friction
-  #            proof-of-effort, no JS bundle, no external script load.
-  #   altcha — Embeds the ALTCHA v2 widget with a pre-computed challenge.
-  #            The browser brute-forces SHA-256(salt + N) == challenge;
-  #            challenge is HMAC-signed with `secret`. Privacy-respecting,
-  #            per-solve CPU cost on bots, solved challenges are single-use.
-  #            See https://altcha.org/docs/v2/.
+  # Short name of a built-in provider ("math", "altcha", "turnstile") or FQCN
+  # of a class implementing
+  # Kanopi\Firewall\Challenge\ChallengeProviderInterface.
+  #   math      — "What is A + B?" with single-digit operands. Low-friction
+  #               proof-of-effort, no JS bundle, no external script load.
+  #   altcha    — Embeds the ALTCHA v2 widget with a pre-computed challenge.
+  #               The browser brute-forces SHA-256(salt + N) == challenge;
+  #               challenge is HMAC-signed with `secret`. Privacy-respecting,
+  #               per-solve CPU cost on bots, solved challenges are
+  #               single-use. See https://altcha.org/docs/v2/.
+  #   turnstile — Embeds the Cloudflare Turnstile widget and verifies its
+  #               token against Cloudflare's siteverify API. Strongest bot
+  #               resistance, and the only provider that needs a third party
+  #               reachable from BOTH the browser and this server. Requires
+  #               provider_options.site_key and .secret_key. Replay is
+  #               handled by Cloudflare, so no storage is involved.
+  #               See https://developers.cloudflare.com/turnstile/.
   provider: math
   # Optional per-provider settings, forwarded to the provider constructor.
   # Unknown keys are ignored, so this is safe to leave empty.
@@ -95,6 +103,37 @@ challenge:
   #                      a mismatched digest would block the script.
   #                      Generate with:
   #                        openssl dgst -sha384 -binary FILE | openssl base64 -A
+  #
+  # turnstile accepts:
+  #   site_key         — REQUIRED. Turnstile site key. PUBLIC: it is rendered
+  #                      into the interstitial.
+  #   secret_key       — REQUIRED. Turnstile secret key. PRIVATE: only ever
+  #                      sent server-to-server to siteverify. Note this is
+  #                      NOT the same thing as `challenge.secret` below.
+  #                      Omitting either key throws at startup rather than
+  #                      serving a widget nobody could pass.
+  #   theme            — Widget colour scheme: auto (default), light, dark.
+  #   timeout          — Seconds to wait for siteverify. Clamped to 1-10,
+  #                      default 2. This runs while the visitor waits.
+  #   on_error         — What to do when siteverify cannot be REACHED:
+  #                      block (default) or allow. Blocking is the safe
+  #                      default — a verdict you could not obtain is not a
+  #                      pass, and failing open would make any siteverify
+  #                      disruption a bypass for every challenged route. The
+  #                      trade-off is that challenged routes are impassable
+  #                      while Cloudflare is unreachable. This never applies
+  #                      to a token Cloudflare actively rejected.
+  #   send_remoteip    — Forward the visitor's IP to Cloudflare. Default
+  #                      false, because getClientIp() is only trustworthy
+  #                      when global.require_trusted_proxies is configured;
+  #                      behind an unconfigured proxy a spoofed
+  #                      X-Forwarded-For would send Cloudflare an unrelated
+  #                      address and fail verification for real visitors.
+  #   widget_src       — Override the widget bundle URL, e.g. to serve it via
+  #                      a first-party proxy. No SRI digest is emitted for
+  #                      any value: Cloudflare's URL is unversioned and
+  #                      mutable, so a pinned digest would break on their
+  #                      next deploy.
   provider_options: {}
   # Scopes pass tokens to this instance. Tokens carry the value as an `aud`
   # claim and only verify against a firewall configured with the same one,
@@ -104,8 +143,10 @@ challenge:
   # share passes (e.g. a public site and an admin portal).
   audience: ''
   # HMAC secret used to sign pass tokens. MUST be a long, random value. The
-  # `${VAR}` syntax loads it from an env var so it stays out of source control.
-  secret: '${FIREWALL_CHALLENGE_SECRET}'
+  # `%env(VAR)%` syntax loads it from an env var so it stays out of source
+  # control. Note `${VAR}` is NOT substituted — it would be taken literally,
+  # giving every deployment that copied it the same known secret.
+  secret: '%env(FIREWALL_CHALLENGE_SECRET)%'
   # URL the interstitial form POSTs to. Configurable so it can avoid colliding
   # with application routes.
   path: /_firewall/challenge

--- a/example/demo/config.turnstile.yml
+++ b/example/demo/config.turnstile.yml
@@ -1,0 +1,52 @@
+# Cloudflare Turnstile variant of the demo config.
+#
+# Loaded by example/demo/index.php whenever the request touches the Turnstile
+# routes (/secure-turnstile or /_firewall/challenge-turnstile) — see that file
+# for the dispatch logic. Everything else falls back to config.yml.
+#
+# Each provider gets a distinct challenge submit path, cookie name, and header
+# name so pass tokens from the three providers can co-exist in one browser
+# session without overwriting each other.
+#
+# Unlike the math and ALTCHA routes, this one is NOT self-contained: the
+# widget loads from challenges.cloudflare.com and the submitted token is
+# verified server-to-server against Cloudflare's siteverify API. The demo will
+# not work without outbound network access.
+
+global:
+  banning_message: "Blocked: {{request.path}} is restricted (request {{request.id}})."
+
+# Same storage file as config.yml so a block recorded by one Firewall
+# instance is observed by the other (repeat-offender behavior).
+storage:
+  type: Kanopi\Firewall\Storage\FileStorage
+  config:
+    storage_file: /tmp/firewall-demo.data
+
+challenge:
+  provider: turnstile
+  secret: 'demo-secret-do-not-reuse-in-prod'
+  cookie_name: fw_challenge_turnstile_pass
+  header_name: X-Firewall-Challenge-Turnstile
+  path: /_firewall/challenge-turnstile
+  provider_options:
+    # Cloudflare's documented test keys: the widget always passes and
+    # siteverify always accepts the token. Swap in real keys from the
+    # Turnstile section of the Cloudflare dashboard to see the genuine
+    # behaviour, including the interactive challenge.
+    #   https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+    # To watch a rejection instead, set secret_key to
+    # 2x0000000000000000000000000000000AA (always fails) or
+    # 3x0000000000000000000000000000000AA (token already spent).
+    site_key: '1x00000000000000000000AA'
+    secret_key: '1x0000000000000000000000000000000AA'
+
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: challenge
+    weight: 0
+    enable: true
+    metadata:
+      default_expiration_time: 60
+    config:
+      - "path@starts_with:/secure-turnstile"

--- a/example/demo/index.php
+++ b/example/demo/index.php
@@ -5,18 +5,23 @@ declare(strict_types=1);
 /*
  * Front controller for the Lite Firewall demo.
  *
- * Four demo routes — see example/demo/config.yml and config.altcha.yml
- * for the rules:
+ * Five demo routes — see example/demo/config.yml, config.altcha.yml and
+ * config.turnstile.yml for the rules:
  *
- *   /                allowed
- *   /admin           blocked
- *   /secure          challenged via the math provider
- *   /secure-altcha   challenged via the ALTCHA provider
+ *   /                  allowed
+ *   /admin             blocked
+ *   /secure            challenged via the math provider
+ *   /secure-altcha     challenged via the ALTCHA provider
+ *   /secure-turnstile  challenged via the Cloudflare Turnstile provider
  *
  * Only one ChallengeProviderInterface is wired per Firewall instance,
- * so the two challenge providers live in separate config files and we
- * dispatch by path: anything touching /secure-altcha (or its submit
- * endpoint) loads config.altcha.yml; everything else loads config.yml.
+ * so the three challenge providers live in separate config files and we
+ * dispatch by path: anything touching /secure-altcha or /secure-turnstile
+ * (or their submit endpoints) loads the matching config; everything else
+ * loads config.yml.
+ *
+ * The Turnstile route needs outbound network access — the widget loads
+ * from Cloudflare and the token is verified against their siteverify API.
  *
  * Run with the PHP built-in server (single-process):
  *
@@ -34,7 +39,14 @@ $requestPath = strtok((string) ($_SERVER['REQUEST_URI'] ?? '/'), '?') ?: '/';
 $useAltcha = str_starts_with($requestPath, '/secure-altcha')
     || $requestPath === '/_firewall/challenge-altcha';
 
-$configFile = $useAltcha ? 'config.altcha.yml' : 'config.yml';
+$useTurnstile = str_starts_with($requestPath, '/secure-turnstile')
+    || $requestPath === '/_firewall/challenge-turnstile';
+
+$configFile = match (true) {
+    $useAltcha => 'config.altcha.yml',
+    $useTurnstile => 'config.turnstile.yml',
+    default => 'config.yml',
+};
 
 \Kanopi\Firewall\Firewall::create([__DIR__ . '/' . $configFile])->evaluate();
 
@@ -44,6 +56,7 @@ $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
 $path = $_SERVER['REQUEST_URI'] ?? '/';
 $mathCookie = isset($_COOKIE['fw_challenge_pass']);
 $altchaCookie = isset($_COOKIE['fw_challenge_altcha_pass']);
+$turnstileCookie = isset($_COOKIE['fw_challenge_turnstile_pass']);
 
 header('Content-Type: text/html; charset=utf-8');
 
@@ -76,13 +89,14 @@ header('Content-Type: text/html; charset=utf-8');
       <tr><td><a href="/admin">/admin</a></td><td>Blocked — the URL plugin rejects anything under <code>/admin</code> with a 400.</td></tr>
       <tr><td><a href="/secure">/secure</a></td><td>Challenged via the <strong>math</strong> provider — "What is A + B?" interstitial. 60s pass cookie.</td></tr>
       <tr><td><a href="/secure-altcha">/secure-altcha</a></td><td>Challenged via the <strong>ALTCHA</strong> provider — proof-of-work widget solves automatically. 60s pass cookie.</td></tr>
+      <tr><td><a href="/secure-turnstile">/secure-turnstile</a></td><td>Challenged via the <strong>Cloudflare Turnstile</strong> provider, using Cloudflare's always-passes test keys. 60s pass cookie. <strong>Needs outbound network access</strong> — the widget loads from Cloudflare and the token is verified against their API.</td></tr>
     </tbody>
   </table>
 
   <h2>Re-triggering the challenge</h2>
   <p>The pass token TTL is 60s in this demo. To force the interstitial again sooner:</p>
   <ul>
-    <li>Delete the <code>fw_challenge_pass</code> / <code>fw_challenge_altcha_pass</code> cookie via browser dev tools, or</li>
+    <li>Delete the <code>fw_challenge_pass</code> / <code>fw_challenge_altcha_pass</code> / <code>fw_challenge_turnstile_pass</code> cookie via browser dev tools, or</li>
     <li>Reload the route in an incognito window.</li>
   </ul>
 
@@ -90,7 +104,8 @@ header('Content-Type: text/html; charset=utf-8');
     Request path: <code><?= htmlspecialchars($path, ENT_QUOTES, 'UTF-8') ?></code><br>
     Client IP (as the firewall sees it): <code><?= htmlspecialchars($ip, ENT_QUOTES, 'UTF-8') ?></code><br>
     Math pass cookie present: <code><?= $mathCookie ? 'yes' : 'no' ?></code><br>
-    ALTCHA pass cookie present: <code><?= $altchaCookie ? 'yes' : 'no' ?></code>
+    ALTCHA pass cookie present: <code><?= $altchaCookie ? 'yes' : 'no' ?></code><br>
+    Turnstile pass cookie present: <code><?= $turnstileCookie ? 'yes' : 'no' ?></code>
   </p>
 </body>
 </html>

--- a/src/Challenge/ChallengeProviderFactory.php
+++ b/src/Challenge/ChallengeProviderFactory.php
@@ -30,6 +30,7 @@ final class ChallengeProviderFactory
     private const BUILTINS = [
         'math' => MathChallengeProvider::class,
         'altcha' => AltchaChallengeProvider::class,
+        'turnstile' => TurnstileChallengeProvider::class,
     ];
 
     /**
@@ -41,11 +42,8 @@ final class ChallengeProviderFactory
      *   Shared HMAC manager. Providers that need to sign per-challenge
      *   state (like MathChallengeProvider) receive it via constructor.
      * @param array<string, mixed> $options
-     *   Contents of `challenge.provider_options`, passed as a second
-     *   constructor argument to providers that declare one. Providers
-     *   taking only a TokenManager — including every custom provider
-     *   written against the original single-argument signature — are
-     *   constructed unchanged, so this stays backward compatible.
+     *   Contents of `challenge.provider_options`, passed to providers that
+     *   declare an `array` constructor parameter.
      *
      * @throws ConfigurationException
      *   When the provider name resolves to nothing or to a class that
@@ -84,17 +82,30 @@ final class ChallengeProviderFactory
     }
 
     /**
-     * Construct the provider, passing options only when it accepts them.
+     * Construct the provider, giving it only the collaborators it declares.
      *
-     * `ChallengeProviderInterface` cannot describe a constructor, so the
-     * arity is checked directly rather than assumed. A provider written
-     * against the original `__construct(TokenManager $tm)` signature keeps
-     * working; one that declares a second parameter receives the options.
+     * `ChallengeProviderInterface` cannot describe a constructor, so what to
+     * pass is read off the signature rather than assumed. Each parameter is
+     * matched by declared type: an `array` receives
+     * `challenge.provider_options`, anything else receives the shared
+     * `TokenManager`.
+     *
+     * Reading types rather than counting parameters is what lets a provider
+     * decline the TokenManager altogether. `TurnstileChallengeProvider` has
+     * no per-challenge state to sign — Cloudflare owns the only thing that
+     * has to survive from render to verify — and accepting a collaborator it
+     * never uses would be a lie in its signature.
+     *
+     * Backward compatible in both directions: an untyped parameter is
+     * treated as wanting the TokenManager, so providers written against the
+     * original `__construct(TokenManager $tm)` or
+     * `__construct(TokenManager $tm, array $opts)` signatures are
+     * constructed exactly as before.
      *
      * @param class-string<ChallengeProviderInterface> $class
      *   Resolved provider class.
      * @param array<string, mixed> $options
-     *   Provider options to forward when supported.
+     *   Provider options to forward to an `array` parameter.
      */
     private static function instantiate(
         string $class,
@@ -103,10 +114,18 @@ final class ChallengeProviderFactory
     ): ChallengeProviderInterface {
         $constructor = (new \ReflectionClass($class))->getConstructor();
 
-        if ($constructor instanceof \ReflectionMethod && $constructor->getNumberOfParameters() >= 2) {
-            return new $class($tokenManager, $options);
+        if (!$constructor instanceof \ReflectionMethod) {
+            return new $class();
         }
 
-        return new $class($tokenManager);
+        $arguments = [];
+        foreach ($constructor->getParameters() as $reflectionParameter) {
+            $type = $reflectionParameter->getType();
+            $arguments[] = $type instanceof \ReflectionNamedType && $type->getName() === 'array'
+                ? $options
+                : $tokenManager;
+        }
+
+        return new $class(...$arguments);
     }
 }

--- a/src/Challenge/InterstitialRenderer.php
+++ b/src/Challenge/InterstitialRenderer.php
@@ -65,10 +65,10 @@ final class InterstitialRenderer
     /**
      * Build the interstitial document.
      *
-     * `form_fields`, `extra_script`, `extra_head`, `extra_styles` and
-     * `submit_guard` are injected verbatim — the calling provider owns
-     * escaping anything it interpolates into them. Every other value is
-     * escaped here.
+     * `form_fields`, `extra_script`, `extra_head`, `extra_styles`,
+     * `submit_guard` and `submit_failure` are injected verbatim — the
+     * calling provider owns escaping anything it interpolates into them.
+     * Every other value is escaped here.
      *
      * @param array{
      *   intro: string,
@@ -84,9 +84,12 @@ final class InterstitialRenderer
      *   ttl: string|int,
      *   header_name: string|int,
      *   redirect_field: string|int,
-     *   ttl_field: string|int
+     *   ttl_field: string|int,
+     *   submit_failure?: string
      * } $parts
-     *   Provider-supplied document pieces.
+     *   Provider-supplied document pieces. `submit_failure` is optional and
+     *   defaults to none, so providers written before it existed are
+     *   unaffected.
      */
     public static function render(array $parts): string
     {
@@ -108,6 +111,12 @@ final class InterstitialRenderer
         $submitGuard = $parts['submit_guard'];
         $extraScript = $parts['extra_script'];
         $disabled = $parts['submit_disabled'] ? ' disabled' : '';
+
+        // Runs whenever a submission is refused. Providers whose challenge
+        // token is spent by the attempt (Turnstile) need to issue a fresh
+        // one here, otherwise clicking Continue again re-posts a token the
+        // remote service has already marked as used and can never succeed.
+        $submitFailure = $parts['submit_failure'] ?? '';
 
         return <<<HTML
 <!DOCTYPE html>
@@ -149,6 +158,11 @@ final class InterstitialRenderer
       var submit = document.getElementById('submit');
       var headerName = {$headerNameJs};
       var redirectTo = {$redirectToJs};
+
+      function fail() {
+        err.classList.add('visible');
+{$submitFailure}
+      }
 {$extraScript}
       form.addEventListener('submit', function (event) {
         event.preventDefault();
@@ -165,7 +179,7 @@ final class InterstitialRenderer
           return resp.json().then(function (body) { return { ok: resp.ok, body: body }; });
         }).then(function (result) {
           if (!result.ok || !result.body || !result.body.token) {
-            err.classList.add('visible');
+            fail();
             return;
           }
           try {
@@ -175,7 +189,7 @@ final class InterstitialRenderer
           } catch (e) { /* localStorage blocked — cookie still works */ }
           window.location.href = result.body.redirect || redirectTo;
         }).catch(function () {
-          err.classList.add('visible');
+          fail();
         });
       });
     })();

--- a/src/Challenge/TurnstileChallengeProvider.php
+++ b/src/Challenge/TurnstileChallengeProvider.php
@@ -1,0 +1,585 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kanopi\Firewall\Challenge;
+
+use Kanopi\Firewall\Exception\ConfigurationException;
+use Kanopi\Firewall\Logging\LoggingFactory;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Built-in Cloudflare Turnstile challenge.
+ *
+ * Renders the Turnstile widget, then verifies the token it produces against
+ * Cloudflare's siteverify API.
+ *
+ * Unlike the other built-in providers this one is **not** self-contained.
+ * `MathChallengeProvider` re-checks an HMAC it signed itself and
+ * `AltchaChallengeProvider` re-runs a hash locally, so both decide validity
+ * with nothing but the posted payload and the shared secret. A
+ * `cf-turnstile-response` token is an opaque artifact minted by Cloudflare;
+ * there is no published format or key that would let it be verified offline.
+ * Deciding whether it is genuine therefore costs one server-to-server round
+ * trip on the challenge POST — not on ordinary requests, which never reach
+ * this class.
+ *
+ * Wire format (per https://developers.cloudflare.com/turnstile/):
+ *   server → client: the widget script plus a `data-sitekey` element.
+ *   client → server: the widget writes an opaque token into the
+ *                    `cf-turnstile-response` form field.
+ *   server → Cloudflare: POST {secret, response, remoteip?} to siteverify.
+ *   Cloudflare → server: {success, challenge_ts, hostname, error-codes}.
+ *
+ * Replay is handled at the source: Cloudflare returns `timeout-or-duplicate`
+ * for a token that has already been validated, so a solve cannot be
+ * redistributed to other clients. That is why this provider — unlike
+ * `AltchaChallengeProvider` — does not need `SingleUseSolutionInterface` or
+ * any storage-backed record of consumed solutions.
+ *
+ * Trade-offs worth knowing before choosing this provider over `math` or
+ * `altcha`:
+ *
+ *   - It depends on a third party being reachable from both the visitor's
+ *     browser and this server. A visitor whose network blocks
+ *     `challenges.cloudflare.com` cannot pass, and when siteverify is
+ *     unreachable this provider fails closed by default (see `on_error`).
+ *   - No Subresource Integrity. Cloudflare serves the widget from an
+ *     unversioned, mutable URL, so a pinned digest would break on their
+ *     next deploy — `AltchaChallengeProvider` can pin an exact version and
+ *     an SRI hash, this cannot.
+ *   - Operators need a Content-Security-Policy that permits
+ *     `https://challenges.cloudflare.com` in both `script-src` and
+ *     `frame-src`.
+ */
+final class TurnstileChallengeProvider implements ChallengeProviderInterface
+{
+    /**
+     * Form field carrying the widget's token.
+     *
+     * Fixed by Turnstile's implicit rendering mode, which injects a hidden
+     * input under this name into the enclosing form.
+     */
+    public const PAYLOAD_FIELD = 'cf-turnstile-response';
+
+    /**
+     * Cloudflare's server-side verification endpoint.
+     */
+    public const SITEVERIFY_ENDPOINT = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+
+    /**
+     * Widget bundle emitted into the interstitial by default.
+     *
+     * Deliberately unversioned: Cloudflare publishes no pinned URL, and the
+     * unpinned one is what they support. See the class docblock on why that
+     * rules out Subresource Integrity here.
+     */
+    public const DEFAULT_WIDGET_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
+
+    /**
+     * Seconds to wait on siteverify before giving up.
+     *
+     * Short by design — this runs inside a request the visitor is waiting
+     * on, and a slow answer is worth less than a fast failure handled by
+     * `on_error`.
+     */
+    private const DEFAULT_TIMEOUT = 2;
+
+    /**
+     * Ceiling for the configurable timeout.
+     */
+    private const MAX_TIMEOUT = 10;
+
+    /**
+     * Longest token accepted before the request is refused unsent.
+     *
+     * Cloudflare documents tokens as up to 2048 bytes; anything longer did
+     * not come from the widget, so there is nothing to be gained by paying
+     * a round trip to be told so.
+     */
+    private const MAX_TOKEN_LENGTH = 2048;
+
+    /**
+     * Widget colour themes Turnstile accepts.
+     *
+     * @var array<int, string>
+     */
+    private const THEMES = ['auto', 'light', 'dark'];
+
+    /**
+     * Error codes that mean this firewall is misconfigured, not that the
+     * visitor failed. Logged at `error` because every visitor will fail
+     * until an operator fixes the configuration.
+     *
+     * @var array<int, string>
+     */
+    private const CONFIG_ERROR_CODES = ['missing-input-secret', 'invalid-input-secret', 'bad-request'];
+
+    /**
+     * Error codes Cloudflare documents as retryable. Treated as a transport
+     * failure so `on_error` decides, rather than as a verdict on the token.
+     *
+     * @var array<int, string>
+     */
+    private const RETRYABLE_ERROR_CODES = ['internal-error'];
+
+    /**
+     * Public key rendered into the widget.
+     */
+    private readonly string $siteKey;
+
+    /**
+     * Private key sent to siteverify. Never rendered, never logged.
+     */
+    private readonly string $secretKey;
+
+    /**
+     * Widget bundle URL actually emitted.
+     */
+    private readonly string $widgetSrc;
+
+    /**
+     * Widget colour theme.
+     */
+    private readonly string $theme;
+
+    /**
+     * siteverify timeout in seconds.
+     */
+    private readonly int $timeout;
+
+    /**
+     * Whether an unreachable siteverify lets the visitor through.
+     */
+    private readonly bool $allowOnError;
+
+    /**
+     * Whether the visitor's IP is forwarded to Cloudflare.
+     */
+    private readonly bool $sendRemoteIp;
+
+    /**
+     * Constructs a new TurnstileChallengeProvider object.
+     *
+     * Takes no `TokenManager`, unlike the other built-in providers: there is
+     * no per-challenge state of ours to sign, because the only thing that
+     * has to survive from render to verify is Cloudflare's own token.
+     * `ChallengeProviderFactory` matches constructor parameters by declared
+     * type, so declining it is enough to not be handed one.
+     *
+     * @param array<string, mixed> $options
+     *   Provider options from `challenge.provider_options`:
+     *     - site_key:      REQUIRED. Turnstile site key (public).
+     *     - secret_key:    REQUIRED. Turnstile secret key (private).
+     *     - widget_src:    Override the widget bundle URL, e.g. to serve it
+     *                      through a first-party proxy your CSP allows.
+     *     - theme:         `auto` (default), `light` or `dark`.
+     *     - timeout:       siteverify timeout in seconds, 1-10, default 2.
+     *     - on_error:      `block` (default) or `allow` — what happens when
+     *                      siteverify cannot be reached. See verifySolution().
+     *     - send_remoteip: Forward the client IP to Cloudflare. Default
+     *                      FALSE; see fetch() for why that is not the
+     *                      obvious choice it looks like.
+     *
+     * @throws ConfigurationException
+     *   When `site_key` or `secret_key` is missing or empty. Failing at
+     *   startup is the point: the alternative is a firewall that renders a
+     *   widget every visitor is guaranteed to fail.
+     */
+    public function __construct(array $options = [])
+    {
+        $this->siteKey = $this->requireOption($options, 'site_key');
+        $this->secretKey = $this->requireOption($options, 'secret_key');
+
+        $widgetSrc = trim((string) ($options['widget_src'] ?? ''));
+        $this->widgetSrc = $widgetSrc !== '' ? $widgetSrc : self::DEFAULT_WIDGET_SRC;
+
+        $theme = strtolower(trim((string) ($options['theme'] ?? '')));
+        $this->theme = in_array($theme, self::THEMES, true) ? $theme : 'auto';
+
+        $timeout = (int) ($options['timeout'] ?? self::DEFAULT_TIMEOUT);
+        $this->timeout = max(1, min(self::MAX_TIMEOUT, $timeout));
+
+        $this->allowOnError = strtolower(trim((string) ($options['on_error'] ?? 'block'))) === 'allow';
+        $this->sendRemoteIp = ($options['send_remoteip'] ?? false) === true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return 'turnstile';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function renderInterstitial(Request $request, array $context): string
+    {
+        $siteKey = InterstitialRenderer::escapeHtml($this->siteKey);
+        $theme = InterstitialRenderer::escapeHtml($this->theme);
+        $widgetSrc = InterstitialRenderer::escapeHtml($this->widgetSrc);
+        $payloadField = InterstitialRenderer::escapeHtml(self::PAYLOAD_FIELD);
+
+        return InterstitialRenderer::render([
+            'intro' => 'Please complete the check below to continue.',
+            'extra_styles' => '    .cf-turnstile { display: block; margin-bottom: 1rem; min-height: 65px; }'
+                . "\n" . '    button:disabled { background: #9bb8e6; cursor: not-allowed; }',
+            // The widget callbacks are declared here, ahead of the async
+            // bundle, and resolve the button lazily. Declaring them in the
+            // document-bottom script instead would be a race: the widget
+            // can finish and call back before that script has run, and a
+            // missing callback leaves the button disabled for good.
+            'extra_head' => <<<HEAD
+  <script>
+    window.fwTurnstileVerified = function () {
+      var b = document.getElementById('submit');
+      if (b) { b.disabled = false; }
+    };
+    window.fwTurnstileReset = function () {
+      var b = document.getElementById('submit');
+      if (b) { b.disabled = true; }
+    };
+  </script>
+  <script src="{$widgetSrc}" async defer></script>
+HEAD,
+            'form_fields' => <<<FIELDS
+      <div class="cf-turnstile" data-sitekey="{$siteKey}" data-theme="{$theme}"
+           data-callback="fwTurnstileVerified"
+           data-expired-callback="fwTurnstileReset"
+           data-error-callback="fwTurnstileReset"></div>
+FIELDS,
+            // Enabled by the widget's success callback, so the visitor
+            // cannot post an empty token.
+            'submit_disabled' => true,
+            'error_message' => 'Verification failed. Please try again.',
+            'submit_guard' => <<<GUARD
+        if (!data.get('{$payloadField}')) {
+          err.classList.add('visible');
+          return;
+        }
+
+GUARD,
+            // A refused submission has spent its token — Cloudflare answers
+            // `timeout-or-duplicate` to any further use of it — so recycle
+            // the widget rather than leaving the visitor to click Continue
+            // on a token that can no longer succeed.
+            'submit_failure' => <<<'FAILURE'
+        window.fwTurnstileReset();
+        if (window.turnstile && typeof window.turnstile.reset === 'function') {
+          window.turnstile.reset();
+        }
+FAILURE,
+            'extra_script' => '',
+            'submit_url' => $context['submit_url'] ?? '',
+            'redirect_to' => $context['redirect_to'] ?? '/',
+            'ttl' => $context['ttl'] ?? '3600',
+            'header_name' => $context['header_name'] ?? '',
+            'redirect_field' => self::REDIRECT_FIELD,
+            'ttl_field' => self::TTL_FIELD,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Three outcomes, deliberately kept distinct:
+     *
+     *   - Cloudflare says the token is good → TRUE.
+     *   - Cloudflare says it is not → FALSE. This covers replay
+     *     (`timeout-or-duplicate`), so a solve cannot be shared around.
+     *   - Cloudflare could not be asked → the `on_error` option decides,
+     *     defaulting to FALSE.
+     *
+     * That last case is the one worth being deliberate about. Failing open
+     * turns any disruption of siteverify — an outage, a DNS failure, egress
+     * filtering on this host — into a bypass for every challenged route,
+     * and an attacker who can cause it gets the bypass on demand. Failing
+     * closed instead makes those routes impassable for the duration, which
+     * is visible and self-correcting. Operators who would rather absorb the
+     * risk than lock visitors out can set `on_error: allow`.
+     */
+    public function verifySolution(Request $request): bool
+    {
+        $token = $this->postedToken($request);
+
+        // No round trip for a request that cannot carry a valid token.
+        if ($token === '' || strlen($token) > self::MAX_TOKEN_LENGTH) {
+            return false;
+        }
+
+        $result = $this->fetch($token, $request);
+
+        if ($result['transport_error'] !== null) {
+            LoggingFactory::logMessage('error', 'Turnstile verification could not be completed', [
+                'provider' => $this->getName(),
+                'error' => $result['transport_error'],
+                'on_error' => $this->allowOnError ? 'allow' : 'block',
+            ]);
+
+            return $this->allowOnError;
+        }
+
+        if (!$result['verified']) {
+            // Configuration faults are indistinguishable from a failed
+            // visitor in the return value, so separate them in the log —
+            // otherwise a wrong secret key looks like a wave of bots.
+            $misconfigured = array_intersect($result['error_codes'], self::CONFIG_ERROR_CODES) !== [];
+
+            LoggingFactory::logMessage($misconfigured ? 'error' : 'info', $misconfigured
+                ? 'Turnstile rejected the request because this firewall is misconfigured'
+                : 'Turnstile verification failed', [
+                    'provider' => $this->getName(),
+                    'error_codes' => $result['error_codes'],
+                ]);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Ask Cloudflare whether a token is genuine.
+     *
+     * Uses the stream wrapper rather than an HTTP client library, matching
+     * `AbuseIpdb::fetch()` and `Config::fileGetContents()` — the two other
+     * places this package talks to the network — so a security library's
+     * dependency surface stays unchanged. `ignore_errors` is on so an error
+     * body can be read rather than surfacing as an opaque failure.
+     *
+     * On `send_remoteip`: forwarding the client IP sharpens Cloudflare's
+     * signal, but `$request->getClientIp()` is only trustworthy when
+     * `global.require_trusted_proxies` is configured. Behind an
+     * unconfigured proxy it returns whatever `X-Forwarded-For` claimed,
+     * which means a spoofed header sends Cloudflare an IP unrelated to the
+     * visitor and can fail verification for legitimate people. A provider
+     * cannot see that global, so this defaults off rather than guessing.
+     *
+     * @param string $token
+     *   The token posted by the widget. Already length-checked.
+     * @param Request $request
+     *   The submission, used only for the optional client IP.
+     *
+     * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null}
+     *   `transport_error` is non-null only when Cloudflare's verdict could
+     *   not be obtained at all, which is the case `on_error` governs.
+     */
+    protected function fetch(string $token, Request $request): array
+    {
+        $body = $this->buildRequestBody($token, $request);
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'timeout' => $this->timeout,
+                'ignore_errors' => true,
+                'header' => [
+                    'Content-Type: application/x-www-form-urlencoded',
+                    'Content-Length: ' . strlen($body),
+                    'Accept: application/json',
+                ],
+                'content' => $body,
+            ],
+        ]);
+
+        $handle = @fopen(self::SITEVERIFY_ENDPOINT, 'r', false, $context);
+        if ($handle === false) {
+            return $this->transportFailure('could not reach the Turnstile siteverify API');
+        }
+
+        $metadata = stream_get_meta_data($handle);
+        $payload = stream_get_contents($handle);
+        fclose($handle);
+
+        /** @var array<int, string> $headers */
+        $headers = is_array($metadata['wrapper_data'] ?? null) ? $metadata['wrapper_data'] : [];
+
+        return $this->interpretResponse($this->statusFromHeaders($headers), $payload);
+    }
+
+    /**
+     * Build the urlencoded siteverify request body.
+     *
+     * Separate from the transport so tests can assert what would be sent to
+     * Cloudflare — in particular that the client IP is absent unless it was
+     * explicitly opted into — without a network call.
+     *
+     * @param string $token
+     *   The token posted by the widget.
+     * @param Request $request
+     *   The submission, used only for the optional client IP.
+     */
+    protected function buildRequestBody(string $token, Request $request): string
+    {
+        $fields = [
+            'secret' => $this->secretKey,
+            'response' => $token,
+        ];
+
+        if ($this->sendRemoteIp) {
+            $ip = (string) $request->getClientIp();
+            if ($ip !== '') {
+                $fields['remoteip'] = $ip;
+            }
+        }
+
+        return http_build_query($fields);
+    }
+
+    /**
+     * Turn a siteverify HTTP response into a verdict.
+     *
+     * Separate from the transport because every interesting case here is a
+     * malformed or unhappy response, and reproducing those against the real
+     * endpoint is neither reliable nor fast.
+     *
+     * @param int|null $status
+     *   HTTP status, or NULL when none could be parsed.
+     * @param string|false $body
+     *   Raw response body as read from the stream.
+     *
+     * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null}
+     */
+    protected function interpretResponse(?int $status, string|false $body): array
+    {
+        // Cloudflare answers 200 even when it rejects a token, so a non-200
+        // is an infrastructure problem rather than a verdict.
+        if ($status !== 200) {
+            return $this->transportFailure(sprintf(
+                'the Turnstile siteverify API returned HTTP %s',
+                $status ?? 'an unreadable status'
+            ));
+        }
+
+        if ($body === false || $body === '') {
+            return $this->transportFailure('the Turnstile siteverify API returned an empty body');
+        }
+
+        $decoded = json_decode($body, true);
+        if (!is_array($decoded) || !isset($decoded['success'])) {
+            return $this->transportFailure(
+                'the Turnstile siteverify API returned a body that is not a verification result'
+            );
+        }
+
+        $errorCodes = $this->normalizeErrorCodes($decoded['error-codes'] ?? []);
+
+        // "Retry this" is not the same as "this token is bad", so an
+        // internal error is handed to `on_error` rather than being counted
+        // as a failed visitor.
+        if ($decoded['success'] !== true && array_intersect($errorCodes, self::RETRYABLE_ERROR_CODES) !== []) {
+            return $this->transportFailure('the Turnstile siteverify API reported an internal error');
+        }
+
+        return [
+            'verified' => $decoded['success'] === true,
+            'error_codes' => $errorCodes,
+            'transport_error' => null,
+        ];
+    }
+
+    /**
+     * Read the posted token without ever throwing.
+     *
+     * `InputBag::get()` raises `BadRequestException` when the value is an
+     * array, so reading `cf-turnstile-response[]=x` through it would turn
+     * attacker-controlled input into a 500. `verifySolution()` is
+     * contractually forbidden from throwing, so the raw bag is inspected
+     * instead and anything that is not a string is simply not a token.
+     */
+    private function postedToken(Request $request): string
+    {
+        $raw = $request->request->all()[self::PAYLOAD_FIELD] ?? '';
+
+        return is_string($raw) ? trim($raw) : '';
+    }
+
+    /**
+     * Pull a required, non-empty string option or fail startup.
+     *
+     * @param array<string, mixed> $options
+     *   The provider options as configured.
+     * @param string $key
+     *   Option name to read.
+     *
+     * @throws ConfigurationException
+     *   When the option is absent or empty.
+     */
+    private function requireOption(array $options, string $key): string
+    {
+        $value = $options[$key] ?? null;
+        $value = is_scalar($value) ? trim((string) $value) : '';
+
+        if ($value === '') {
+            throw new ConfigurationException(sprintf(
+                'Turnstile provider requires `challenge.provider_options.%s`. Get one from the '
+                . 'Turnstile section of the Cloudflare dashboard, and inject it with %%env(VAR)%%.',
+                $key
+            ));
+        }
+
+        return $value;
+    }
+
+    /**
+     * Coerce Cloudflare's `error-codes` into a list of strings.
+     *
+     * @param mixed $codes
+     *   Whatever occupied the `error-codes` key.
+     *
+     * @return array<int, string>
+     *   Only the string entries, re-indexed.
+     */
+    private function normalizeErrorCodes(mixed $codes): array
+    {
+        if (!is_array($codes)) {
+            return [];
+        }
+
+        return array_values(array_filter($codes, is_string(...)));
+    }
+
+    /**
+     * Read the HTTP status out of the stream wrapper's response headers.
+     *
+     * @param array<int, string> $headers
+     *   `wrapper_data` as reported by `stream_get_meta_data()`.
+     *
+     * @return int|null
+     *   The status code, or NULL when no status line could be parsed.
+     */
+    protected function statusFromHeaders(array $headers): ?int
+    {
+        $status = null;
+
+        // Every header line is scanned rather than stopping at the first
+        // match: a redirect chain leaves several status lines here, and the
+        // one that actually answered is the last.
+        foreach ($headers as $header) {
+            if (preg_match('#^HTTP/\S+\s+(\d{3})#', $header, $matches) === 1) {
+                $status = (int) $matches[1];
+            }
+        }
+
+        return $status;
+    }
+
+    /**
+     * Build a "could not get a verdict" result.
+     *
+     * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null}
+     */
+    private function transportFailure(string $reason): array
+    {
+        return ['verified' => false, 'error_codes' => [], 'transport_error' => $reason];
+    }
+}

--- a/tests/Challenge/AlwaysVerifyingTurnstileProvider.php
+++ b/tests/Challenge/AlwaysVerifyingTurnstileProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Challenge;
+
+use Kanopi\Firewall\Challenge\TurnstileChallengeProvider;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Turnstile provider with Cloudflare replaced by a standing "yes".
+ *
+ * Registered by FQCN in `challenge.provider` so the integration suite can
+ * walk the whole submission flow — form fields, pass-token minting, cookie
+ * delivery — without a network call. Everything except the siteverify round
+ * trip is the real provider.
+ */
+class AlwaysVerifyingTurnstileProvider extends TurnstileChallengeProvider
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function fetch(string $token, Request $request): array
+    {
+        return ['verified' => true, 'error_codes' => [], 'transport_error' => null];
+    }
+}

--- a/tests/Challenge/UnreachableTurnstileProvider.php
+++ b/tests/Challenge/UnreachableTurnstileProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Challenge;
+
+use Kanopi\Firewall\Challenge\TurnstileChallengeProvider;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Turnstile provider with siteverify permanently unreachable.
+ *
+ * Stands in for a Cloudflare outage, egress filtering, or a DNS failure, so
+ * the integration suite can assert what the `on_error` option actually does
+ * to a live challenge flow.
+ */
+class UnreachableTurnstileProvider extends TurnstileChallengeProvider
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function fetch(string $token, Request $request): array
+    {
+        return [
+            'verified' => false,
+            'error_codes' => [],
+            'transport_error' => 'could not reach the Turnstile siteverify API',
+        ];
+    }
+}

--- a/tests/Integration/ChallengeFlowTest.php
+++ b/tests/Integration/ChallengeFlowTest.php
@@ -6,11 +6,14 @@ namespace Kanopi\Firewall\Tests\Integration;
 
 use Kanopi\Firewall\Challenge\AltchaChallengeProvider;
 use Kanopi\Firewall\Challenge\MathChallengeProvider;
+use Kanopi\Firewall\Challenge\TurnstileChallengeProvider;
 use Kanopi\Firewall\Exception\ChallengeRequiredException;
 use Kanopi\Firewall\Exception\ChallengeSolvedException;
 use Kanopi\Firewall\Exception\ConfigurationException;
 use Kanopi\Firewall\Exception\FirewallBlockedException;
 use Kanopi\Firewall\Firewall;
+use Kanopi\Firewall\Tests\Challenge\AlwaysVerifyingTurnstileProvider;
+use Kanopi\Firewall\Tests\Challenge\UnreachableTurnstileProvider;
 use Kanopi\Firewall\Traits\FileTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -703,6 +706,206 @@ class ChallengeFlowTest extends TestCase
                 AltchaChallengeProvider::PAYLOAD_FIELD => $payload,
                 AltchaChallengeProvider::REDIRECT_FIELD => '/protected',
                 AltchaChallengeProvider::TTL_FIELD => '600',
+            ],
+            [],
+            [],
+            ['REMOTE_ADDR' => $ip]
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // Turnstile
+    // -------------------------------------------------------------------
+
+    public function testTurnstileChallengePluginThrowsRequired(): void
+    {
+        $firewall = Firewall::create([$this->configWithTurnstileChallenge()]);
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($this->blockedRequest('10.0.0.50', '/protected'));
+    }
+
+    public function testTurnstileInterstitialCarriesTheWidgetAndTheRedirect(): void
+    {
+        $firewall = Firewall::create([$this->configWithTurnstileChallenge()]);
+        $provider = $this->challengeProvider($firewall);
+
+        $html = $provider->renderInterstitial(
+            Request::create('/protected', 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.50']),
+            [
+                'submit_url' => '/_firewall/challenge',
+                'redirect_to' => '/protected',
+                'ttl' => '600',
+                'header_name' => 'X-Firewall-Challenge-Turnstile',
+            ]
+        );
+
+        $this->assertStringContainsString('class="cf-turnstile"', $html);
+        $this->assertStringContainsString('data-sitekey="1x00000000000000000000AA"', $html);
+        $this->assertStringContainsString('value="/protected"', $html);
+        $this->assertStringNotContainsString('1x0000000000000000000000000000000AA', $html);
+    }
+
+    public function testVerifiedTurnstileTokenMintsAPassToken(): void
+    {
+        $firewall = Firewall::create([$this->configWithTurnstileChallenge()]);
+
+        try {
+            $firewall->evaluate($this->turnstileSubmission('a-token-cloudflare-likes', '10.0.0.50'));
+            $this->fail('Expected ChallengeSolvedException');
+        } catch (ChallengeSolvedException $e) {
+            $this->assertNotEmpty($e->getToken());
+            $this->assertSame('/protected', $e->getRedirect());
+        }
+    }
+
+    public function testTurnstilePassTokenAllowsTheNextRequest(): void
+    {
+        $config = $this->configWithTurnstileChallenge();
+        $token = '';
+
+        try {
+            Firewall::create([$config])->evaluate(
+                $this->turnstileSubmission('a-token-cloudflare-likes', '10.0.0.50')
+            );
+        } catch (ChallengeSolvedException $e) {
+            $token = $e->getToken();
+        }
+
+        $this->assertNotEmpty($token);
+
+        $request = Request::create('/protected', 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.50']);
+        $request->cookies->set('fw_challenge_turnstile_pass', $token);
+
+        // No exception: the pass token short-circuits the challenge bucket.
+        Firewall::create([$config])->evaluate($request);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testEmptyTurnstileTokenIsRefused(): void
+    {
+        $firewall = Firewall::create([$this->configWithTurnstileChallenge()]);
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($this->turnstileSubmission('', '10.0.0.50'));
+    }
+
+    public function testUnreachableSiteverifyRefusesTheSubmission(): void
+    {
+        // Fail closed: the default must not hand out a pass token when
+        // Cloudflare's verdict could not be obtained.
+        $firewall = Firewall::create([
+            $this->configWithTurnstileChallenge(UnreachableTurnstileProvider::class, 'turnstile_down.yml'),
+        ]);
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($this->turnstileSubmission('a-token-nobody-can-check', '10.0.0.50'));
+    }
+
+    public function testUnreachableSiteverifyMintsATokenWhenConfiguredToAllow(): void
+    {
+        $firewall = Firewall::create([
+            $this->configWithTurnstileChallenge(
+                UnreachableTurnstileProvider::class,
+                'turnstile_down_allow.yml',
+                ['on_error' => 'allow']
+            ),
+        ]);
+
+        $this->expectException(ChallengeSolvedException::class);
+        $firewall->evaluate($this->turnstileSubmission('a-token-nobody-can-check', '10.0.0.50'));
+    }
+
+    public function testTurnstileWithoutKeysFailsAtStartup(): void
+    {
+        $config = $this->writeConfig([
+            'global' => ['mode' => 'exception'],
+            'challenge' => [
+                'provider' => 'turnstile',
+                'secret' => self::SECRET,
+                'path' => '/_firewall/challenge',
+            ],
+            'plugins' => [
+                [
+                    'plugin' => 'Kanopi\Firewall\Plugins\Url',
+                    'response' => 'challenge',
+                    'weight' => 0,
+                    'enable' => true,
+                    'config' => ['path@starts_with:/protected'],
+                ],
+            ],
+        ], 'turnstile_keyless.yml');
+
+        $this->expectException(ConfigurationException::class);
+        Firewall::create([$config]);
+    }
+
+    /**
+     * Config using a Turnstile provider whose siteverify call is stubbed.
+     *
+     * @param class-string $provider
+     *   Provider FQCN — a subclass standing in for one Cloudflare behaviour.
+     * @param string $filename
+     *   Config filename, unique per case so the files do not collide.
+     * @param array<string, mixed> $extraOptions
+     *   Extra `provider_options` merged over the dummy keys.
+     */
+    private function configWithTurnstileChallenge(
+        string $provider = AlwaysVerifyingTurnstileProvider::class,
+        string $filename = 'turnstile_config.yml',
+        array $extraOptions = []
+    ): string {
+        return $this->writeConfig([
+            'global' => ['mode' => 'exception'],
+            'storage' => [
+                'type' => 'Kanopi\Firewall\Storage\FileStorage',
+                'config' => ['storage_file' => $this->tempDir . '/turnstile-storage.data'],
+            ],
+            'challenge' => [
+                'provider' => $provider,
+                'secret' => self::SECRET,
+                'cookie_name' => 'fw_challenge_turnstile_pass',
+                'header_name' => 'X-Firewall-Challenge-Turnstile',
+                'path' => '/_firewall/challenge',
+                'provider_options' => $extraOptions + [
+                    // Cloudflare's documented always-passes test pair.
+                    'site_key' => '1x00000000000000000000AA',
+                    'secret_key' => '1x0000000000000000000000000000000AA',
+                ],
+            ],
+            'plugins' => [
+                [
+                    'plugin' => 'Kanopi\Firewall\Plugins\Url',
+                    'response' => 'challenge',
+                    'weight' => 0,
+                    'enable' => true,
+                    'metadata' => ['default_expiration_time' => 600],
+                    'config' => ['path@starts_with:/protected'],
+                ],
+            ],
+        ], $filename);
+    }
+
+    /**
+     * Reach the provider the Firewall built from config.
+     */
+    private function challengeProvider(Firewall $firewall): TurnstileChallengeProvider
+    {
+        $provider = (new \ReflectionProperty($firewall, 'challengeProvider'))->getValue($firewall);
+        $this->assertInstanceOf(TurnstileChallengeProvider::class, $provider);
+
+        return $provider;
+    }
+
+    private function turnstileSubmission(string $token, string $ip): Request
+    {
+        return Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [
+                TurnstileChallengeProvider::PAYLOAD_FIELD => $token,
+                TurnstileChallengeProvider::REDIRECT_FIELD => '/protected',
+                TurnstileChallengeProvider::TTL_FIELD => '600',
             ],
             [],
             [],

--- a/tests/Traits/ChallengeNamespaceOverrides.php
+++ b/tests/Traits/ChallengeNamespaceOverrides.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * Namespace-scoped shims for Kanopi\Firewall\Challenge.
+ *
+ * `TurnstileChallengeProvider::fetch()` talks to Cloudflare's siteverify API
+ * through the stream wrapper — `fopen()`, `stream_get_meta_data()`,
+ * `stream_get_contents()` — so the transport itself is only reachable with a
+ * real HTTP response to read. The rest of the suite substitutes `fetch()`
+ * wholesale, which is right for testing the decision logic but leaves the
+ * transport unexercised: the unreachable-host branch, and the read back of a
+ * response whose headers carry no status line.
+ *
+ * Reaching those against the live endpoint would mean a network call in CI,
+ * a real secret key, and asking Cloudflare to fail on demand.
+ *
+ * PHP resolves an unqualified function call against the current namespace
+ * first, so defining these here intercepts the calls without touching the
+ * provider. `fopen()` hands back an in-memory stream holding a canned body,
+ * and `stream_get_meta_data()` reports canned `wrapper_data` headers for
+ * exactly the handles this file created — anything else is delegated
+ * untouched, so the other providers in this namespace are unaffected.
+ *
+ * Every shim is inert unless its flag is set. Callers MUST reset the flags in
+ * tearDown(): they are process-global, and a leaked flag would feed a canned
+ * HTTP response to every later test in the run.
+ *
+ * Mirrors tests/Traits/PluginsNamespaceOverrides.php.
+ */
+
+namespace Kanopi\Firewall\Challenge;
+
+/**
+ * Canned response, or FALSE to make fopen() fail. NULL disables the shim.
+ *
+ * Shape: ['headers' => array<int, string>, 'body' => string]
+ */
+$GLOBALS['fake_challenge_http_response'] = null;
+
+/**
+ * Handles this file created, mapped to the headers they should report.
+ */
+$GLOBALS['fake_challenge_http_handles'] = [];
+
+/**
+ * @param string $filename
+ *   Target to open.
+ * @param string $mode
+ *   Open mode.
+ * @param mixed ...$args
+ *   Remaining native arguments, forwarded untouched.
+ *
+ * @return resource|false
+ *   A stream, or FALSE when the canned response says the host is unreachable.
+ */
+function fopen($filename, $mode, ...$args)
+{
+    $fake = $GLOBALS['fake_challenge_http_response'] ?? null;
+
+    if ($fake === null) {
+        return \fopen($filename, $mode, ...$args);
+    }
+
+    if ($fake === false) {
+        return false;
+    }
+
+    $handle = \fopen('php://memory', 'r+');
+    if ($handle === false) {
+        return false;
+    }
+
+    \fwrite($handle, (string) ($fake['body'] ?? ''));
+    \rewind($handle);
+
+    // `headers` is deliberately allowed to be absent rather than defaulted to
+    // an empty array: the two cases reach different code in the provider, and
+    // only an absent key produces the missing `wrapper_data` that the status
+    // parse has to survive.
+    if (array_key_exists('headers', $fake)) {
+        $GLOBALS['fake_challenge_http_handles'][(int) $handle] = $fake['headers'];
+    } else {
+        $GLOBALS['fake_challenge_http_handles'][(int) $handle] = null;
+    }
+
+    return $handle;
+}
+
+/**
+ * @param resource $stream
+ *   Stream to describe.
+ *
+ * @return array<string, mixed>
+ *   Metadata, with `wrapper_data` faked for handles this file created.
+ */
+function stream_get_meta_data($stream)
+{
+    $id = (int) $stream;
+
+    if (array_key_exists($id, $GLOBALS['fake_challenge_http_handles'] ?? [])) {
+        $headers = $GLOBALS['fake_challenge_http_handles'][$id];
+
+        // A NULL entry stands for a response the wrapper reported no headers
+        // for at all, so the key is omitted rather than set to NULL.
+        return $headers === null ? [] : ['wrapper_data' => $headers];
+    }
+
+    return \stream_get_meta_data($stream);
+}

--- a/tests/Unit/Challenge/ChallengeProviderFactoryTest.php
+++ b/tests/Unit/Challenge/ChallengeProviderFactoryTest.php
@@ -9,6 +9,7 @@ use Kanopi\Firewall\Challenge\ChallengeProviderFactory;
 use Kanopi\Firewall\Challenge\ChallengeProviderInterface;
 use Kanopi\Firewall\Challenge\MathChallengeProvider;
 use Kanopi\Firewall\Challenge\TokenManager;
+use Kanopi\Firewall\Challenge\TurnstileChallengeProvider;
 use Kanopi\Firewall\Exception\ConfigurationException;
 use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -84,5 +85,160 @@ final class ChallengeProviderFactoryTest extends AbstractTestCase
 
         $this->assertInstanceOf(MathChallengeProvider::class, $provider);
         $this->assertInstanceOf(ChallengeProviderInterface::class, $provider);
+    }
+
+    public function testResolvesTurnstileShortName(): void
+    {
+        $provider = ChallengeProviderFactory::create(
+            'turnstile',
+            new TokenManager('secret-value'),
+            ['site_key' => 'site', 'secret_key' => 'secret']
+        );
+
+        $this->assertInstanceOf(TurnstileChallengeProvider::class, $provider);
+        $this->assertSame('turnstile', $provider->getName());
+    }
+
+    public function testTurnstileMisconfigurationSurfacesAtCreation(): void
+    {
+        // Startup is the only good time to find out: the alternative is a
+        // widget every visitor is guaranteed to fail.
+        $this->expectException(ConfigurationException::class);
+
+        ChallengeProviderFactory::create('turnstile', new TokenManager('secret-value'));
+    }
+
+    public function testProvidersMayDeclineTheTokenManager(): void
+    {
+        // Parameters are matched by declared type, so a provider with no
+        // state of its own to sign receives only the options.
+        $provider = ChallengeProviderFactory::create(
+            OptionsOnlyProvider::class,
+            new TokenManager('secret-value'),
+            ['marker' => 'received']
+        );
+
+        $this->assertInstanceOf(OptionsOnlyProvider::class, $provider);
+        $this->assertSame('received', $provider->marker());
+    }
+
+    public function testUntypedConstructorParametersStillReceiveTheTokenManager(): void
+    {
+        // Back-compat: a custom provider predating type-based injection may
+        // not have declared a type at all.
+        $tokenManager = new TokenManager('secret-value');
+
+        $provider = ChallengeProviderFactory::create(UntypedProvider::class, $tokenManager);
+
+        $this->assertInstanceOf(UntypedProvider::class, $provider);
+        $this->assertSame($tokenManager, $provider->injected());
+    }
+
+    public function testProvidersWithNoConstructorAreConstructable(): void
+    {
+        $provider = ChallengeProviderFactory::create(
+            NoConstructorProvider::class,
+            new TokenManager('secret-value')
+        );
+
+        $this->assertInstanceOf(NoConstructorProvider::class, $provider);
+    }
+}
+
+/**
+ * Stands in for a provider that needs options but no TokenManager.
+ */
+class OptionsOnlyProvider implements ChallengeProviderInterface
+{
+    /**
+     * @param array<string, mixed> $options
+     *   Provider options.
+     */
+    public function __construct(private readonly array $options = [])
+    {
+    }
+
+    public function marker(): string
+    {
+        return (string) ($this->options['marker'] ?? '');
+    }
+
+    public function getName(): string
+    {
+        return 'options-only';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function renderInterstitial(Request $request, array $context): string
+    {
+        return '';
+    }
+
+    public function verifySolution(Request $request): bool
+    {
+        return false;
+    }
+}
+
+/**
+ * Stands in for a custom provider written without a parameter type.
+ */
+class UntypedProvider implements ChallengeProviderInterface
+{
+    /**
+     * @param mixed $tokenManager
+     *   Whatever the factory decided to inject.
+     */
+    public function __construct(private $tokenManager)
+    {
+    }
+
+    public function injected(): mixed
+    {
+        return $this->tokenManager;
+    }
+
+    public function getName(): string
+    {
+        return 'untyped';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function renderInterstitial(Request $request, array $context): string
+    {
+        return '';
+    }
+
+    public function verifySolution(Request $request): bool
+    {
+        return false;
+    }
+}
+
+/**
+ * Stands in for a provider with nothing to inject at all.
+ */
+class NoConstructorProvider implements ChallengeProviderInterface
+{
+    public function getName(): string
+    {
+        return 'no-constructor';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function renderInterstitial(Request $request, array $context): string
+    {
+        return '';
+    }
+
+    public function verifySolution(Request $request): bool
+    {
+        return false;
     }
 }

--- a/tests/Unit/Challenge/InterstitialRendererTest.php
+++ b/tests/Unit/Challenge/InterstitialRendererTest.php
@@ -8,6 +8,7 @@ use Kanopi\Firewall\Challenge\AltchaChallengeProvider;
 use Kanopi\Firewall\Challenge\InterstitialRenderer;
 use Kanopi\Firewall\Challenge\MathChallengeProvider;
 use Kanopi\Firewall\Challenge\TokenManager;
+use Kanopi\Firewall\Challenge\TurnstileChallengeProvider;
 use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -61,6 +62,23 @@ final class InterstitialRendererTest extends AbstractTestCase
     public function testAltchaInterstitialStaysSyntacticallyValid(string $redirect): void
     {
         $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+        $html = $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => $redirect,
+            'ttl' => '60',
+            'header_name' => 'X-FW',
+        ]);
+
+        $this->assertInlineScriptParses($html);
+    }
+
+    #[DataProvider('hostileRedirectProvider')]
+    public function testTurnstileInterstitialStaysSyntacticallyValid(string $redirect): void
+    {
+        $provider = new TurnstileChallengeProvider([
+            'site_key' => '1x00000000000000000000AA',
+            'secret_key' => '1x0000000000000000000000000000000AA',
+        ]);
         $html = $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
             'submit_url' => '/_firewall/challenge',
             'redirect_to' => $redirect,

--- a/tests/Unit/Challenge/TurnstileChallengeProviderTest.php
+++ b/tests/Unit/Challenge/TurnstileChallengeProviderTest.php
@@ -1,0 +1,565 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Challenge;
+
+use Kanopi\Firewall\Challenge\TurnstileChallengeProvider;
+use Kanopi\Firewall\Exception\ConfigurationException;
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Unit coverage for the Cloudflare Turnstile provider.
+ *
+ * The network is the one thing these tests replace: `fetch()` is overridden
+ * with scripted results, and the response handling it delegates to is
+ * exercised directly through `interpretResponse()`. Nothing here reaches
+ * Cloudflare.
+ */
+final class TurnstileChallengeProviderTest extends AbstractTestCase
+{
+    private const SITE_KEY = '1x00000000000000000000AA';
+
+    private const SECRET_KEY = '1x0000000000000000000000000000000AA';
+
+    public function testGetNameReturnsTurnstile(): void
+    {
+        $this->assertSame('turnstile', $this->provider()->getName());
+    }
+
+    public function testMissingSiteKeyFailsAtConstruction(): void
+    {
+        // A firewall that renders a keyless widget challenges every visitor
+        // with something none of them can pass, so this has to be loud.
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessageMatches('/site_key/');
+
+        new TurnstileChallengeProvider(['secret_key' => self::SECRET_KEY]);
+    }
+
+    public function testMissingSecretKeyFailsAtConstruction(): void
+    {
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessageMatches('/secret_key/');
+
+        new TurnstileChallengeProvider(['site_key' => self::SITE_KEY]);
+    }
+
+    public function testWhitespaceOnlyKeysAreTreatedAsMissing(): void
+    {
+        $this->expectException(ConfigurationException::class);
+
+        new TurnstileChallengeProvider(['site_key' => '   ', 'secret_key' => self::SECRET_KEY]);
+    }
+
+    public function testNonScalarKeyIsTreatedAsMissing(): void
+    {
+        $this->expectException(ConfigurationException::class);
+
+        new TurnstileChallengeProvider(['site_key' => ['nested'], 'secret_key' => self::SECRET_KEY]);
+    }
+
+    public function testRenderProducesTheWidgetAndTheContractFields(): void
+    {
+        $html = $this->render($this->provider());
+
+        $this->assertStringContainsString('<form', $html);
+        $this->assertStringContainsString('action="/_firewall/challenge"', $html);
+        $this->assertStringContainsString('class="cf-turnstile"', $html);
+        $this->assertStringContainsString('data-sitekey="' . self::SITE_KEY . '"', $html);
+        $this->assertStringContainsString(
+            'src="' . TurnstileChallengeProvider::DEFAULT_WIDGET_SRC . '"',
+            $html
+        );
+        $this->assertStringContainsString('name="' . TurnstileChallengeProvider::REDIRECT_FIELD . '"', $html);
+        $this->assertStringContainsString('name="' . TurnstileChallengeProvider::TTL_FIELD . '"', $html);
+        $this->assertStringContainsString('value="/wanted-page"', $html);
+        $this->assertStringContainsString('value="900"', $html);
+    }
+
+    public function testRenderShipsTheSubmitButtonDisabled(): void
+    {
+        // Enabled only by the widget's success callback, so an empty token
+        // cannot be posted.
+        $this->assertMatchesRegularExpression('/<button[^>]*\sdisabled/', $this->render($this->provider()));
+    }
+
+    public function testCallbacksAreDeclaredBeforeTheWidgetBundleLoads(): void
+    {
+        // The bundle is async: it can finish and invoke the callback before
+        // a document-bottom script would have defined it, and a missing
+        // callback leaves the button disabled with no way forward. Ordering
+        // is the whole defence, so assert it.
+        $html = $this->render($this->provider());
+
+        $callback = strpos($html, 'window.fwTurnstileVerified');
+        $bundle = strpos($html, TurnstileChallengeProvider::DEFAULT_WIDGET_SRC);
+
+        $this->assertIsInt($callback);
+        $this->assertIsInt($bundle);
+        $this->assertLessThan($bundle, $callback);
+    }
+
+    public function testCallbacksResolveTheButtonLazily(): void
+    {
+        // Declared in <head>, so they must not capture the element — it does
+        // not exist yet at that point.
+        $this->assertStringContainsString(
+            "document.getElementById('submit')",
+            $this->render($this->provider())
+        );
+    }
+
+    public function testRenderEmitsNoIntegrityAttribute(): void
+    {
+        // Deliberate, and different from ALTCHA: Cloudflare's bundle URL is
+        // unversioned and mutable, so a pinned digest would block the script
+        // the first time they ship a change.
+        $this->assertStringNotContainsString('integrity=', $this->render($this->provider()));
+    }
+
+    public function testRenderEscapesTheSiteKeyIntoTheAttribute(): void
+    {
+        $provider = $this->provider(['site_key' => '1x000" onload="alert(1)']);
+
+        $html = $this->render($provider);
+
+        $this->assertStringNotContainsString('onload="alert(1)"', $html);
+        $this->assertStringContainsString('&quot;', $html);
+    }
+
+    public function testRenderEscapesContextValues(): void
+    {
+        $html = $this->render($this->provider(), '/"><script>alert(1)</script>');
+
+        $this->assertStringNotContainsString('<script>alert(1)</script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testConfiguredThemeIsRendered(): void
+    {
+        $this->assertStringContainsString(
+            'data-theme="dark"',
+            $this->render($this->provider(['theme' => 'DARK']))
+        );
+    }
+
+    public function testUnknownThemeFallsBackToAuto(): void
+    {
+        $this->assertStringContainsString(
+            'data-theme="auto"',
+            $this->render($this->provider(['theme' => 'chartreuse']))
+        );
+    }
+
+    public function testCustomWidgetSrcIsHonoured(): void
+    {
+        $html = $this->render($this->provider(['widget_src' => '/assets/turnstile.js']));
+
+        $this->assertStringContainsString('src="/assets/turnstile.js"', $html);
+        $this->assertStringNotContainsString(TurnstileChallengeProvider::DEFAULT_WIDGET_SRC, $html);
+    }
+
+    public function testFailedSubmissionRecyclesTheWidget(): void
+    {
+        // The attempt spends the token, so without a reset the visitor is
+        // left clicking Continue on something Cloudflare will only ever
+        // answer `timeout-or-duplicate` to.
+        $this->assertStringContainsString('window.turnstile.reset()', $this->render($this->provider()));
+    }
+
+    public function testMissingTokenIsRejectedWithoutAskingCloudflare(): void
+    {
+        $provider = $this->scriptedProvider([]);
+
+        $this->assertFalse($provider->verifySolution($this->submission('')));
+        $this->assertSame(0, $provider->fetchCount, 'An absent token cannot be valid — do not spend a round trip.');
+    }
+
+    public function testOverlongTokenIsRejectedWithoutAskingCloudflare(): void
+    {
+        $provider = $this->scriptedProvider([]);
+
+        $this->assertFalse($provider->verifySolution($this->submission(str_repeat('a', 2049))));
+        $this->assertSame(0, $provider->fetchCount);
+    }
+
+    public function testArrayTokenIsRejectedWithoutThrowing(): void
+    {
+        // `InputBag::get()` raises BadRequestException on a non-scalar, and
+        // verifySolution() is contractually forbidden from throwing, so
+        // `cf-turnstile-response[]=x` must be an ordinary rejection.
+        $provider = $this->scriptedProvider([]);
+
+        $request = Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [TurnstileChallengeProvider::PAYLOAD_FIELD => ['nested']],
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.5']
+        );
+
+        $this->assertFalse($provider->verifySolution($request));
+        $this->assertSame(0, $provider->fetchCount);
+    }
+
+    public function testSuccessfulVerificationIsAccepted(): void
+    {
+        $provider = $this->scriptedProvider([self::verified()]);
+
+        $this->assertTrue($provider->verifySolution($this->submission('a-plausible-token')));
+        $this->assertSame(1, $provider->fetchCount);
+    }
+
+    public function testRejectedTokenIsRefused(): void
+    {
+        $provider = $this->scriptedProvider([self::refused(['invalid-input-response'])]);
+
+        $this->assertFalse($provider->verifySolution($this->submission('a-plausible-token')));
+    }
+
+    public function testReplayedTokenIsRefused(): void
+    {
+        // Replay protection lives at Cloudflare, which is why this provider
+        // needs no SingleUseSolutionInterface or storage record.
+        $provider = $this->scriptedProvider([self::refused(['timeout-or-duplicate'])]);
+
+        $this->assertFalse($provider->verifySolution($this->submission('a-replayed-token')));
+    }
+
+    public function testMisconfiguredSecretIsRefused(): void
+    {
+        $provider = $this->scriptedProvider([self::refused(['invalid-input-secret'])]);
+
+        $this->assertFalse($provider->verifySolution($this->submission('a-plausible-token')));
+    }
+
+    public function testUnreachableSiteverifyBlocksByDefault(): void
+    {
+        $provider = $this->scriptedProvider([self::unreachable()]);
+
+        $this->assertFalse(
+            $provider->verifySolution($this->submission('a-plausible-token')),
+            'Fail closed: a verdict that could not be obtained is not a pass.'
+        );
+    }
+
+    public function testUnreachableSiteverifyAllowsWhenExplicitlyConfigured(): void
+    {
+        $provider = $this->scriptedProvider([self::unreachable()], ['on_error' => 'allow']);
+
+        $this->assertTrue($provider->verifySolution($this->submission('a-plausible-token')));
+    }
+
+    public function testOnErrorOnlyAppliesToUnreachability(): void
+    {
+        // `allow` is about not locking visitors out during an outage. It must
+        // never turn a token Cloudflare actively rejected into a pass.
+        $provider = $this->scriptedProvider(
+            [self::refused(['invalid-input-response'])],
+            ['on_error' => 'allow']
+        );
+
+        $this->assertFalse($provider->verifySolution($this->submission('a-plausible-token')));
+    }
+
+    public function testClientIpIsWithheldByDefault(): void
+    {
+        // Behind an unconfigured proxy `getClientIp()` returns whatever
+        // X-Forwarded-For claimed, so sending it can fail verification for
+        // legitimate visitors. Opt-in only.
+        $body = $this->provider()->exposedRequestBody('a-token', $this->submission('a-token'));
+
+        $this->assertStringContainsString('response=a-token', $body);
+        $this->assertStringNotContainsString('remoteip', $body);
+    }
+
+    public function testClientIpIsSentWhenOptedIn(): void
+    {
+        $body = $this->provider(['send_remoteip' => true])
+            ->exposedRequestBody('a-token', $this->submission('a-token'));
+
+        $this->assertStringContainsString('remoteip=10.0.0.5', $body);
+    }
+
+    public function testSendRemoteIpOnlyAcceptsABooleanTrue(): void
+    {
+        // A truthy YAML string must not silently enable it.
+        $body = $this->provider(['send_remoteip' => 'yes'])
+            ->exposedRequestBody('a-token', $this->submission('a-token'));
+
+        $this->assertStringNotContainsString('remoteip', $body);
+    }
+
+    public function testSecretKeyIsSentToCloudflareButNeverRendered(): void
+    {
+        $provider = $this->provider();
+
+        $this->assertStringContainsString(
+            'secret=' . self::SECRET_KEY,
+            $provider->exposedRequestBody('a-token', $this->submission('a-token'))
+        );
+        $this->assertStringNotContainsString(self::SECRET_KEY, $this->render($provider));
+    }
+
+    public function testSuccessResponseIsInterpretedAsVerified(): void
+    {
+        $result = $this->provider()->exposedInterpret(200, (string) json_encode([
+            'success' => true,
+            'challenge_ts' => '2026-08-04T00:00:00Z',
+            'hostname' => 'example.com',
+        ]));
+
+        $this->assertTrue($result['verified']);
+        $this->assertNull($result['transport_error']);
+    }
+
+    public function testFailureResponseCarriesItsErrorCodes(): void
+    {
+        $result = $this->provider()->exposedInterpret(200, (string) json_encode([
+            'success' => false,
+            'error-codes' => ['invalid-input-response'],
+        ]));
+
+        $this->assertFalse($result['verified']);
+        $this->assertNull($result['transport_error'], 'A rejection is a verdict, not a transport failure.');
+        $this->assertSame(['invalid-input-response'], $result['error_codes']);
+    }
+
+    public function testInternalErrorIsTreatedAsATransportFailure(): void
+    {
+        // Cloudflare documents internal-error as retryable, so it is not a
+        // verdict on the token and `on_error` should govern it.
+        $result = $this->provider()->exposedInterpret(200, (string) json_encode([
+            'success' => false,
+            'error-codes' => ['internal-error'],
+        ]));
+
+        $this->assertFalse($result['verified']);
+        $this->assertNotNull($result['transport_error']);
+    }
+
+    /**
+     * Responses that mean "no verdict available".
+     *
+     * @return array<string, array{0: int|null, 1: string|false}>
+     */
+    public static function noVerdictProvider(): array
+    {
+        return [
+            'server error' => [500, '{"success":true}'],
+            'gateway timeout' => [504, ''],
+            'unparseable status' => [null, '{"success":true}'],
+            'empty body' => [200, ''],
+            'read failure' => [200, false],
+            'not json' => [200, 'definitely not json'],
+            'json but not an object' => [200, '"a string"'],
+            'object without success' => [200, '{"error-codes":["bad-request"]}'],
+        ];
+    }
+
+    /**
+     * @param int|null $status
+     *   HTTP status to interpret.
+     * @param string|false $body
+     *   Body to interpret.
+     */
+    #[DataProvider('noVerdictProvider')]
+    public function testResponsesWithoutAVerdictAreTransportFailures(?int $status, string|false $body): void
+    {
+        $result = $this->provider()->exposedInterpret($status, $body);
+
+        $this->assertFalse($result['verified']);
+        $this->assertNotNull($result['transport_error']);
+    }
+
+    public function testSuccessOutsideAJsonBooleanIsNotAPass(): void
+    {
+        // A truthy-but-not-true value must not be read as verified.
+        $result = $this->provider()->exposedInterpret(200, '{"success":"true"}');
+
+        $this->assertFalse($result['verified']);
+        $this->assertNull($result['transport_error']);
+    }
+
+    public function testMalformedErrorCodesAreNormalisedRatherThanTrusted(): void
+    {
+        $result = $this->provider()->exposedInterpret(200, (string) json_encode([
+            'success' => false,
+            'error-codes' => ['invalid-input-response', 42, ['nested'], null],
+        ]));
+
+        $this->assertSame(['invalid-input-response'], $result['error_codes']);
+    }
+
+    public function testNonArrayErrorCodesAreIgnored(): void
+    {
+        $result = $this->provider()->exposedInterpret(200, '{"success":false,"error-codes":"oops"}');
+
+        $this->assertSame([], $result['error_codes']);
+    }
+
+    public function testStatusIsReadFromTheLastStatusLine(): void
+    {
+        // A redirect chain leaves several; the last one answered.
+        $this->assertSame(200, $this->provider()->exposedStatus([
+            'HTTP/1.1 301 Moved Permanently',
+            'Location: https://example.com/',
+            'HTTP/1.1 200 OK',
+        ]));
+    }
+
+    public function testStatusIsNullWhenNoStatusLineIsPresent(): void
+    {
+        $this->assertNull($this->provider()->exposedStatus(['Content-Type: application/json']));
+    }
+
+    /**
+     * A provider with the protected seams exposed for assertions.
+     *
+     * @param array<string, mixed> $options
+     *   Options merged over valid defaults.
+     */
+    private function provider(array $options = []): TurnstileChallengeProvider
+    {
+        $options += ['site_key' => self::SITE_KEY, 'secret_key' => self::SECRET_KEY];
+
+        return new class ($options) extends TurnstileChallengeProvider {
+            /**
+             * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null}
+             */
+            public function exposedInterpret(?int $status, string|false $body): array
+            {
+                return $this->interpretResponse($status, $body);
+            }
+
+            public function exposedRequestBody(string $token, Request $request): string
+            {
+                return $this->buildRequestBody($token, $request);
+            }
+
+            /**
+             * @param array<int, string> $headers
+             */
+            public function exposedStatus(array $headers): ?int
+            {
+                return $this->statusFromHeaders($headers);
+            }
+        };
+    }
+
+    /**
+     * A provider with the network replaced by scripted results.
+     *
+     * @param array<int, array{verified: bool, error_codes: array<int, string>, transport_error: string|null}> $results
+     *   Results to return from successive fetch() calls, in order.
+     * @param array<string, mixed> $options
+     *   Options merged over valid defaults.
+     */
+    private function scriptedProvider(array $results, array $options = []): TurnstileChallengeProvider
+    {
+        $options += ['site_key' => self::SITE_KEY, 'secret_key' => self::SECRET_KEY];
+
+        return new class ($options, $results) extends TurnstileChallengeProvider {
+            /**
+             * How many times siteverify would have been called.
+             */
+            public int $fetchCount = 0;
+
+            /**
+             * Remaining scripted results.
+             *
+             * @var array<int, array{verified: bool, error_codes: array<int, string>, transport_error: string|null}>
+             */
+            private array $scripted;
+
+            /**
+             * @param array<string, mixed> $options
+             *   Provider options.
+             * @param array<int, array{verified: bool, error_codes: array<int, string>, transport_error: string|null}> $scripted
+             *   Scripted fetch results.
+             */
+            public function __construct(array $options, array $scripted)
+            {
+                parent::__construct($options);
+                $this->scripted = $scripted;
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            protected function fetch(string $token, Request $request): array
+            {
+                $this->fetchCount++;
+
+                $next = array_shift($this->scripted);
+
+                return $next ?? [
+                    'verified' => false,
+                    'error_codes' => [],
+                    'transport_error' => 'the test scripted no further results',
+                ];
+            }
+        };
+    }
+
+    /**
+     * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null}
+     */
+    private static function verified(): array
+    {
+        return ['verified' => true, 'error_codes' => [], 'transport_error' => null];
+    }
+
+    /**
+     * @param array<int, string> $codes
+     *   Error codes Cloudflare returned.
+     *
+     * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null}
+     */
+    private static function refused(array $codes): array
+    {
+        return ['verified' => false, 'error_codes' => $codes, 'transport_error' => null];
+    }
+
+    /**
+     * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null}
+     */
+    private static function unreachable(): array
+    {
+        return [
+            'verified' => false,
+            'error_codes' => [],
+            'transport_error' => 'could not reach the Turnstile siteverify API',
+        ];
+    }
+
+    /**
+     * Render an interstitial with a stock context.
+     */
+    private function render(TurnstileChallengeProvider $provider, string $redirectTo = '/wanted-page'): string
+    {
+        return $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => $redirectTo,
+            'ttl' => '900',
+            'cookie_name' => 'fw_pass',
+            'header_name' => 'X-FW',
+        ]);
+    }
+
+    private function submission(string $token): Request
+    {
+        return Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [TurnstileChallengeProvider::PAYLOAD_FIELD => $token],
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.5']
+        );
+    }
+}

--- a/tests/Unit/Challenge/TurnstileTransportTest.php
+++ b/tests/Unit/Challenge/TurnstileTransportTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Challenge;
+
+require_once __DIR__ . '/../../Traits/ChallengeNamespaceOverrides.php';
+
+use Kanopi\Firewall\Challenge\TurnstileChallengeProvider;
+use Kanopi\Firewall\Logging\LoggingFactory;
+use Kanopi\Firewall\Tests\Logging\TestLogHandler;
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use Monolog\Level;
+use Monolog\Logger;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * The Turnstile siteverify transport, with the stream wrapper shimmed.
+ *
+ * `TurnstileChallengeProviderTest` and the integration suite both substitute
+ * `fetch()` so the provider's decision logic can be tested without a network.
+ * That is the right split, but it leaves the transport itself unexercised —
+ * the unreachable endpoint, and reading back a response whose headers carry
+ * no status line — and those are exactly the paths that decide whether a
+ * Cloudflare outage locks every challenged route or waves everyone through.
+ *
+ * Reaching them against the live endpoint would need a real secret key in CI
+ * and Cloudflare failing on demand, so the stream wrapper is shimmed instead.
+ * See tests/Traits/ChallengeNamespaceOverrides.php.
+ */
+final class TurnstileTransportTest extends AbstractTestCase
+{
+    private const SITE_KEY = '1x00000000000000000000AA';
+
+    private const SECRET_KEY = '1x0000000000000000000000000000000AA';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        // These are process-global. A leaked flag would feed a canned HTTP
+        // response to every later test in the run.
+        $GLOBALS['fake_challenge_http_response'] = null;
+        $GLOBALS['fake_challenge_http_handles'] = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * A genuine token verified over the real transport.
+     */
+    public function testVerifiedTokenPassesThroughTheTransport(): void
+    {
+        $this->fakeResponse(200, (string) json_encode(['success' => true]));
+
+        $this->assertTrue($this->provider()->verifySolution($this->submission()));
+    }
+
+    /**
+     * Cloudflare's rejection is read back as a plain failure.
+     */
+    public function testRejectedTokenFailsThroughTheTransport(): void
+    {
+        $this->fakeResponse(200, (string) json_encode([
+            'success' => false,
+            'error-codes' => ['timeout-or-duplicate'],
+        ]));
+
+        $handler = $this->captureLogs();
+
+        $this->assertFalse($this->provider()->verifySolution($this->submission()));
+        $this->assertFalse(
+            $handler->hasErrorContaining('could not be completed'),
+            'A token Cloudflare answered about is a verdict, not a transport failure.',
+        );
+    }
+
+    /**
+     * An unreachable siteverify endpoint blocks by default.
+     *
+     * Fail-closed is the deliberate choice here, unlike the reputation
+     * lookups: an attacker who can disrupt siteverify would otherwise get a
+     * bypass for every challenged route on demand.
+     */
+    public function testUnreachableEndpointBlocksByDefault(): void
+    {
+        $GLOBALS['fake_challenge_http_response'] = false;
+
+        $handler = $this->captureLogs();
+
+        $this->assertFalse($this->provider()->verifySolution($this->submission()));
+        $this->assertTrue(
+            $handler->hasErrorContaining('Turnstile verification could not be completed'),
+            'Locking visitors out has to be stated in the log, not inferred from a failed solve.',
+        );
+    }
+
+    /**
+     * The same outage lets visitors through under `on_error: allow`.
+     */
+    public function testUnreachableEndpointAllowsWhenConfiguredTo(): void
+    {
+        $GLOBALS['fake_challenge_http_response'] = false;
+
+        $this->assertTrue(
+            $this->provider(['on_error' => 'allow'])->verifySolution($this->submission())
+        );
+    }
+
+    /**
+     * A response the wrapper reported no headers for is a transport failure.
+     *
+     * Without `wrapper_data` there is no status line to read, so the body
+     * cannot be trusted as a verdict however well-formed it looks — treating
+     * it as one would turn a broken proxy into a free pass.
+     */
+    public function testResponseWithoutWrapperHeadersIsATransportFailure(): void
+    {
+        $GLOBALS['fake_challenge_http_response'] = [
+            'body' => (string) json_encode(['success' => true]),
+        ];
+
+        $handler = $this->captureLogs();
+
+        $this->assertFalse($this->provider()->verifySolution($this->submission()));
+        $this->assertStringContainsString('unreadable status', $this->loggedTransportError($handler));
+    }
+
+    /**
+     * A non-200 from siteverify is an outage, not a failed visitor.
+     */
+    public function testServerErrorFromSiteverifyIsATransportFailure(): void
+    {
+        $this->fakeResponse(503, '');
+
+        $handler = $this->captureLogs();
+
+        $this->assertFalse($this->provider()->verifySolution($this->submission()));
+        $this->assertStringContainsString('returned HTTP 503', $this->loggedTransportError($handler));
+    }
+
+    /**
+     * With `send_remoteip` on, the client IP reaches the wire.
+     *
+     * `buildRequestBody()` is unit-tested directly, but only the transport
+     * proves the body it builds is what gets sent — an opt-in that never
+     * left the process would look identical from the outside.
+     */
+    public function testRemoteIpOptInReachesTheRequestBody(): void
+    {
+        $this->fakeResponse(200, (string) json_encode(['success' => true]));
+
+        $provider = new class (['site_key' => self::SITE_KEY, 'secret_key' => self::SECRET_KEY, 'send_remoteip' => true]) extends TurnstileChallengeProvider {
+            public string $sent = '';
+
+            /**
+             * {@inheritdoc}
+             */
+            protected function buildRequestBody(string $token, Request $request): string
+            {
+                return $this->sent = parent::buildRequestBody($token, $request);
+            }
+        };
+
+        $this->assertTrue($provider->verifySolution($this->submission()));
+        $this->assertStringContainsString('remoteip=203.0.113.45', $provider->sent);
+    }
+
+    /**
+     * Install a canned HTTP response with a conventional status line.
+     */
+    private function fakeResponse(int $status, string $body): void
+    {
+        $GLOBALS['fake_challenge_http_response'] = [
+            'headers' => ['HTTP/1.1 ' . $status . ' ' . ($status === 200 ? 'OK' : 'Error')],
+            'body' => $body,
+        ];
+    }
+
+    /**
+     * The reason recorded alongside a transport failure.
+     *
+     * `verifySolution()` logs one message for every unreachable verdict and
+     * puts the specific reason in the context, so asserting on the message
+     * alone cannot tell a 503 apart from a DNS failure — which is the whole
+     * point of recording it.
+     */
+    private function loggedTransportError(TestLogHandler $handler): string
+    {
+        foreach ($handler->records as $record) {
+            if (str_contains((string) $record->message, 'could not be completed')) {
+                return (string) ($record->context['error'] ?? '');
+            }
+        }
+
+        return '';
+    }
+
+    private function captureLogs(): TestLogHandler
+    {
+        $handler = new TestLogHandler(Level::Debug);
+        LoggingFactory::setLogger(new Logger('test', [$handler]));
+
+        return $handler;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *   Provider options; the keys are filled in.
+     */
+    private function provider(array $options = []): TurnstileChallengeProvider
+    {
+        $options['site_key'] ??= self::SITE_KEY;
+        $options['secret_key'] ??= self::SECRET_KEY;
+
+        return new TurnstileChallengeProvider($options);
+    }
+
+    /**
+     * A POST carrying a plausible widget token.
+     */
+    private function submission(string $ip = '203.0.113.45'): Request
+    {
+        return Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [TurnstileChallengeProvider::PAYLOAD_FIELD => str_repeat('t', 64)],
+            [],
+            [],
+            ['REMOTE_ADDR' => $ip]
+        );
+    }
+}


### PR DESCRIPTION
## Description

Adds Cloudflare Turnstile as a built-in `challenge.provider`, alongside `math` and `altcha`. Previously `docs/plugins/challenges.md` told operators who wanted real bot resistance to write their own provider and shipped a partial Turnstile sketch as the worked example, leaving server-side verification, escaping, timeouts and CSP to each of them individually.

## Related Issue

Fixes #125

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- **`src/Challenge/TurnstileChallengeProvider.php`** — renders the Turnstile widget through `InterstitialRenderer`, verifies the posted token against Cloudflare's siteverify API.
- **`ChallengeProviderFactory`** — registers the `turnstile` short name, and now matches constructor parameters **by declared type** rather than counting them.
- **`InterstitialRenderer`** — new optional `submit_failure` hook.
- **Tests** — 46 unit cases, 7 transport cases, 8 integration cases, factory cases for the new injection rule, and Turnstile added to the inline-script parse guard.
- **`tests/Traits/ChallengeNamespaceOverrides.php`** — namespace-scoped `fopen()` / `stream_get_meta_data()` shims for `Kanopi\Firewall\Challenge`, so the siteverify transport can be exercised without a network. Mirrors the existing `PluginsNamespaceOverrides.php`.
- **Docs / config / demo** — built-in provider section with a comparison table, `config/config.yml` and `example/config.notes.yml` option reference, and a `/secure-turnstile` demo route.

### The one architectural difference

`math` re-checks an HMAC it signed; `altcha` re-runs a hash locally. Both decide validity from the posted payload alone. A `cf-turnstile-response` token is opaque — no published format or key verifies it offline — so `verifySolution()` makes one server-to-server call on the challenge POST (never on ordinary requests). It uses the stream wrapper, matching `AbuseIpdb::fetch()`, so no new Composer dependency and the dependency surface stays flat after #124 dropped Guzzle.

### Decisions worth reviewing

| Decision | Rationale |
|---|---|
| **Fail closed** when siteverify is unreachable (`on_error: block` default) | A verdict that could not be obtained is not a pass. Failing open would make any siteverify disruption — outage, DNS failure, egress filtering — a bypass for every challenged route, on demand for anyone who can cause it. The cost is explicit in the docs: challenged routes are impassable while Cloudflare is unreachable. `on_error: allow` opts out, and only governs unreachability — a token Cloudflare actively rejects is always refused. |
| **`send_remoteip` off by default** | `getClientIp()` is only trustworthy with `global.require_trusted_proxies` configured. Behind an unconfigured proxy it returns whatever `X-Forwarded-For` claimed, so a spoofed header sends Cloudflare an unrelated address and fails verification for legitimate visitors. A provider cannot see that global, so it must not infer. |
| **`internal-error` counts as unreachability** | Cloudflare documents it as retryable, so it is not a verdict on the token. |
| **No `SingleUseSolutionInterface`** | Cloudflare answers `timeout-or-duplicate` to a replayed token, so solutions are single-use at the source. No storage record, unlike `altcha`. |
| **Missing keys throw at startup** | The alternative is a firewall serving a widget every visitor is guaranteed to fail. |
| **No abstract base class yet** | Written concretely; extract `AbstractRemoteCaptchaProvider` when hCaptcha lands, with two real implementations to generalise from. |
| **Turnstile is not the new default** | `math` and `altcha` need no reachable third party. A visitor whose network blocks `challenges.cloudflare.com` can never pass. Documented as a per-route choice. |

### Two supporting changes

**Type-based constructor injection.** Turnstile signs no state of its own, so accepting a `TokenManager` would be a lie in its signature — and PHPStan at level max rejects the unused parameter, correctly. The factory now passes `provider_options` to an `array` parameter and the `TokenManager` to anything else. Backward compatible in both directions: untyped parameters still receive the `TokenManager`, so custom providers written against the previous fixed `new $class($tokenManager)` signature are unaffected. Covered by four new factory tests including the untyped and no-constructor cases.

**`submit_failure` renderer hook.** A refused Turnstile submission has spent its token — Cloudflare answers `timeout-or-duplicate` to any further use — so without recycling the widget the visitor is left clicking **Continue** on something that can never succeed, with only a page reload as a way out. The hook is optional and defaults to empty, so `math` and `altcha` render byte-identical output.

### Unrelated fix included

`example/config.notes.yml` documented `secret: '${FIREWALL_CHALLENGE_SECRET}'`, but `TokenSubstitute` only implements `%env(VAR)%` — `${VAR}` is taken literally. Anyone who copy-pasted it got a pass-token HMAC secret that is the literal string `${FIREWALL_CHALLENGE_SECRET}`, identical across every deployment that followed the docs. Corrected in the challenge section I was already editing, since leaving it would have contradicted the Turnstile examples right above it.

**The same broken syntax appears in `docs/configuration/logging.md` (9 occurrences) and is left alone here** — it deserves its own issue rather than being buried in a feature PR. Filed as #129.

## Testing

### How to Test

Automated:

```bash
composer test      # 1188 unit + 57 integration, all green
composer phpunit   # both suites in one pass, with coverage — what the CI gate runs
composer check     # PHPCS, PHPStan level max, Rector — all clean
```

Against the real Cloudflare API, using their published dummy keys:

```bash
composer demo
open http://localhost:8000/secure-turnstile
```

Verified locally end to end:

1. `/secure-turnstile` serves the interstitial — widget present, `data-sitekey` rendered, **Continue** ships `disabled`, `redirect_to=/secure-turnstile` and `ttl=60` echoed back.
2. POST to `/_firewall/challenge-turnstile` → real siteverify round trip → `{"token":"…","redirect":"/secure-turnstile"}` plus a `fw_challenge_turnstile_pass` cookie. The decoded token carries `"aud":"turnstile"`.
3. Replaying that cookie on `/secure-turnstile` passes through to the demo page.

The live transport was also exercised directly against all three dummy secrets. This is now backed by automated tests as well (see the coverage note below), but the live run is what confirms the request Cloudflare actually accepts:

| Secret key | Result |
|---|---|
| `1x0000000000000000000000000000000AA` (always passes) | `true` |
| `2x0000000000000000000000000000000AA` (always fails) | `false` |
| `3x0000000000000000000000000000000AA` (token already spent) | `false` |
| empty token (no request sent) | `false` |

### Test Configuration

```yaml
challenge:
  provider: turnstile
  secret: '%env(FIREWALL_CHALLENGE_SECRET)%'
  path: /_firewall/challenge
  cookie_name: fw_challenge_turnstile_pass
  provider_options:
    site_key: '1x00000000000000000000AA'
    secret_key: '1x0000000000000000000000000000000AA'

plugins:
  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
    response: challenge
    weight: 0
    enable: true
    metadata:
      default_expiration_time: 60
    config:
      - "path@starts_with:/secure-turnstile"
```

## Checklist

### Code Quality

- [x] My code follows the project's code style (`composer cs` passes)
- [x] Static analysis passes (`composer stan` passes)
- [x] I have added appropriate code comments explaining complex logic
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors

### Testing

- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have added integration tests if necessary
- [x] New and existing tests pass locally (`composer test` passes)
- [x] I have achieved 100% test coverage for new code — **now met. See below.**
- [x] I have tested edge cases and error conditions

**Coverage, resolved.** An earlier revision of this description recorded `TurnstileChallengeProvider.php` at 83.5% (111/133), with the 22 uncovered statements being the body of `fetch()` — `stream_context_create()` / `fopen()` / `stream_get_meta_data()` / `fclose()`. **That file is now at 100% (133/133).**

The fix came from merging `2.x`, which brought in #132 and with it the pattern for this exact problem. `AbuseIpdbTransportTest` covers the identical stream-wrapper transport by defining `fopen()` and `stream_get_meta_data()` inside the plugin's own namespace, where PHP resolves unqualified calls before falling back to the global function. `AbuseIpdb.php` went from 65.8% to 100% that way. The same approach is now applied here via `tests/Traits/ChallengeNamespaceOverrides.php` — inert unless a flag is set, reset in `tearDown()`, and delegating untouched for any handle it did not create, so `math` and `altcha` are unaffected.

Seven cases in `tests/Unit/Challenge/TurnstileTransportTest.php` drive the real `fetch()` end to end: a verified token, a rejected one, an unreachable endpoint under both `on_error` settings, a non-200, a response whose headers carry no parseable status line, and the `send_remoteip` opt-in reaching the request body.

The last two are worth a reviewer's eye. A well-formed `success: true` body arriving with no readable status line must still be refused — otherwise a broken proxy becomes a free pass — and only an *absent* `wrapper_data` key reproduces it, so the shim distinguishes an absent `headers` key from an empty one.

Note that #127 is superseded by #131; making these wrappers injectable is no longer the plan, since the namespace shim reaches the same paths without changing production signatures.

**Repo-wide coverage.** The figures in the earlier revision (92.11% against an 85% gate) are stale — #132 raised the gate to 90 and took the project to 100%. Measured locally on this branch after the merge: **98.76% (3896/3945)**. The whole of the shortfall is `RedisRateLimitStorage.php` (0/49), skipped by `#[RequiresPhpExtension('redis')]` on machines without `ext-redis`; 3896 + 49 = 3945, so CI — which does `pecl install redis` — reports 100%. Every line reachable without that extension is covered.

### Security Considerations

- [x] I have considered the security implications of my changes
- [x] Input validation is properly implemented
- [x] No sensitive information is logged or exposed
- [x] Rate limiting is considered for new endpoints/features
- [x] Changes don't introduce new attack vectors

Specifics:

- **The secret key never reaches the browser.** Asserted by a test that renders the interstitial and greps for it.
- **`verifySolution()` cannot be made to throw.** `InputBag::get()` raises `BadRequestException` on a non-scalar, so posting `cf-turnstile-response[]=x` through it would turn attacker input into a 500. The token is read off `->all()` instead, with a test for the array case. *`math` and `altcha` do read through `get()` and have this defect — since confirmed end-to-end (the exception escapes `Firewall::evaluate()` uncaught) and filed as #130. Not touched here.*
- **No round trip for input that cannot be valid** — an empty or over-2048-byte token is refused unsent, so the endpoint cannot be used to make this server flood Cloudflare.
- **`success` must be a JSON `true`**, not merely truthy. Tested.
- **`error-codes` is normalised** rather than trusted, so a hostile or malformed array cannot reach the logger.
- **Configuration faults are logged at `error`** and distinguished from failed visitors, so a wrong secret key does not read as a wave of bots.
- **No SRI, deliberately** — documented, with the CSP directives operators need.

### Documentation

- [x] I have added/updated configuration examples
- [x] I have documented any new plugin variables or options
- [x] I have updated inline documentation/comments
- [ ] I have updated the README.md if needed — README does not enumerate providers, so no change was needed

## Breaking Changes

- [ ] This PR introduces breaking changes

The factory's injection rule changed, but it is backward compatible: every previously valid provider signature is constructed exactly as before. Existing `math` and `altcha` interstitials render byte-identical output.

## Performance Impact

- [x] This change has performance implications

One outbound HTTPS round trip per challenge **submission** — not per request. Ordinary traffic never reaches this provider, and the interstitial itself renders with no network call. The timeout defaults to 2s (clamped 1–10) because it runs while the visitor waits. No change to any existing provider's path.

## Reviewer Notes

Most useful places to push back:

1. **`on_error: block` as the default.** This is the judgement call with real operational teeth — a Cloudflare incident makes challenged routes impassable. I think fail-closed is right for a security library and the escape hatch is one line of config, but it is worth a second opinion.
2. **The factory change.** It resolves a genuine PHPStan complaint rather than papering over it, but it does touch a contract custom providers depend on. The BC argument is that untyped and `TokenManager`-first signatures are unchanged — please check I have not missed a shape.
3. **`internal-error` mapped to unreachability.** Defensible from Cloudflare's docs, but it does mean a sustained internal error behaves like an outage under `on_error`.
4. **`submit_failure` touching shared rendering.** Small and additive, but it is the one change that affects the other two providers' code path.
5. **The namespace shim for the transport tests.** It follows the precedent set by `PluginsNamespaceOverrides.php` on `2.x` rather than inventing anything, but function shadowing is a sharp tool: the flags are process-global, so a leaked one would feed a canned HTTP response to every later test in the run. They are reset in `tearDown()` — worth confirming there is no path that skips it.

## Rebase note

`2.x` has been merged into this branch (`940cca9`), picking up #132's coverage work. That merge is what surfaced the `fetch()` gap and supplied the pattern used to close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

