### PR TITLE
Add a built-in Google reCAPTCHA challenge provider (Fixes #134)

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -16,7 +16,8 @@ plugins: []
 #                plugins are active. Use a long random string, typically
 #                injected from an env var (`%env(VAR)%`). Unrelated to any
 #                third-party challenge service's secret key.
-#   provider:    Built-in short name (`math`, `altcha`, `turnstile`) or a
+#   provider:    Built-in short name (`math`, `altcha`, `turnstile`,
+#                `recaptcha`) or a
 #                FQCN that implements
 #                Kanopi\Firewall\Challenge\ChallengeProviderInterface.
 #   path:        URL the interstitial form POSTs to.
@@ -28,11 +29,14 @@ plugins: []
 #   provider_options:
 #                Optional per-provider settings forwarded to the provider
 #                constructor. `altcha` accepts `widget_src` and
-#                `widget_integrity`; `turnstile` REQUIRES `site_key` and
-#                `secret_key`. See example/config.notes.yml.
+#                `widget_integrity`; `turnstile` and `recaptcha` REQUIRE
+#                `site_key` and `secret_key`, and `recaptcha` also takes
+#                `version` (v2 or v3). See example/config.notes.yml.
 #   audience:    Scopes pass tokens to this instance so two firewalls
 #                sharing a secret do not accept each other's tokens.
-#                Defaults to the provider name when left empty.
+#                Defaults to the `provider` value above when left empty --
+#                so instances running the SAME provider (including
+#                `recaptcha` at v2 and v3) must set this explicitly.
 challenge:
   provider: math
   secret: ''

--- a/docs/guides/demo.md
+++ b/docs/guides/demo.md
@@ -1,6 +1,6 @@
 # Lite Firewall local demo
 
-A throwaway harness for poking at the firewall in a browser. Demonstrates all three response modes (`allow`, `block`, `challenge`) and all three built-in challenge providers (`math`, `altcha` and `turnstile`) side by side, and ships a production-shaped nginx → php-fpm stack so you can run perf experiments against something that looks like a real deployment.
+A throwaway harness for poking at the firewall in a browser. Demonstrates all three response modes (`allow`, `block`, `challenge`) and all four built-in challenge providers (`math`, `altcha`, `turnstile` and `recaptcha`) side by side, and ships a production-shaped nginx → php-fpm stack so you can run perf experiments against something that looks like a real deployment.
 
 ## TL;DR — composer shortcuts
 
@@ -24,7 +24,8 @@ The config keys rules off the URL so behavior is identical on any networking set
 | `/admin`          | Blocked — a `response: block` URL plugin returns 400 with the configured banning message.       |
 | `/secure`         | Challenged via the **math** provider. Solve "What is A + B?" → 60s pass cookie (`fw_challenge_pass`). |
 | `/secure-altcha`  | Challenged via the **ALTCHA** provider. The widget solves a SHA-256 proof-of-work automatically → 60s pass cookie (`fw_challenge_altcha_pass`). |
-| `/secure-turnstile` | Challenged via the **Cloudflare Turnstile** provider, using Cloudflare's always-passes [test keys](https://developers.cloudflare.com/turnstile/troubleshooting/testing/) → 60s pass cookie (`fw_challenge_turnstile_pass`). Unlike the other routes this one needs outbound network access: the widget loads from Cloudflare and the token is verified against their siteverify API. |
+| `/secure-turnstile` | Challenged via the **Cloudflare Turnstile** provider, using Cloudflare's always-passes [test keys](https://developers.cloudflare.com/turnstile/troubleshooting/testing/) → 60s pass cookie (`fw_challenge_turnstile_pass`). Like the reCAPTCHA route, this one needs outbound network access: the widget loads from Cloudflare and the token is verified against their siteverify API. |
+| `/secure-recaptcha` | Challenged via the **Google reCAPTCHA** provider in its v2 checkbox mode, using Google's always-passes [test keys](https://developers.google.com/recaptcha/docs/faq) → 60s pass cookie (`fw_challenge_recaptcha_pass`). Also needs outbound network access: the widget loads from Google and the token is verified against their siteverify API. |
 
 ### What each route looks like
 
@@ -55,9 +56,9 @@ The config keys rules off the URL so behavior is identical on any networking set
     request to any route is rejected by the blocklist before plugins run. Run
     `composer demo:reset` between experiments to start clean.
 
-Only one `challenge.provider` is configurable per Firewall instance, so the demo ships three configs (`config.yml` for math, `config.altcha.yml` for ALTCHA, `config.turnstile.yml` for Turnstile) and `index.php` dispatches between them based on the request path. Each pass token lives in its own cookie and submit path so they coexist in one browser session.
+Only one `challenge.provider` is configurable per Firewall instance, so the demo ships four configs (`config.yml` for math, `config.altcha.yml` for ALTCHA, `config.turnstile.yml` for Turnstile, `config.recaptcha.yml` for reCAPTCHA) and `index.php` dispatches between them based on the request path. Each pass token lives in its own cookie and submit path so they coexist in one browser session.
 
-Note that the distinct cookie names are ergonomics, not a security boundary. The two instances share a `challenge.secret`, so what actually stops a token earned on the easy math challenge from opening `/secure-altcha` is the `aud` claim, which defaults to the provider name — see [Scoping tokens across instances](../plugins/challenges.md#scoping-tokens-across-instances). Try it: solve `/secure`, copy `fw_challenge_pass` into `fw_challenge_altcha_pass`, and `/secure-altcha` still challenges you.
+Note that the distinct cookie names are ergonomics, not a security boundary. The instances share a `challenge.secret`, so what actually stops a token earned on the easy math challenge from opening `/secure-altcha` is the `aud` claim, which defaults to the provider name — see [Scoping tokens across instances](../plugins/challenges.md#scoping-tokens-across-instances). Try it: solve `/secure`, copy `fw_challenge_pass` into `fw_challenge_altcha_pass`, and `/secure-altcha` still challenges you.
 
 ## Option 1 — PHP built-in server (quick)
 

--- a/docs/plugins/challenges.md
+++ b/docs/plugins/challenges.md
@@ -14,7 +14,7 @@ The pass token is:
 
 ```yaml
 challenge:
-  provider: math                # 'math', 'altcha' or 'turnstile'; or a FQCN implementing ChallengeProviderInterface
+  provider: math                # 'math', 'altcha', 'turnstile' or 'recaptcha'; or a FQCN implementing ChallengeProviderInterface
   secret: '%env(FIREWALL_CHALLENGE_SECRET)%'   # REQUIRED. Long random string, ideally from an env var.
   cookie_name: fw_challenge_pass
   header_name: X-Firewall-Challenge
@@ -67,7 +67,7 @@ The alternative is to give each instance its own `challenge.secret`, which isola
 
 ## Built-in providers
 
-Three providers ship with the firewall — set `challenge.provider` to a short name:
+Four providers ship with the firewall — set `challenge.provider` to a short name:
 
 === "math"
 
@@ -87,21 +87,27 @@ Three providers ship with the firewall — set `challenge.provider` to a short n
 === "turnstile"
 
     Cloudflare's Turnstile widget, verified server-side against their
-    siteverify API. The strongest bot resistance of the three, and the only
-    one that depends on a third party being reachable — from the visitor's
+    siteverify API. The strongest bot resistance of the four, and one of two
+    that depend on a third party being reachable — from the visitor's
     browser *and* from your server.
+
+=== "recaptcha"
+
+    Google's reCAPTCHA, in either the v2 "I'm not a robot" checkbox (the
+    default) or the invisible, score-based v3. Verified server-side against
+    Google's siteverify API.
 
 The math and ALTCHA screenshots come from the [demo application](../guides/demo.md), which serves each provider on its own route.
 
 Which to pick is mostly a question of what you are willing to depend on:
 
-| | `math` | `altcha` | `turnstile` |
-|---|---|---|---|
-| Third-party script | none | CDN (self-hostable) | Cloudflare only |
-| Outbound call from your server | none | none | one per submission |
-| Subresource Integrity | n/a | yes, pinned | not possible |
-| Bot resistance | lowest | CPU cost per solve | highest |
-| Fails if the third party is down | n/a | interstitial degrades | nobody can pass (default) |
+| | `math` | `altcha` | `turnstile` | `recaptcha` |
+|---|---|---|---|---|
+| Third-party script | none | CDN (self-hostable) | Cloudflare only | Google only |
+| Outbound call from your server | none | none | one per submission | one per submission |
+| Subresource Integrity | n/a | yes, pinned | not possible | not possible |
+| Bot resistance | lowest | CPU cost per solve | highest | high |
+| Fails if the third party is down | n/a | interstitial degrades | nobody can pass (default) | nobody can pass (default) |
 
 - **`math`** — asks "What is A + B?" with single-digit operands. Low-friction proof-of-effort, no JS bundle, no external script load. Defeats the laziest bots; trivial for a human.
 - **`altcha`** — embeds the [ALTCHA](https://altcha.org/docs/v2/) v2 widget with a pre-computed challenge (no server round-trip to fetch one). The visitor's browser brute-forces `SHA-256(salt + N) == challenge`; the salt embeds an expiry and the challenge is HMAC-signed with `challenge.secret`, so the server stays stateless. Privacy-respecting, and imposes a per-solve CPU cost on bots. Solved challenges are single-use — see [Single-use solutions](#single-use-solutions).
@@ -160,7 +166,68 @@ Which to pick is mostly a question of what you are willing to depend on:
 
   For local development, Cloudflare publishes [dummy keys](https://developers.cloudflare.com/turnstile/troubleshooting/testing/) — `1x00000000000000000000AA` with secret `1x0000000000000000000000000000000AA` always passes. The siteverify call still goes over the network, so they do not make the flow work offline.
 
-For hCaptcha, reCAPTCHA, or anything else, implement `Kanopi\Firewall\Challenge\ChallengeProviderInterface` and set `challenge.provider` to its FQCN.
+- **`recaptcha`** — renders a [Google reCAPTCHA](https://developers.google.com/recaptcha/) widget and verifies the token it produces against Google's siteverify API. Shares its shape with `turnstile`; the differences are that it offers two incompatible versions and that one of them returns a score rather than a verdict.
+
+  Create a site at [google.com/recaptcha/admin](https://www.google.com/recaptcha/admin), pick the version there, add the domains it may run on, and configure both keys:
+
+  ```yaml
+  challenge:
+    provider: recaptcha
+    secret: '%env(FIREWALL_CHALLENGE_SECRET)%'     # pass-token HMAC key — NOT a reCAPTCHA key
+    provider_options:
+      site_key: '%env(RECAPTCHA_SITE_KEY)%'        # public; rendered into the page
+      secret_key: '%env(RECAPTCHA_SECRET_KEY)%'    # private; only ever sent to Google
+  ```
+
+  As with Turnstile: `challenge.secret` signs pass tokens and has nothing to do with Google, and despite looking like a pair, `site_key` is public while `secret_key` must never reach the browser. Both keys are required; omitting either throws `ConfigurationException` at startup.
+
+  **The keys and the `version` must agree.** A v2 key pair registered at Google returns no score, and a v3 pair does not render a checkbox. The provider refuses a scoreless response on `version: v3` rather than treating "well-formed token" as "trustworthy visitor", and logs it at `error` with a hint — that message means the keys are v2.
+
+  Optional settings:
+
+  | Option | Default | Applies to | Purpose |
+  |---|---|---|---|
+  | `version` | `v2` | both | `v2` (checkbox) or `v3` (invisible, scored). |
+  | `theme` | `light` | v2 | Widget colour scheme: `light` or `dark`. reCAPTCHA has no `auto`. |
+  | `size` | `normal` | v2 | `normal` or `compact`. |
+  | `min_score` | `0.5` | v3 | Lowest score that passes, 0.0–1.0. Clamped into range. |
+  | `action` | `firewall` | v3 | Action name minted and required back. See below. |
+  | `timeout` | `2` | both | Seconds to wait for siteverify, clamped to 1–10. |
+  | `on_error` | `block` | both | What happens when siteverify cannot be reached. |
+  | `send_remoteip` | `false` | both | Forward the visitor's IP to Google. |
+  | `use_recaptcha_net` | `false` | both | Serve and verify via `www.recaptcha.net` instead of `www.google.com`, for networks where google.com is blocked. Moves both halves together. |
+  | `widget_src` | Google's URL | both | Override to serve the bundle through a first-party proxy. On v3 the `render` parameter is appended unless the URL already has one. |
+
+  `on_error` and `send_remoteip` behave exactly as they do for `turnstile`, and for the same reasons — read those two paragraphs above; they apply here unchanged.
+
+  **Prefer v2 unless you have a reason not to.** v3 never asks the visitor for anything, which sounds strictly better and is not: `success: true` on v3 only means the token was well-formed and unspent, and the actual accept/reject is your `min_score` threshold. A human who scores below it has no puzzle to solve and no retry that helps — they simply cannot reach the route. Pick the threshold from observed traffic rather than from the 0.5 in Google's documentation, and think twice before putting v3 in front of anything real people need.
+
+  **`action` is a security control on v3, not a label.** A v3 token is minted by the site key, not by a page, so without binding it to an action a token produced by *any other* reCAPTCHA v3 call on your site — a newsletter signup, a search box, anything an attacker can trigger without friction — would satisfy the firewall challenge too. The provider requires the `action` Google echoes back to equal the configured one. Google drops characters outside alphanumerics, slashes and underscores, so the configured value is filtered the same way before it is compared.
+
+  **v2 and v3 instances sharing a `challenge.secret` need an explicit `audience`.** The `aud` claim defaults to the `challenge.provider` config string, which is `recaptcha` for both versions — so a pass earned on a v3 route would open a v2 route, and a v3 pass is the weaker claim of the two. Set [`challenge.audience`](#scoping-tokens-across-instances) on at least one of them:
+
+  ```yaml
+  challenge:
+    provider: recaptcha
+    audience: recaptcha-v3   # keeps v3 passes out of v2-protected routes
+    provider_options:
+      version: v3
+  ```
+
+  **Content-Security-Policy** needs Google in two directives, and one host more than you would expect — api.js bootstraps a second bundle from `gstatic.com`:
+
+  ```
+  script-src https://www.google.com https://www.gstatic.com;
+  frame-src  https://www.google.com;
+  ```
+
+  Substitute `https://www.recaptcha.net` for `https://www.google.com` if you set `use_recaptcha_net`.
+
+  Replay needs no configuration: Google answers `timeout-or-duplicate` to a token that has already been redeemed or has aged out, so a solve cannot be redistributed. That is why this provider does not implement [`SingleUseSolutionInterface`](#single-use-solutions) or touch storage at all. Tokens also go stale about two minutes after they are minted — the interstitial handles that itself, via v2's expiry callback and a periodic re-execute on v3.
+
+  For local development, Google publishes [test keys](https://developers.google.com/recaptcha/docs/faq) — site key `6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI` with secret `6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe` always passes, and the widget renders with a visible testing warning. They are v2 only; there is no v3 test pair, and the siteverify call still goes over the network.
+
+For hCaptcha or anything else, implement `Kanopi\Firewall\Challenge\ChallengeProviderInterface` and set `challenge.provider` to its FQCN.
 
 ## Writing a custom provider
 
@@ -242,7 +309,7 @@ Requirements and gotchas:
 - **Escape everything you interpolate.** `redirect_to` originates from the request URI. The built-in providers run every substitution through `InterstitialRenderer::escapeHtml()`; do the same. Values landing inside a `<script>` block need `escapeJs()` instead — HTML entities are not decoded there.
 - **Echo back `redirect_to` and `ttl`** as form fields named exactly that. The Firewall reads them from the POST to decide where to send the visitor and how long to mint the pass token for. Omit them and you get `/` and 3600s.
 - **`verifySolution()` must never throw.** It runs on attacker-controlled input; return `false` for anything you don't like. Note that `$request->request->get()` raises `BadRequestException` on an array value, so read hostile fields off `->all()` instead.
-- **Register via FQCN**, not a short name. `challenge.provider` resolves `math`, `altcha` and `turnstile` as built-ins; everything else must be a loadable class implementing the interface, or `create()` throws `ConfigurationException`.
+- **Register via FQCN**, not a short name. `challenge.provider` resolves `math`, `altcha`, `turnstile` and `recaptcha` as built-ins; everything else must be a loadable class implementing the interface, or `create()` throws `ConfigurationException`.
 - **Declare the collaborators you want.** `ChallengeProviderFactory` matches constructor parameters by declared type — a `TokenManager` parameter gets the shared manager, an `array` parameter gets `challenge.provider_options`, and a provider needing neither can declare no constructor at all. Untyped parameters receive the `TokenManager`, so providers written against the older fixed `new $class($tokenManager)` signature keep working unchanged.
 - Use `$tokenManager->sign()` / `verifySignature()` if you need tamper-proof state in the form. You do **not** need to mint the pass token — the Firewall does that once `verifySolution()` returns `true`.
 - **Reuse the shared interstitial** via `InterstitialRenderer::render()` rather than hand-rolling a document. It owns the submit JS, the two token-delivery paths, and the escaping rules those depend on. Providers whose challenge token is spent by a failed attempt can pass a `submit_failure` snippet to reset the widget.

--- a/example/config.notes.yml
+++ b/example/config.notes.yml
@@ -72,8 +72,8 @@ storage:
 # plugin does, `secret` is REQUIRED — startup throws ConfigurationException
 # if it is empty.
 challenge:
-  # Short name of a built-in provider ("math", "altcha", "turnstile") or FQCN
-  # of a class implementing
+  # Short name of a built-in provider ("math", "altcha", "turnstile",
+  # "recaptcha") or FQCN of a class implementing
   # Kanopi\Firewall\Challenge\ChallengeProviderInterface.
   #   math      — "What is A + B?" with single-digit operands. Low-friction
   #               proof-of-effort, no JS bundle, no external script load.
@@ -89,6 +89,15 @@ challenge:
   #               provider_options.site_key and .secret_key. Replay is
   #               handled by Cloudflare, so no storage is involved.
   #               See https://developers.cloudflare.com/turnstile/.
+  #   recaptcha — Embeds a Google reCAPTCHA widget and verifies its token
+  #               against Google's siteverify API. Same shape as turnstile,
+  #               and the same third-party dependency in both directions.
+  #               Offers two versions: v2 (the "I'm not a robot" checkbox,
+  #               the default) and v3 (invisible, returns a 0.0-1.0 score
+  #               this provider compares against min_score). Requires
+  #               provider_options.site_key and .secret_key. Replay is
+  #               handled by Google, so no storage is involved.
+  #               See https://developers.google.com/recaptcha/.
   provider: math
   # Optional per-provider settings, forwarded to the provider constructor.
   # Unknown keys are ignored, so this is safe to leave empty.
@@ -134,6 +143,57 @@ challenge:
   #                      any value: Cloudflare's URL is unversioned and
   #                      mutable, so a pinned digest would break on their
   #                      next deploy.
+  #
+  # recaptcha accepts:
+  #   site_key          — REQUIRED. reCAPTCHA site key. PUBLIC: it is
+  #                       rendered into the interstitial.
+  #   secret_key        — REQUIRED. reCAPTCHA secret key. PRIVATE: only ever
+  #                       sent server-to-server to siteverify. NOT the same
+  #                       thing as `challenge.secret` below. Omitting either
+  #                       key throws at startup rather than serving a widget
+  #                       nobody could pass.
+  #   version           — v2 (default) or v3. The key pair registered with
+  #                       Google has to match: a v2 pair returns no score,
+  #                       which v3 refuses rather than treating a well-formed
+  #                       token as a trustworthy visitor.
+  #                       Prefer v2. v3 never asks the visitor for anything,
+  #                       so a human scoring below min_score has no puzzle to
+  #                       solve and no retry that helps — they simply cannot
+  #                       reach the route.
+  #   theme             — v2 only. light (default) or dark. reCAPTCHA has no
+  #                       `auto` value.
+  #   size              — v2 only. normal (default) or compact.
+  #   min_score         — v3 only. Lowest passing score, 0.0-1.0, default
+  #                       0.5. Clamped into range. Pick it from observed
+  #                       traffic, not from the 0.5 in Google's docs.
+  #   action            — v3 only, default `firewall`. A security control,
+  #                       not a label: a v3 token is minted by the site key
+  #                       rather than by a page, so without binding it to an
+  #                       action a token from any other reCAPTCHA call on the
+  #                       site would satisfy this challenge too.
+  #   timeout           — Seconds to wait for siteverify. Clamped to 1-10,
+  #                       default 2. This runs while the visitor waits.
+  #   on_error          — What to do when siteverify cannot be REACHED:
+  #                       block (default) or allow. Same trade-off, and the
+  #                       same reasoning, as turnstile above.
+  #   send_remoteip     — Forward the visitor's IP to Google. Default false,
+  #                       for the same proxy-trust reason as turnstile above.
+  #   use_recaptcha_net — Serve the widget from and verify against
+  #                       www.recaptcha.net instead of www.google.com, for
+  #                       networks where google.com is blocked. Moves both
+  #                       halves together; a widget the visitor can load is
+  #                       useless if this server cannot verify its output.
+  #   widget_src        — Override the widget bundle URL, e.g. to serve it
+  #                       via a first-party proxy. On v3 the `render`
+  #                       parameter is appended unless the URL already
+  #                       carries one. No SRI digest is emitted: api.js is
+  #                       unversioned and bootstraps further scripts.
+  #
+  # NOTE for recaptcha: `audience` below defaults to this `provider` string,
+  # which is `recaptcha` for BOTH versions. Two instances sharing a `secret`
+  # but running v2 and v3 will therefore honour each other's pass tokens —
+  # and a v3 pass is the weaker claim. Set `audience` explicitly on at least
+  # one of them.
   provider_options: {}
   # Scopes pass tokens to this instance. Tokens carry the value as an `aud`
   # claim and only verify against a firewall configured with the same one,

--- a/example/demo/README.md
+++ b/example/demo/README.md
@@ -1,8 +1,9 @@
 # Lite Firewall local demo
 
 A throwaway harness for poking at the firewall in a browser. Demonstrates all
-three response modes (`allow`, `block`, `challenge`) and both built-in
-challenge providers (`math` and `altcha`) side by side, and ships a
+three response modes (`allow`, `block`, `challenge`) and all four built-in
+challenge providers (`math`, `altcha`, `turnstile` and `recaptcha`) side by
+side, and ships a
 production-shaped nginx → php-fpm stack so you can run perf experiments against
 something that looks like a real deployment.
 

--- a/example/demo/config.recaptcha.yml
+++ b/example/demo/config.recaptcha.yml
@@ -1,0 +1,55 @@
+# Google reCAPTCHA variant of the demo config.
+#
+# Loaded by example/demo/index.php whenever the request touches the reCAPTCHA
+# routes (/secure-recaptcha or /_firewall/challenge-recaptcha) — see that file
+# for the dispatch logic. Everything else falls back to config.yml.
+#
+# Each provider gets a distinct challenge submit path, cookie name, and header
+# name so pass tokens from the four providers can co-exist in one browser
+# session without overwriting each other.
+#
+# Like the Turnstile route and unlike math and ALTCHA, this one is NOT
+# self-contained: the widget loads from www.google.com and the submitted token
+# is verified server-to-server against Google's siteverify API. The demo will
+# not work without outbound network access.
+
+global:
+  banning_message: "Blocked: {{request.path}} is restricted (request {{request.id}})."
+
+# Same storage file as config.yml so a block recorded by one Firewall
+# instance is observed by the other (repeat-offender behavior).
+storage:
+  type: Kanopi\Firewall\Storage\FileStorage
+  config:
+    storage_file: /tmp/firewall-demo.data
+
+challenge:
+  provider: recaptcha
+  secret: 'demo-secret-do-not-reuse-in-prod'
+  cookie_name: fw_challenge_recaptcha_pass
+  header_name: X-Firewall-Challenge-Recaptcha
+  path: /_firewall/challenge-recaptcha
+  provider_options:
+    # Google's documented v2 test keys: the widget renders with a visible
+    # "for testing purposes only" warning and siteverify accepts any token
+    # it produces. Swap in real keys from https://www.google.com/recaptcha/admin
+    # to see the genuine behaviour.
+    #   https://developers.google.com/recaptcha/docs/faq
+    site_key: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
+    secret_key: '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'
+    # v2 is the default and what this demo route exercises. To try v3
+    # instead you need a real v3 key pair — Google publishes no v3 test
+    # keys, and a v2 pair returns no score, which the provider refuses
+    # rather than treating as a pass:
+    #   version: v3
+    #   min_score: 0.5
+
+plugins:
+  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
+    response: challenge
+    weight: 0
+    enable: true
+    metadata:
+      default_expiration_time: 60
+    config:
+      - "path@starts_with:/secure-recaptcha"

--- a/example/demo/index.php
+++ b/example/demo/index.php
@@ -5,23 +5,25 @@ declare(strict_types=1);
 /*
  * Front controller for the Lite Firewall demo.
  *
- * Five demo routes — see example/demo/config.yml, config.altcha.yml and
- * config.turnstile.yml for the rules:
+ * Six demo routes — see example/demo/config.yml, config.altcha.yml,
+ * config.turnstile.yml and config.recaptcha.yml for the rules:
  *
  *   /                  allowed
  *   /admin             blocked
  *   /secure            challenged via the math provider
  *   /secure-altcha     challenged via the ALTCHA provider
  *   /secure-turnstile  challenged via the Cloudflare Turnstile provider
+ *   /secure-recaptcha  challenged via the Google reCAPTCHA provider
  *
  * Only one ChallengeProviderInterface is wired per Firewall instance,
- * so the three challenge providers live in separate config files and we
- * dispatch by path: anything touching /secure-altcha or /secure-turnstile
- * (or their submit endpoints) loads the matching config; everything else
- * loads config.yml.
+ * so the four challenge providers live in separate config files and we
+ * dispatch by path: anything touching /secure-altcha, /secure-turnstile or
+ * /secure-recaptcha (or their submit endpoints) loads the matching config;
+ * everything else loads config.yml.
  *
- * The Turnstile route needs outbound network access — the widget loads
- * from Cloudflare and the token is verified against their siteverify API.
+ * The Turnstile and reCAPTCHA routes need outbound network access — the
+ * widget loads from a third party and the token is verified against their
+ * siteverify API.
  *
  * Run with the PHP built-in server (single-process):
  *
@@ -42,9 +44,13 @@ $useAltcha = str_starts_with($requestPath, '/secure-altcha')
 $useTurnstile = str_starts_with($requestPath, '/secure-turnstile')
     || $requestPath === '/_firewall/challenge-turnstile';
 
+$useRecaptcha = str_starts_with($requestPath, '/secure-recaptcha')
+    || $requestPath === '/_firewall/challenge-recaptcha';
+
 $configFile = match (true) {
     $useAltcha => 'config.altcha.yml',
     $useTurnstile => 'config.turnstile.yml',
+    $useRecaptcha => 'config.recaptcha.yml',
     default => 'config.yml',
 };
 
@@ -57,6 +63,7 @@ $path = $_SERVER['REQUEST_URI'] ?? '/';
 $mathCookie = isset($_COOKIE['fw_challenge_pass']);
 $altchaCookie = isset($_COOKIE['fw_challenge_altcha_pass']);
 $turnstileCookie = isset($_COOKIE['fw_challenge_turnstile_pass']);
+$recaptchaCookie = isset($_COOKIE['fw_challenge_recaptcha_pass']);
 
 header('Content-Type: text/html; charset=utf-8');
 
@@ -90,13 +97,14 @@ header('Content-Type: text/html; charset=utf-8');
       <tr><td><a href="/secure">/secure</a></td><td>Challenged via the <strong>math</strong> provider — "What is A + B?" interstitial. 60s pass cookie.</td></tr>
       <tr><td><a href="/secure-altcha">/secure-altcha</a></td><td>Challenged via the <strong>ALTCHA</strong> provider — proof-of-work widget solves automatically. 60s pass cookie.</td></tr>
       <tr><td><a href="/secure-turnstile">/secure-turnstile</a></td><td>Challenged via the <strong>Cloudflare Turnstile</strong> provider, using Cloudflare's always-passes test keys. 60s pass cookie. <strong>Needs outbound network access</strong> — the widget loads from Cloudflare and the token is verified against their API.</td></tr>
+      <tr><td><a href="/secure-recaptcha">/secure-recaptcha</a></td><td>Challenged via the <strong>Google reCAPTCHA</strong> provider (v2 checkbox), using Google's always-passes test keys. 60s pass cookie. <strong>Needs outbound network access</strong> — the widget loads from Google and the token is verified against their API.</td></tr>
     </tbody>
   </table>
 
   <h2>Re-triggering the challenge</h2>
   <p>The pass token TTL is 60s in this demo. To force the interstitial again sooner:</p>
   <ul>
-    <li>Delete the <code>fw_challenge_pass</code> / <code>fw_challenge_altcha_pass</code> / <code>fw_challenge_turnstile_pass</code> cookie via browser dev tools, or</li>
+    <li>Delete the <code>fw_challenge_pass</code> / <code>fw_challenge_altcha_pass</code> / <code>fw_challenge_turnstile_pass</code> / <code>fw_challenge_recaptcha_pass</code> cookie via browser dev tools, or</li>
     <li>Reload the route in an incognito window.</li>
   </ul>
 
@@ -105,7 +113,8 @@ header('Content-Type: text/html; charset=utf-8');
     Client IP (as the firewall sees it): <code><?= htmlspecialchars($ip, ENT_QUOTES, 'UTF-8') ?></code><br>
     Math pass cookie present: <code><?= $mathCookie ? 'yes' : 'no' ?></code><br>
     ALTCHA pass cookie present: <code><?= $altchaCookie ? 'yes' : 'no' ?></code><br>
-    Turnstile pass cookie present: <code><?= $turnstileCookie ? 'yes' : 'no' ?></code>
+    Turnstile pass cookie present: <code><?= $turnstileCookie ? 'yes' : 'no' ?></code><br>
+    reCAPTCHA pass cookie present: <code><?= $recaptchaCookie ? 'yes' : 'no' ?></code>
   </p>
 </body>
 </html>

--- a/src/Challenge/ChallengeProviderFactory.php
+++ b/src/Challenge/ChallengeProviderFactory.php
@@ -31,6 +31,7 @@ final class ChallengeProviderFactory
         'math' => MathChallengeProvider::class,
         'altcha' => AltchaChallengeProvider::class,
         'turnstile' => TurnstileChallengeProvider::class,
+        'recaptcha' => RecaptchaChallengeProvider::class,
     ];
 
     /**

--- a/src/Challenge/ChallengeProviderInterface.php
+++ b/src/Challenge/ChallengeProviderInterface.php
@@ -14,7 +14,7 @@ namespace Kanopi\Firewall\Challenge;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Contract for challenge providers (math, Turnstile, hCaptcha, …).
+ * Contract for challenge providers (math, Turnstile, reCAPTCHA, …).
  *
  * A provider owns two halves of the challenge round-trip:
  *   1. Rendering the interstitial body that asks the visitor to prove they

--- a/src/Challenge/RecaptchaChallengeProvider.php
+++ b/src/Challenge/RecaptchaChallengeProvider.php
@@ -1,0 +1,994 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kanopi\Firewall\Challenge;
+
+use Kanopi\Firewall\Exception\ConfigurationException;
+use Kanopi\Firewall\Logging\LoggingFactory;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Built-in Google reCAPTCHA challenge.
+ *
+ * Renders a reCAPTCHA widget, then verifies the token it produces against
+ * Google's siteverify API. Shares its shape with
+ * `TurnstileChallengeProvider` — an opaque third-party token, one
+ * server-to-server round trip on the challenge POST, no local verification
+ * possible — and differs from it in the two places reCAPTCHA genuinely
+ * differs: it offers two incompatible versions, and one of them returns a
+ * score rather than a verdict.
+ *
+ * Wire format (per https://developers.google.com/recaptcha/):
+ *   server → client: the api.js bundle plus either a `g-recaptcha` element
+ *                    (v2) or a `grecaptcha.execute()` call (v3).
+ *   client → server: an opaque token in a form field.
+ *   server → Google: POST {secret, response, remoteip?} to siteverify.
+ *   Google → server: {success, challenge_ts, hostname, error-codes} plus
+ *                    {score, action} on v3.
+ *
+ * ## The two versions
+ *
+ * `version: v2` (the default) is the "I'm not a robot" checkbox. The visitor
+ * does something, the widget mints a token, and Google answers a plain
+ * yes/no. It is the closer analogue to Turnstile and the safer default: a
+ * visitor who fails can try again.
+ *
+ * `version: v3` is invisible and scores the visitor from 0.0 to 1.0 instead
+ * of judging them. `success: true` on v3 only means the token was
+ * well-formed and unspent — the actual decision is this provider's, made by
+ * comparing `score` against `min_score`. That difference has a sharp edge
+ * worth stating plainly: **a human whose score sits below the threshold has
+ * no way to pass.** There is no puzzle to solve and no retry that helps, so
+ * a v3 challenge on a route real people need is a lockout waiting to happen.
+ * Prefer v2 unless you have a reason not to, and pick `min_score` from
+ * observed traffic rather than from the 0.5 in the documentation.
+ *
+ * ## Why v3 binds the action
+ *
+ * A v3 token is minted by the site key, not by any particular page, and
+ * carries only the `action` string the caller asked for. If this provider
+ * checked `success` and `score` alone, a token produced by *any other*
+ * reCAPTCHA v3 call on the same site — a newsletter signup, a search box,
+ * anything an attacker can trigger without friction — would satisfy the
+ * firewall challenge too. `verifySolution()` therefore requires the
+ * returned `action` to equal the configured one, which is the only part of
+ * the response that ties the token to this challenge.
+ *
+ * ## Replay
+ *
+ * Handled at the source on both versions: Google answers
+ * `timeout-or-duplicate` to a token that has already been redeemed or has
+ * aged out. That is why this provider — like `TurnstileChallengeProvider`
+ * and unlike `AltchaChallengeProvider` — needs no
+ * `SingleUseSolutionInterface` and touches no storage.
+ *
+ * Tokens also expire about two minutes after they are minted, which the
+ * interstitial has to handle rather than the server: see
+ * `renderInterstitial()` for the v2 expiry callback and the v3 refresh.
+ *
+ * ## Trade-offs against the other built-ins
+ *
+ *   - It depends on a third party being reachable from both the visitor's
+ *     browser and this server. When siteverify is unreachable this provider
+ *     fails closed by default (see `on_error`).
+ *   - No Subresource Integrity. api.js is served from an unversioned,
+ *     mutable URL and bootstraps further scripts, so a pinned digest would
+ *     break on Google's next deploy.
+ *   - Operators need a Content-Security-Policy that permits the reCAPTCHA
+ *     host in both `script-src` and `frame-src`, plus `www.gstatic.com` in
+ *     `script-src` for the bundle api.js pulls in.
+ *   - Where google.com is unreachable, `use_recaptcha_net` moves both the
+ *     widget and siteverify to Google's alternate domain.
+ */
+final class RecaptchaChallengeProvider implements ChallengeProviderInterface
+{
+    /**
+     * Form field carrying a v2 widget's token.
+     *
+     * Fixed by reCAPTCHA v2's automatic rendering, which injects a hidden
+     * textarea under this name into the enclosing form.
+     */
+    public const PAYLOAD_FIELD = 'g-recaptcha-response';
+
+    /**
+     * Form field carrying a v3 token.
+     *
+     * Deliberately *not* `g-recaptcha-response`. On v3 the token arrives in
+     * a promise and has to be parked in a field of our own making, and
+     * api.js also injects hidden textareas of its own under the v2 name.
+     * Two same-named fields in one form make `FormData` carry both values,
+     * and which one `get()` returns is not something to stake a security
+     * check on. Using a name Google never writes to removes the question.
+     */
+    public const V3_PAYLOAD_FIELD = 'firewall-recaptcha-token';
+
+    /**
+     * Checkbox reCAPTCHA. The default.
+     */
+    public const VERSION_V2 = 'v2';
+
+    /**
+     * Invisible, score-based reCAPTCHA.
+     */
+    public const VERSION_V3 = 'v3';
+
+    /**
+     * Google's primary reCAPTCHA host.
+     */
+    public const GOOGLE_HOST = 'https://www.google.com';
+
+    /**
+     * Google's alternate host, for networks where google.com is blocked.
+     *
+     * Documented by Google as a drop-in replacement serving both the widget
+     * and siteverify. Selected by `use_recaptcha_net`, not by a free-form
+     * URL option: an operator-supplied verification endpoint would be an
+     * inviting place to point a firewall at something that always says yes.
+     */
+    public const RECAPTCHA_NET_HOST = 'https://www.recaptcha.net';
+
+    /**
+     * Path of the server-side verification endpoint, under either host.
+     */
+    public const SITEVERIFY_PATH = '/recaptcha/api/siteverify';
+
+    /**
+     * Path of the widget bundle, under either host.
+     */
+    public const WIDGET_PATH = '/recaptcha/api.js';
+
+    /**
+     * Default score a v3 visitor must reach.
+     *
+     * Google's own suggested starting point. It is a starting point and not
+     * a recommendation — see the class docblock.
+     */
+    public const DEFAULT_MIN_SCORE = 0.5;
+
+    /**
+     * Default v3 action name.
+     *
+     * Sent by the interstitial and required back from Google unchanged.
+     */
+    public const DEFAULT_ACTION = 'firewall';
+
+    /**
+     * Seconds to wait on siteverify before giving up.
+     *
+     * Short by design — this runs inside a request the visitor is waiting
+     * on, and a slow answer is worth less than a fast failure handled by
+     * `on_error`.
+     */
+    private const DEFAULT_TIMEOUT = 2;
+
+    /**
+     * Ceiling for the configurable timeout.
+     */
+    private const MAX_TIMEOUT = 10;
+
+    /**
+     * Longest token accepted before the request is refused unsent.
+     *
+     * Unlike Cloudflare, Google publishes no maximum token length, so this
+     * is a sanity bound rather than a specification: generous enough that no
+     * genuine token approaches it, small enough that a multi-megabyte POST
+     * is not forwarded to Google to be told it is nonsense.
+     */
+    private const MAX_TOKEN_LENGTH = 8192;
+
+    /**
+     * Widget colour themes reCAPTCHA v2 accepts.
+     *
+     * No `auto`, unlike Turnstile — reCAPTCHA has no such value, so offering
+     * one would mean silently rendering something else.
+     *
+     * @var array<int, string>
+     */
+    private const THEMES = ['light', 'dark'];
+
+    /**
+     * Widget sizes reCAPTCHA v2 accepts here.
+     *
+     * `invisible` is a documented v2 size but a different flow — no visible
+     * control, and the token is minted by an explicit `execute()` bound to
+     * the submit button. It is excluded rather than silently mishandled;
+     * `version: v3` covers the "no visitor interaction" case.
+     *
+     * @var array<int, string>
+     */
+    private const SIZES = ['normal', 'compact'];
+
+    /**
+     * Error codes that mean this firewall is misconfigured, not that the
+     * visitor failed. Logged at `error` because every visitor will fail
+     * until an operator fixes the configuration.
+     *
+     * @var array<int, string>
+     */
+    private const CONFIG_ERROR_CODES = ['missing-input-secret', 'invalid-input-secret', 'bad-request'];
+
+    /**
+     * reCAPTCHA version in use.
+     */
+    private readonly string $version;
+
+    /**
+     * Public key rendered into the widget.
+     */
+    private readonly string $siteKey;
+
+    /**
+     * Private key sent to siteverify. Never rendered, never logged.
+     */
+    private readonly string $secretKey;
+
+    /**
+     * Host serving both the widget and siteverify.
+     */
+    private readonly string $host;
+
+    /**
+     * Widget bundle URL actually emitted.
+     */
+    private readonly string $widgetSrc;
+
+    /**
+     * Widget colour theme. v2 only.
+     */
+    private readonly string $theme;
+
+    /**
+     * Widget size. v2 only.
+     */
+    private readonly string $size;
+
+    /**
+     * Lowest score accepted from v3.
+     */
+    private readonly float $minScore;
+
+    /**
+     * Action name the interstitial requests and siteverify must echo back.
+     */
+    private readonly string $action;
+
+    /**
+     * siteverify timeout in seconds.
+     */
+    private readonly int $timeout;
+
+    /**
+     * Whether an unreachable siteverify lets the visitor through.
+     */
+    private readonly bool $allowOnError;
+
+    /**
+     * Whether the visitor's IP is forwarded to Google.
+     */
+    private readonly bool $sendRemoteIp;
+
+    /**
+     * Constructs a new RecaptchaChallengeProvider object.
+     *
+     * Takes no `TokenManager`: there is no per-challenge state of ours to
+     * sign, because the only thing that has to survive from render to verify
+     * is Google's own token. `ChallengeProviderFactory` matches constructor
+     * parameters by declared type, so declining it is enough to not be
+     * handed one.
+     *
+     * @param array<string, mixed> $options
+     *   Provider options from `challenge.provider_options`:
+     *     - site_key:          REQUIRED. reCAPTCHA site key (public).
+     *     - secret_key:        REQUIRED. reCAPTCHA secret key (private).
+     *     - version:           `v2` (default) or `v3`. See the class
+     *                          docblock before choosing `v3`.
+     *     - theme:             v2 only. `light` (default) or `dark`.
+     *     - size:              v2 only. `normal` (default) or `compact`.
+     *     - min_score:         v3 only. 0.0-1.0, default 0.5.
+     *     - action:            v3 only. Action name to mint and require
+     *                          back, default `firewall`.
+     *     - timeout:           siteverify timeout in seconds, 1-10,
+     *                          default 2.
+     *     - on_error:          `block` (default) or `allow` — what happens
+     *                          when siteverify cannot be reached. See
+     *                          verifySolution().
+     *     - send_remoteip:     Forward the client IP to Google. Default
+     *                          FALSE; see fetch() for why that is not the
+     *                          obvious choice it looks like.
+     *     - use_recaptcha_net: Serve the widget from and verify against
+     *                          www.recaptcha.net instead of www.google.com.
+     *     - widget_src:        Override the widget bundle URL, e.g. to serve
+     *                          it through a first-party proxy your CSP
+     *                          allows. On v3 the `render` parameter is
+     *                          appended unless the URL already carries one.
+     *
+     * @throws ConfigurationException
+     *   When `site_key` or `secret_key` is missing or empty. Failing at
+     *   startup is the point: the alternative is a firewall that renders a
+     *   widget every visitor is guaranteed to fail.
+     */
+    public function __construct(array $options = [])
+    {
+        $this->siteKey = $this->requireOption($options, 'site_key');
+        $this->secretKey = $this->requireOption($options, 'secret_key');
+
+        $version = strtolower(trim((string) ($options['version'] ?? '')));
+        $this->version = $version === self::VERSION_V3 ? self::VERSION_V3 : self::VERSION_V2;
+
+        $this->host = ($options['use_recaptcha_net'] ?? false) === true
+            ? self::RECAPTCHA_NET_HOST
+            : self::GOOGLE_HOST;
+
+        $theme = strtolower(trim((string) ($options['theme'] ?? '')));
+        $this->theme = in_array($theme, self::THEMES, true) ? $theme : 'light';
+
+        $size = strtolower(trim((string) ($options['size'] ?? '')));
+        $this->size = in_array($size, self::SIZES, true) ? $size : 'normal';
+
+        $this->minScore = $this->readMinScore($options);
+        $this->action = $this->readAction($options);
+
+        $timeout = (int) ($options['timeout'] ?? self::DEFAULT_TIMEOUT);
+        $this->timeout = max(1, min(self::MAX_TIMEOUT, $timeout));
+
+        $this->allowOnError = strtolower(trim((string) ($options['on_error'] ?? 'block'))) === 'allow';
+        $this->sendRemoteIp = ($options['send_remoteip'] ?? false) === true;
+
+        $widgetSrc = trim((string) ($options['widget_src'] ?? ''));
+        $this->widgetSrc = $this->buildWidgetSrc($widgetSrc);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Version-scoped so logs say which mode made a decision: a v3 refusal is
+     * this provider's own score threshold talking, a v2 refusal is Google's,
+     * and telling them apart is most of diagnosing a challenge nobody can
+     * pass.
+     *
+     * It does **not** scope pass tokens, which is worth knowing because it
+     * looks like it should. `Firewall` builds the `aud` claim from the
+     * `challenge.provider` config string — necessarily, since the
+     * `TokenManager` is constructed and handed to the factory before any
+     * provider exists — so a v2 and a v3 instance both configured as
+     * `recaptcha` share an audience and will honour each other's tokens. A
+     * v3 pass is the weaker claim of the two: the visitor cleared a score
+     * rather than doing anything. Deployments running both against one
+     * `challenge.secret` must therefore set `challenge.audience` explicitly
+     * on at least one of them.
+     */
+    public function getName(): string
+    {
+        return $this->version === self::VERSION_V3 ? 'recaptcha-v3' : 'recaptcha';
+    }
+
+    /**
+     * Form field this provider reads its token from.
+     *
+     * Differs by version; see V3_PAYLOAD_FIELD for why.
+     */
+    public function getPayloadField(): string
+    {
+        return $this->version === self::VERSION_V3 ? self::V3_PAYLOAD_FIELD : self::PAYLOAD_FIELD;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function renderInterstitial(Request $request, array $context): string
+    {
+        $parts = $this->version === self::VERSION_V3 ? $this->v3Parts() : $this->v2Parts();
+
+        return InterstitialRenderer::render([
+            'intro' => $parts['intro'],
+            'extra_styles' => $parts['extra_styles'],
+            'extra_head' => $parts['extra_head'],
+            'form_fields' => $parts['form_fields'],
+            'submit_guard' => $parts['submit_guard'],
+            'submit_failure' => $parts['submit_failure'],
+            'extra_script' => $parts['extra_script'],
+            'error_message' => 'Verification failed. Please try again.',
+            // Enabled only once a token exists, so the visitor cannot post
+            // an empty one.
+            'submit_disabled' => true,
+            'submit_url' => $context['submit_url'] ?? '',
+            'redirect_to' => $context['redirect_to'] ?? '/',
+            'ttl' => $context['ttl'] ?? '3600',
+            'header_name' => $context['header_name'] ?? '',
+            'redirect_field' => self::REDIRECT_FIELD,
+            'ttl_field' => self::TTL_FIELD,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Outcomes, deliberately kept distinct:
+     *
+     *   - Google says the token is good, and on v3 it also clears the score
+     *     and action gates → TRUE.
+     *   - Google says it is not → FALSE. This covers replay
+     *     (`timeout-or-duplicate`), so a solve cannot be shared around.
+     *   - Google said yes but the v3 gates refuse it → FALSE, logged
+     *     separately so a threshold that is too high does not look like a
+     *     wave of bots.
+     *   - Google could not be asked → the `on_error` option decides,
+     *     defaulting to FALSE.
+     *
+     * That last case is the one worth being deliberate about. Failing open
+     * turns any disruption of siteverify — an outage, a DNS failure, egress
+     * filtering on this host — into a bypass for every challenged route,
+     * and an attacker who can cause it gets the bypass on demand. Failing
+     * closed instead makes those routes impassable for the duration, which
+     * is visible and self-correcting. Operators who would rather absorb the
+     * risk than lock visitors out can set `on_error: allow`.
+     */
+    public function verifySolution(Request $request): bool
+    {
+        $token = $this->postedToken($request);
+
+        // No round trip for a request that cannot carry a valid token.
+        if ($token === '' || strlen($token) > self::MAX_TOKEN_LENGTH) {
+            return false;
+        }
+
+        $result = $this->fetch($token, $request);
+
+        if ($result['transport_error'] !== null) {
+            LoggingFactory::logMessage('error', 'reCAPTCHA verification could not be completed', [
+                'provider' => $this->getName(),
+                'error' => $result['transport_error'],
+                'on_error' => $this->allowOnError ? 'allow' : 'block',
+            ]);
+
+            return $this->allowOnError;
+        }
+
+        if (!$result['verified']) {
+            // Configuration faults are indistinguishable from a failed
+            // visitor in the return value, so separate them in the log —
+            // otherwise a wrong secret key looks like a wave of bots.
+            $misconfigured = array_intersect($result['error_codes'], self::CONFIG_ERROR_CODES) !== [];
+
+            LoggingFactory::logMessage($misconfigured ? 'error' : 'info', $misconfigured
+                ? 'reCAPTCHA rejected the request because this firewall is misconfigured'
+                : 'reCAPTCHA verification failed', [
+                    'provider' => $this->getName(),
+                    'error_codes' => $result['error_codes'],
+                ]);
+
+            return false;
+        }
+
+        // On v2 Google's yes is the whole answer. On v3 it only means the
+        // token was well-formed and unspent.
+        return $this->version !== self::VERSION_V3 || $this->passesScoreGate($result);
+    }
+
+    /**
+     * Ask Google whether a token is genuine.
+     *
+     * Uses the stream wrapper rather than an HTTP client library, matching
+     * `TurnstileChallengeProvider::fetch()` and `AbuseIpdb::fetch()` — the
+     * other places this package talks to the network — so a security
+     * library's dependency surface stays unchanged. `ignore_errors` is on so
+     * an error body can be read rather than surfacing as an opaque failure.
+     *
+     * On `send_remoteip`: forwarding the client IP sharpens Google's signal,
+     * but `$request->getClientIp()` is only trustworthy when
+     * `global.require_trusted_proxies` is configured. Behind an unconfigured
+     * proxy it returns whatever `X-Forwarded-For` claimed, which means a
+     * spoofed header sends Google an IP unrelated to the visitor and can
+     * fail verification for legitimate people. A provider cannot see that
+     * global, so this defaults off rather than guessing.
+     *
+     * @param string $token
+     *   The token posted by the widget. Already length-checked.
+     * @param Request $request
+     *   The submission, used only for the optional client IP.
+     *
+     * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null, score: float|null, action: string|null}
+     *   `transport_error` is non-null only when Google's verdict could not
+     *   be obtained at all, which is the case `on_error` governs.
+     */
+    protected function fetch(string $token, Request $request): array
+    {
+        $body = $this->buildRequestBody($token, $request);
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'timeout' => $this->timeout,
+                'ignore_errors' => true,
+                'header' => [
+                    'Content-Type: application/x-www-form-urlencoded',
+                    'Content-Length: ' . strlen($body),
+                    'Accept: application/json',
+                ],
+                'content' => $body,
+            ],
+        ]);
+
+        $handle = @fopen($this->getSiteverifyEndpoint(), 'r', false, $context);
+        if ($handle === false) {
+            return $this->transportFailure('could not reach the reCAPTCHA siteverify API');
+        }
+
+        $metadata = stream_get_meta_data($handle);
+        $payload = stream_get_contents($handle);
+        fclose($handle);
+
+        /** @var array<int, string> $headers */
+        $headers = is_array($metadata['wrapper_data'] ?? null) ? $metadata['wrapper_data'] : [];
+
+        return $this->interpretResponse($this->statusFromHeaders($headers), $payload);
+    }
+
+    /**
+     * The siteverify URL this provider will call.
+     */
+    public function getSiteverifyEndpoint(): string
+    {
+        return $this->host . self::SITEVERIFY_PATH;
+    }
+
+    /**
+     * Build the urlencoded siteverify request body.
+     *
+     * Separate from the transport so tests can assert what would be sent to
+     * Google — in particular that the client IP is absent unless it was
+     * explicitly opted into — without a network call.
+     *
+     * @param string $token
+     *   The token posted by the widget.
+     * @param Request $request
+     *   The submission, used only for the optional client IP.
+     */
+    protected function buildRequestBody(string $token, Request $request): string
+    {
+        $fields = [
+            'secret' => $this->secretKey,
+            'response' => $token,
+        ];
+
+        if ($this->sendRemoteIp) {
+            $ip = (string) $request->getClientIp();
+            if ($ip !== '') {
+                $fields['remoteip'] = $ip;
+            }
+        }
+
+        return http_build_query($fields);
+    }
+
+    /**
+     * Turn a siteverify HTTP response into a verdict.
+     *
+     * Separate from the transport because every interesting case here is a
+     * malformed or unhappy response, and reproducing those against the real
+     * endpoint is neither reliable nor fast.
+     *
+     * Unlike Cloudflare, Google documents no retryable error code, so any
+     * well-formed `success: false` is taken as a verdict on the token rather
+     * than handed to `on_error`.
+     *
+     * @param int|null $status
+     *   HTTP status, or NULL when none could be parsed.
+     * @param string|false $body
+     *   Raw response body as read from the stream.
+     *
+     * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null, score: float|null, action: string|null}
+     */
+    protected function interpretResponse(?int $status, string|false $body): array
+    {
+        // Google answers 200 even when it rejects a token, so a non-200 is
+        // an infrastructure problem rather than a verdict.
+        if ($status !== 200) {
+            return $this->transportFailure(sprintf(
+                'the reCAPTCHA siteverify API returned HTTP %s',
+                $status ?? 'an unreadable status'
+            ));
+        }
+
+        if ($body === false || $body === '') {
+            return $this->transportFailure('the reCAPTCHA siteverify API returned an empty body');
+        }
+
+        $decoded = json_decode($body, true);
+        if (!is_array($decoded) || !isset($decoded['success'])) {
+            return $this->transportFailure(
+                'the reCAPTCHA siteverify API returned a body that is not a verification result'
+            );
+        }
+
+        return [
+            'verified' => $decoded['success'] === true,
+            'error_codes' => $this->normalizeErrorCodes($decoded['error-codes'] ?? []),
+            'transport_error' => null,
+            // Absent on v2, and absent on a v3 response only if the keys are
+            // not the v3 pair they were configured as. NULL keeps those two
+            // apart from a genuine 0.0, which is the worst possible score
+            // and must never be read as "no score reported".
+            'score' => is_numeric($decoded['score'] ?? null) ? (float) $decoded['score'] : null,
+            'action' => is_string($decoded['action'] ?? null) ? $decoded['action'] : null,
+        ];
+    }
+
+    /**
+     * Apply the v3 gates Google's `success` does not cover.
+     *
+     * Order matters for the logs, not the outcome: a missing score means the
+     * configured keys are not a v3 pair, which an operator has to fix, and
+     * reporting it as a low score instead would send them tuning a threshold
+     * that was never consulted.
+     *
+     * @param array{verified: bool, error_codes: array<int, string>, transport_error: string|null, score: float|null, action: string|null} $result
+     *   An interpreted siteverify response Google already said yes to.
+     */
+    private function passesScoreGate(array $result): bool
+    {
+        if ($result['score'] === null) {
+            LoggingFactory::logMessage('error', 'reCAPTCHA returned no score for a v3 verification', [
+                'provider' => $this->getName(),
+                'hint' => 'The configured keys are probably a v2 pair; v2 keys never return a score.',
+            ]);
+
+            return false;
+        }
+
+        // The token is only evidence about *this* challenge if it was minted
+        // for this action. See the class docblock.
+        if ($result['action'] !== $this->action) {
+            LoggingFactory::logMessage('warning', 'reCAPTCHA token was minted for a different action', [
+                'provider' => $this->getName(),
+                'expected' => $this->action,
+                'received' => $result['action'],
+            ]);
+
+            return false;
+        }
+
+        if ($result['score'] < $this->minScore) {
+            LoggingFactory::logMessage('info', 'reCAPTCHA score was below the configured threshold', [
+                'provider' => $this->getName(),
+                'score' => $result['score'],
+                'min_score' => $this->minScore,
+            ]);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Interstitial pieces for the v2 checkbox.
+     *
+     * @return array{intro: string, extra_styles: string, extra_head: string, form_fields: string, submit_guard: string, submit_failure: string, extra_script: string}
+     */
+    private function v2Parts(): array
+    {
+        $siteKey = InterstitialRenderer::escapeHtml($this->siteKey);
+        $theme = InterstitialRenderer::escapeHtml($this->theme);
+        $size = InterstitialRenderer::escapeHtml($this->size);
+        $widgetSrc = InterstitialRenderer::escapeHtml($this->widgetSrc);
+        $payloadField = InterstitialRenderer::escapeHtml(self::PAYLOAD_FIELD);
+
+        return [
+            'intro' => 'Please complete the check below to continue.',
+            'extra_styles' => '    .g-recaptcha { display: block; margin-bottom: 1rem; min-height: 78px; }'
+                . "\n" . '    button:disabled { background: #9bb8e6; cursor: not-allowed; }',
+            // The widget callbacks are declared here, ahead of the async
+            // bundle, and resolve the button lazily. Declaring them in the
+            // document-bottom script instead would be a race: the widget can
+            // finish and call back before that script has run, and a missing
+            // callback leaves the button disabled for good.
+            'extra_head' => <<<HEAD
+  <script>
+    window.fwRecaptchaVerified = function () {
+      var b = document.getElementById('submit');
+      if (b) { b.disabled = false; }
+    };
+    window.fwRecaptchaReset = function () {
+      var b = document.getElementById('submit');
+      if (b) { b.disabled = true; }
+    };
+  </script>
+  <script src="{$widgetSrc}" async defer></script>
+HEAD,
+            // `data-expired-callback` matters more here than it looks: v2
+            // tokens go stale about two minutes after the checkbox is
+            // ticked, and without it a visitor who reads the page first
+            // would post a token Google answers `timeout-or-duplicate` to.
+            'form_fields' => <<<FIELDS
+      <div class="g-recaptcha" data-sitekey="{$siteKey}" data-theme="{$theme}" data-size="{$size}"
+           data-callback="fwRecaptchaVerified"
+           data-expired-callback="fwRecaptchaReset"
+           data-error-callback="fwRecaptchaReset"></div>
+FIELDS,
+            'submit_guard' => <<<GUARD
+        if (!data.get('{$payloadField}')) {
+          err.classList.add('visible');
+          return;
+        }
+
+GUARD,
+            // A refused submission has spent its token — Google answers
+            // `timeout-or-duplicate` to any further use of it — so recycle
+            // the widget rather than leaving the visitor to click Continue
+            // on a token that can no longer succeed.
+            'submit_failure' => <<<'FAILURE'
+        window.fwRecaptchaReset();
+        if (window.grecaptcha && typeof window.grecaptcha.reset === 'function') {
+          window.grecaptcha.reset();
+        }
+FAILURE,
+            // v2 needs nothing at the document bottom — the widget drives
+            // the button through its callback attributes.
+            'extra_script' => '',
+        ];
+    }
+
+    /**
+     * Interstitial pieces for the v3 invisible check.
+     *
+     * @return array{intro: string, extra_styles: string, extra_head: string, form_fields: string, submit_guard: string, submit_failure: string, extra_script: string}
+     */
+    private function v3Parts(): array
+    {
+        $widgetSrc = InterstitialRenderer::escapeHtml($this->widgetSrc);
+        $payloadField = InterstitialRenderer::escapeHtml(self::V3_PAYLOAD_FIELD);
+
+        // Script context, so JS literal encoding — HTML entities are not
+        // decoded inside <script> and a stray backslash would break out of
+        // the string.
+        $siteKeyJs = InterstitialRenderer::escapeJs($this->siteKey);
+        $actionJs = InterstitialRenderer::escapeJs($this->action);
+        $fieldJs = InterstitialRenderer::escapeJs(self::V3_PAYLOAD_FIELD);
+
+        return [
+            'intro' => 'Verifying your browser. This only takes a moment.',
+            'extra_styles' => '    button:disabled { background: #9bb8e6; cursor: not-allowed; }',
+            'extra_head' => <<<HEAD
+  <script src="{$widgetSrc}" async defer></script>
+HEAD,
+            'form_fields' => <<<FIELDS
+      <input type="hidden" id="fw-recaptcha-token" name="{$payloadField}" value="">
+FIELDS,
+            // Runs at the document bottom, inside the shared IIFE, so
+            // `submit` and `err` are already bound and the hidden field
+            // exists.
+            'extra_script' => <<<SCRIPT
+
+      var fwField = document.getElementById('fw-recaptcha-token');
+      var fwSiteKey = {$siteKeyJs};
+      var fwAction = {$actionJs};
+
+      // api.js is loaded async and bootstraps further scripts of its own,
+      // so `grecaptcha` may not exist yet when this runs — and unlike v2
+      // there is no callback attribute to hang this off. Polling is the
+      // defensive read: no assumption about load order, and a bundle that
+      // never arrives simply leaves the button disabled.
+      function fwRecaptchaExecute() {
+        if (!window.grecaptcha || typeof window.grecaptcha.ready !== 'function') {
+          window.setTimeout(fwRecaptchaExecute, 100);
+          return;
+        }
+
+        window.grecaptcha.ready(function () {
+          window.grecaptcha.execute(fwSiteKey, { action: fwAction }).then(function (token) {
+            fwField.value = token;
+            submit.disabled = false;
+          }, function () {
+            fwField.value = '';
+            submit.disabled = true;
+            err.classList.add('visible');
+          });
+        });
+      }
+
+      fwRecaptchaExecute();
+
+      // v3 tokens expire about two minutes after they are minted. A visitor
+      // who leaves the tab open would otherwise come back to a token Google
+      // answers `timeout-or-duplicate` to, with nothing on screen to retry.
+      window.setInterval(fwRecaptchaExecute, 90000);
+      window.fwRecaptchaRefresh = fwRecaptchaExecute;
+SCRIPT,
+            'submit_guard' => <<<GUARD
+        if (!data.get({$fieldJs})) {
+          err.classList.add('visible');
+          return;
+        }
+
+GUARD,
+            // The attempt spent the token, so mint a fresh one rather than
+            // leaving Continue wired to something already redeemed. The
+            // button goes down first: minting is asynchronous, and until it
+            // resolves a second click would re-post the spent token.
+            'submit_failure' => <<<'FAILURE'
+        submit.disabled = true;
+        if (typeof window.fwRecaptchaRefresh === 'function') {
+          window.fwRecaptchaRefresh();
+        }
+FAILURE,
+        ];
+    }
+
+    /**
+     * Resolve the widget bundle URL, including v3's `render` parameter.
+     *
+     * v3 mints tokens through `grecaptcha.execute()`, which only exists when
+     * api.js was loaded with `render=<site key>`. An operator overriding
+     * `widget_src` to proxy the bundle should not have to know that, so the
+     * parameter is appended for them — unless the URL already carries one,
+     * in which case they meant it.
+     *
+     * @param string $configured
+     *   The `widget_src` option, already trimmed. Empty for the default.
+     */
+    private function buildWidgetSrc(string $configured): string
+    {
+        $src = $configured !== '' ? $configured : $this->host . self::WIDGET_PATH;
+
+        if ($this->version !== self::VERSION_V3 || str_contains($src, 'render=')) {
+            return $src;
+        }
+
+        return $src . (str_contains($src, '?') ? '&' : '?') . 'render=' . rawurlencode($this->siteKey);
+    }
+
+    /**
+     * Read and clamp the v3 score threshold.
+     *
+     * Clamped rather than rejected: `min_score: 5` is a plausible mistake
+     * from someone thinking in percentages, and a threshold above 1.0 would
+     * silently reject every visitor forever.
+     *
+     * @param array<string, mixed> $options
+     *   The provider options as configured.
+     */
+    private function readMinScore(array $options): float
+    {
+        $configured = $options['min_score'] ?? null;
+
+        if (!is_numeric($configured)) {
+            return self::DEFAULT_MIN_SCORE;
+        }
+
+        return max(0.0, min(1.0, (float) $configured));
+    }
+
+    /**
+     * Read the v3 action name.
+     *
+     * Google restricts action names to alphanumerics, slashes and
+     * underscores, and silently drops anything else server-side. Filtering
+     * here rather than passing it through means the value this provider
+     * compares against is the value Google will actually echo back —
+     * otherwise a stray character would fail every verification with a
+     * mismatch that looks like an attack.
+     *
+     * @param array<string, mixed> $options
+     *   The provider options as configured.
+     */
+    private function readAction(array $options): string
+    {
+        $configured = $options['action'] ?? null;
+        $configured = is_scalar($configured) ? trim((string) $configured) : '';
+
+        $filtered = preg_replace('#[^A-Za-z0-9/_]#', '', $configured) ?? '';
+
+        return $filtered !== '' ? $filtered : self::DEFAULT_ACTION;
+    }
+
+    /**
+     * Read the posted token without ever throwing.
+     *
+     * `InputBag::get()` raises `BadRequestException` when the value is an
+     * array, so reading `g-recaptcha-response[]=x` through it would turn
+     * attacker-controlled input into a 500. `verifySolution()` is
+     * contractually forbidden from throwing, so the raw bag is inspected
+     * instead and anything that is not a string is simply not a token.
+     */
+    private function postedToken(Request $request): string
+    {
+        $raw = $request->request->all()[$this->getPayloadField()] ?? '';
+
+        return is_string($raw) ? trim($raw) : '';
+    }
+
+    /**
+     * Pull a required, non-empty string option or fail startup.
+     *
+     * @param array<string, mixed> $options
+     *   The provider options as configured.
+     * @param string $key
+     *   Option name to read.
+     *
+     * @throws ConfigurationException
+     *   When the option is absent or empty.
+     */
+    private function requireOption(array $options, string $key): string
+    {
+        $value = $options[$key] ?? null;
+        $value = is_scalar($value) ? trim((string) $value) : '';
+
+        if ($value === '') {
+            throw new ConfigurationException(sprintf(
+                'reCAPTCHA provider requires `challenge.provider_options.%s`. Register a site at '
+                . 'https://www.google.com/recaptcha/admin, and inject the key with %%env(VAR)%%.',
+                $key
+            ));
+        }
+
+        return $value;
+    }
+
+    /**
+     * Coerce Google's `error-codes` into a list of strings.
+     *
+     * @param mixed $codes
+     *   Whatever occupied the `error-codes` key.
+     *
+     * @return array<int, string>
+     *   Only the string entries, re-indexed.
+     */
+    private function normalizeErrorCodes(mixed $codes): array
+    {
+        if (!is_array($codes)) {
+            return [];
+        }
+
+        return array_values(array_filter($codes, is_string(...)));
+    }
+
+    /**
+     * Read the HTTP status out of the stream wrapper's response headers.
+     *
+     * @param array<int, string> $headers
+     *   `wrapper_data` as reported by `stream_get_meta_data()`.
+     *
+     * @return int|null
+     *   The status code, or NULL when no status line could be parsed.
+     */
+    protected function statusFromHeaders(array $headers): ?int
+    {
+        $status = null;
+
+        // Every header line is scanned rather than stopping at the first
+        // match: a redirect chain leaves several status lines here, and the
+        // one that actually answered is the last.
+        foreach ($headers as $header) {
+            if (preg_match('#^HTTP/\S+\s+(\d{3})#', $header, $matches) === 1) {
+                $status = (int) $matches[1];
+            }
+        }
+
+        return $status;
+    }
+
+    /**
+     * Build a "could not get a verdict" result.
+     *
+     * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null, score: float|null, action: string|null}
+     */
+    private function transportFailure(string $reason): array
+    {
+        return [
+            'verified' => false,
+            'error_codes' => [],
+            'transport_error' => $reason,
+            'score' => null,
+            'action' => null,
+        ];
+    }
+}

--- a/tests/Challenge/AlwaysVerifyingRecaptchaProvider.php
+++ b/tests/Challenge/AlwaysVerifyingRecaptchaProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Challenge;
+
+use Kanopi\Firewall\Challenge\RecaptchaChallengeProvider;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * reCAPTCHA provider with Google replaced by a standing "yes".
+ *
+ * Registered by FQCN in `challenge.provider` so the integration suite can
+ * walk the whole submission flow — form fields, pass-token minting, cookie
+ * delivery — without a network call. Everything except the siteverify round
+ * trip is the real provider.
+ *
+ * The canned response carries a top score and the default action, so it
+ * satisfies the v3 gates as well as v2's plain yes.
+ */
+class AlwaysVerifyingRecaptchaProvider extends RecaptchaChallengeProvider
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function fetch(string $token, Request $request): array
+    {
+        return [
+            'verified' => true,
+            'error_codes' => [],
+            'transport_error' => null,
+            'score' => 1.0,
+            'action' => self::DEFAULT_ACTION,
+        ];
+    }
+}

--- a/tests/Challenge/LowScoringRecaptchaProvider.php
+++ b/tests/Challenge/LowScoringRecaptchaProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Challenge;
+
+use Kanopi\Firewall\Challenge\RecaptchaChallengeProvider;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * reCAPTCHA provider whose tokens Google accepts but scores badly.
+ *
+ * The case that distinguishes v3 from every other built-in: siteverify is
+ * reachable, the token is genuine and unspent, and the visitor is still
+ * refused — by this provider's own threshold rather than by Google. The
+ * integration suite uses it to prove that decision reaches the firewall as
+ * a failed challenge rather than a minted pass token.
+ */
+class LowScoringRecaptchaProvider extends RecaptchaChallengeProvider
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function fetch(string $token, Request $request): array
+    {
+        return [
+            'verified' => true,
+            'error_codes' => [],
+            'transport_error' => null,
+            'score' => 0.1,
+            'action' => self::DEFAULT_ACTION,
+        ];
+    }
+}

--- a/tests/Challenge/UnreachableRecaptchaProvider.php
+++ b/tests/Challenge/UnreachableRecaptchaProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Challenge;
+
+use Kanopi\Firewall\Challenge\RecaptchaChallengeProvider;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * reCAPTCHA provider with siteverify permanently unreachable.
+ *
+ * Stands in for a Google outage, egress filtering, or a DNS failure, so the
+ * integration suite can assert what the `on_error` option actually does to a
+ * live challenge flow.
+ */
+class UnreachableRecaptchaProvider extends RecaptchaChallengeProvider
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function fetch(string $token, Request $request): array
+    {
+        return [
+            'verified' => false,
+            'error_codes' => [],
+            'transport_error' => 'could not reach the reCAPTCHA siteverify API',
+            'score' => null,
+            'action' => null,
+        ];
+    }
+}

--- a/tests/Integration/ChallengeFlowTest.php
+++ b/tests/Integration/ChallengeFlowTest.php
@@ -6,13 +6,17 @@ namespace Kanopi\Firewall\Tests\Integration;
 
 use Kanopi\Firewall\Challenge\AltchaChallengeProvider;
 use Kanopi\Firewall\Challenge\MathChallengeProvider;
+use Kanopi\Firewall\Challenge\RecaptchaChallengeProvider;
 use Kanopi\Firewall\Challenge\TurnstileChallengeProvider;
 use Kanopi\Firewall\Exception\ChallengeRequiredException;
 use Kanopi\Firewall\Exception\ChallengeSolvedException;
 use Kanopi\Firewall\Exception\ConfigurationException;
 use Kanopi\Firewall\Exception\FirewallBlockedException;
 use Kanopi\Firewall\Firewall;
+use Kanopi\Firewall\Tests\Challenge\AlwaysVerifyingRecaptchaProvider;
 use Kanopi\Firewall\Tests\Challenge\AlwaysVerifyingTurnstileProvider;
+use Kanopi\Firewall\Tests\Challenge\LowScoringRecaptchaProvider;
+use Kanopi\Firewall\Tests\Challenge\UnreachableRecaptchaProvider;
 use Kanopi\Firewall\Tests\Challenge\UnreachableTurnstileProvider;
 use Kanopi\Firewall\Traits\FileTrait;
 use PHPUnit\Framework\TestCase;
@@ -33,6 +37,13 @@ class ChallengeFlowTest extends TestCase
     private string $tempDir;
 
     private const SECRET = 'integration-test-secret-value';
+
+    /**
+     * Google's documented always-passes reCAPTCHA v2 test pair.
+     */
+    private const RECAPTCHA_SITE_KEY = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
+
+    private const RECAPTCHA_SECRET_KEY = '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe';
 
     protected function setUp(): void
     {
@@ -906,6 +917,331 @@ class ChallengeFlowTest extends TestCase
                 TurnstileChallengeProvider::PAYLOAD_FIELD => $token,
                 TurnstileChallengeProvider::REDIRECT_FIELD => '/protected',
                 TurnstileChallengeProvider::TTL_FIELD => '600',
+            ],
+            [],
+            [],
+            ['REMOTE_ADDR' => $ip]
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // reCAPTCHA
+    // -------------------------------------------------------------------
+
+    public function testRecaptchaChallengePluginThrowsRequired(): void
+    {
+        $firewall = Firewall::create([$this->configWithRecaptchaChallenge()]);
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($this->blockedRequest('10.0.0.60', '/protected'));
+    }
+
+    public function testRecaptchaInterstitialCarriesTheWidgetAndTheRedirect(): void
+    {
+        $firewall = Firewall::create([$this->configWithRecaptchaChallenge()]);
+        $provider = $this->recaptchaProvider($firewall);
+
+        $html = $provider->renderInterstitial(
+            Request::create('/protected', 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.60']),
+            [
+                'submit_url' => '/_firewall/challenge',
+                'redirect_to' => '/protected',
+                'ttl' => '600',
+                'header_name' => 'X-Firewall-Challenge-Recaptcha',
+            ]
+        );
+
+        $this->assertStringContainsString('class="g-recaptcha"', $html);
+        $this->assertStringContainsString('data-sitekey="' . self::RECAPTCHA_SITE_KEY . '"', $html);
+        $this->assertStringContainsString('value="/protected"', $html);
+        $this->assertStringNotContainsString(self::RECAPTCHA_SECRET_KEY, $html);
+    }
+
+    public function testVerifiedRecaptchaTokenMintsAPassToken(): void
+    {
+        $firewall = Firewall::create([$this->configWithRecaptchaChallenge()]);
+
+        try {
+            $firewall->evaluate($this->recaptchaSubmission('a-token-google-likes', '10.0.0.60'));
+            $this->fail('Expected ChallengeSolvedException');
+        } catch (ChallengeSolvedException $e) {
+            $this->assertNotEmpty($e->getToken());
+            $this->assertSame('/protected', $e->getRedirect());
+        }
+    }
+
+    public function testRecaptchaPassTokenAllowsTheNextRequest(): void
+    {
+        $config = $this->configWithRecaptchaChallenge();
+        $token = '';
+
+        try {
+            Firewall::create([$config])->evaluate(
+                $this->recaptchaSubmission('a-token-google-likes', '10.0.0.60')
+            );
+        } catch (ChallengeSolvedException $e) {
+            $token = $e->getToken();
+        }
+
+        $this->assertNotEmpty($token);
+
+        $request = Request::create('/protected', 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.60']);
+        $request->cookies->set('fw_challenge_recaptcha_pass', $token);
+
+        // No exception: the pass token short-circuits the challenge bucket.
+        Firewall::create([$config])->evaluate($request);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testEmptyRecaptchaTokenIsRefused(): void
+    {
+        $firewall = Firewall::create([$this->configWithRecaptchaChallenge()]);
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($this->recaptchaSubmission('', '10.0.0.60'));
+    }
+
+    public function testUnreachableRecaptchaSiteverifyRefusesTheSubmission(): void
+    {
+        // Fail closed: the default must not hand out a pass token when
+        // Google's verdict could not be obtained.
+        $firewall = Firewall::create([
+            $this->configWithRecaptchaChallenge(
+                UnreachableRecaptchaProvider::class,
+                'recaptcha_down.yml'
+            ),
+        ]);
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($this->recaptchaSubmission('a-token-nobody-can-check', '10.0.0.60'));
+    }
+
+    public function testUnreachableRecaptchaMintsATokenWhenConfiguredToAllow(): void
+    {
+        $firewall = Firewall::create([
+            $this->configWithRecaptchaChallenge(
+                UnreachableRecaptchaProvider::class,
+                'recaptcha_down_allow.yml',
+                ['on_error' => 'allow']
+            ),
+        ]);
+
+        $this->expectException(ChallengeSolvedException::class);
+        $firewall->evaluate($this->recaptchaSubmission('a-token-nobody-can-check', '10.0.0.60'));
+    }
+
+    public function testRecaptchaWithoutKeysFailsAtStartup(): void
+    {
+        $config = $this->writeConfig([
+            'global' => ['mode' => 'exception'],
+            'challenge' => [
+                'provider' => 'recaptcha',
+                'secret' => self::SECRET,
+                'path' => '/_firewall/challenge',
+            ],
+            'plugins' => [
+                [
+                    'plugin' => 'Kanopi\Firewall\Plugins\Url',
+                    'response' => 'challenge',
+                    'weight' => 0,
+                    'enable' => true,
+                    'config' => ['path@starts_with:/protected'],
+                ],
+            ],
+        ], 'recaptcha_keyless.yml');
+
+        $this->expectException(ConfigurationException::class);
+        Firewall::create([$config]);
+    }
+
+    public function testVerifiedV3TokenMintsAPassToken(): void
+    {
+        $firewall = Firewall::create([
+            $this->configWithRecaptchaChallenge(
+                AlwaysVerifyingRecaptchaProvider::class,
+                'recaptcha_v3.yml',
+                ['version' => 'v3']
+            ),
+        ]);
+
+        $this->expectException(ChallengeSolvedException::class);
+        $firewall->evaluate($this->recaptchaV3Submission('a-token-google-likes', '10.0.0.60'));
+    }
+
+    public function testLowScoringV3TokenIsRefusedDespiteGooglesYes(): void
+    {
+        // The case unique to v3: siteverify was reachable and the token was
+        // genuine, and the visitor is still refused — by the threshold, not
+        // by Google. That has to arrive as a failed challenge, not a pass.
+        $firewall = Firewall::create([
+            $this->configWithRecaptchaChallenge(
+                LowScoringRecaptchaProvider::class,
+                'recaptcha_v3_low.yml',
+                ['version' => 'v3', 'min_score' => 0.5]
+            ),
+        ]);
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($this->recaptchaV3Submission('a-token-google-likes', '10.0.0.60'));
+    }
+
+    public function testV3TokenPostedUnderTheV2FieldIsRefused(): void
+    {
+        // v3 reads its own field precisely so api.js's injected
+        // `g-recaptcha-response` textarea cannot be what gets verified.
+        $firewall = Firewall::create([
+            $this->configWithRecaptchaChallenge(
+                AlwaysVerifyingRecaptchaProvider::class,
+                'recaptcha_v3_wrong_field.yml',
+                ['version' => 'v3']
+            ),
+        ]);
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($this->recaptchaSubmission('a-token-google-likes', '10.0.0.60'));
+    }
+
+    public function testExplicitAudienceKeepsAV3PassOutOfAV2Route(): void
+    {
+        // A v3 pass is the weaker claim — the visitor cleared a score, not a
+        // checkbox — so it must not open a v2-protected route. The `aud`
+        // claim is built from the `challenge.provider` config string, which
+        // is identical for both versions, so the separation has to be
+        // configured rather than inferred. This is the documented fix.
+        $v3Config = $this->configWithRecaptchaChallenge(
+            AlwaysVerifyingRecaptchaProvider::class,
+            'recaptcha_v3_audience.yml',
+            ['version' => 'v3'],
+            'recaptcha-v3'
+        );
+        $token = '';
+
+        try {
+            Firewall::create([$v3Config])->evaluate(
+                $this->recaptchaV3Submission('a-token-google-likes', '10.0.0.60')
+            );
+        } catch (ChallengeSolvedException $e) {
+            $token = $e->getToken();
+        }
+
+        $this->assertNotEmpty($token);
+
+        $request = Request::create('/protected', 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.60']);
+        $request->cookies->set('fw_challenge_recaptcha_pass', $token);
+
+        $this->expectException(ChallengeRequiredException::class);
+        Firewall::create([$this->configWithRecaptchaChallenge()])->evaluate($request);
+    }
+
+    public function testWithoutAnExplicitAudienceAV3PassOpensAV2Route(): void
+    {
+        // The sharp edge the test above configures around, asserted so it
+        // stays a known and documented limitation rather than a surprise.
+        // `getName()` being version-scoped does NOT change this: the
+        // audience comes from the config string, before any provider exists.
+        $v3Config = $this->configWithRecaptchaChallenge(
+            AlwaysVerifyingRecaptchaProvider::class,
+            'recaptcha_v3_shared_audience.yml',
+            ['version' => 'v3']
+        );
+        $token = '';
+
+        try {
+            Firewall::create([$v3Config])->evaluate(
+                $this->recaptchaV3Submission('a-token-google-likes', '10.0.0.60')
+            );
+        } catch (ChallengeSolvedException $e) {
+            $token = $e->getToken();
+        }
+
+        $request = Request::create('/protected', 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.60']);
+        $request->cookies->set('fw_challenge_recaptcha_pass', $token);
+
+        // No exception: the two instances share an audience.
+        Firewall::create([$this->configWithRecaptchaChallenge()])->evaluate($request);
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * Config using a reCAPTCHA provider whose siteverify call is stubbed.
+     *
+     * @param class-string $provider
+     *   Provider FQCN — a subclass standing in for one Google behaviour.
+     * @param string $filename
+     *   Config filename, unique per case so the files do not collide.
+     * @param array<string, mixed> $extraOptions
+     *   Extra `provider_options` merged over the test keys.
+     * @param string $audience
+     *   `challenge.audience`. Empty means the default, which is the
+     *   `provider` config string and therefore shared across versions.
+     */
+    private function configWithRecaptchaChallenge(
+        string $provider = AlwaysVerifyingRecaptchaProvider::class,
+        string $filename = 'recaptcha_config.yml',
+        array $extraOptions = [],
+        string $audience = ''
+    ): string {
+        return $this->writeConfig([
+            'global' => ['mode' => 'exception'],
+            'storage' => [
+                'type' => 'Kanopi\Firewall\Storage\FileStorage',
+                'config' => ['storage_file' => $this->tempDir . '/recaptcha-storage.data'],
+            ],
+            'challenge' => [
+                'provider' => $provider,
+                'secret' => self::SECRET,
+                'cookie_name' => 'fw_challenge_recaptcha_pass',
+                'header_name' => 'X-Firewall-Challenge-Recaptcha',
+                'path' => '/_firewall/challenge',
+                'audience' => $audience,
+                'provider_options' => $extraOptions + [
+                    'site_key' => self::RECAPTCHA_SITE_KEY,
+                    'secret_key' => self::RECAPTCHA_SECRET_KEY,
+                ],
+            ],
+            'plugins' => [
+                [
+                    'plugin' => 'Kanopi\Firewall\Plugins\Url',
+                    'response' => 'challenge',
+                    'weight' => 0,
+                    'enable' => true,
+                    'metadata' => ['default_expiration_time' => 600],
+                    'config' => ['path@starts_with:/protected'],
+                ],
+            ],
+        ], $filename);
+    }
+
+    /**
+     * Reach the provider the Firewall built from config.
+     */
+    private function recaptchaProvider(Firewall $firewall): RecaptchaChallengeProvider
+    {
+        $provider = (new \ReflectionProperty($firewall, 'challengeProvider'))->getValue($firewall);
+        $this->assertInstanceOf(RecaptchaChallengeProvider::class, $provider);
+
+        return $provider;
+    }
+
+    private function recaptchaSubmission(string $token, string $ip): Request
+    {
+        return $this->recaptchaPost(RecaptchaChallengeProvider::PAYLOAD_FIELD, $token, $ip);
+    }
+
+    private function recaptchaV3Submission(string $token, string $ip): Request
+    {
+        return $this->recaptchaPost(RecaptchaChallengeProvider::V3_PAYLOAD_FIELD, $token, $ip);
+    }
+
+    private function recaptchaPost(string $field, string $token, string $ip): Request
+    {
+        return Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [
+                $field => $token,
+                RecaptchaChallengeProvider::REDIRECT_FIELD => '/protected',
+                RecaptchaChallengeProvider::TTL_FIELD => '600',
             ],
             [],
             [],

--- a/tests/Unit/Challenge/ChallengeProviderFactoryTest.php
+++ b/tests/Unit/Challenge/ChallengeProviderFactoryTest.php
@@ -8,6 +8,7 @@ use Kanopi\Firewall\Challenge\AltchaChallengeProvider;
 use Kanopi\Firewall\Challenge\ChallengeProviderFactory;
 use Kanopi\Firewall\Challenge\ChallengeProviderInterface;
 use Kanopi\Firewall\Challenge\MathChallengeProvider;
+use Kanopi\Firewall\Challenge\RecaptchaChallengeProvider;
 use Kanopi\Firewall\Challenge\TokenManager;
 use Kanopi\Firewall\Challenge\TurnstileChallengeProvider;
 use Kanopi\Firewall\Exception\ConfigurationException;
@@ -106,6 +107,36 @@ final class ChallengeProviderFactoryTest extends AbstractTestCase
         $this->expectException(ConfigurationException::class);
 
         ChallengeProviderFactory::create('turnstile', new TokenManager('secret-value'));
+    }
+
+    public function testResolvesRecaptchaShortName(): void
+    {
+        $provider = ChallengeProviderFactory::create(
+            'recaptcha',
+            new TokenManager('secret-value'),
+            ['site_key' => 'site', 'secret_key' => 'secret']
+        );
+
+        $this->assertInstanceOf(RecaptchaChallengeProvider::class, $provider);
+        $this->assertSame('recaptcha', $provider->getName());
+    }
+
+    public function testRecaptchaVersionReachesTheProviderThroughOptions(): void
+    {
+        $provider = ChallengeProviderFactory::create(
+            'recaptcha',
+            new TokenManager('secret-value'),
+            ['site_key' => 'site', 'secret_key' => 'secret', 'version' => 'v3']
+        );
+
+        $this->assertSame('recaptcha-v3', $provider->getName());
+    }
+
+    public function testRecaptchaMisconfigurationSurfacesAtCreation(): void
+    {
+        $this->expectException(ConfigurationException::class);
+
+        ChallengeProviderFactory::create('recaptcha', new TokenManager('secret-value'));
     }
 
     public function testProvidersMayDeclineTheTokenManager(): void

--- a/tests/Unit/Challenge/RecaptchaChallengeProviderTest.php
+++ b/tests/Unit/Challenge/RecaptchaChallengeProviderTest.php
@@ -1,0 +1,1024 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Challenge;
+
+use Kanopi\Firewall\Challenge\RecaptchaChallengeProvider;
+use Kanopi\Firewall\Exception\ConfigurationException;
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Unit coverage for the Google reCAPTCHA provider.
+ *
+ * The network is the one thing these tests replace: `fetch()` is overridden
+ * with scripted results, and the response handling it delegates to is
+ * exercised directly through `interpretResponse()`. Nothing here reaches
+ * Google.
+ */
+final class RecaptchaChallengeProviderTest extends AbstractTestCase
+{
+    /**
+     * Google's documented always-passes v2 test pair.
+     */
+    private const SITE_KEY = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
+
+    private const SECRET_KEY = '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe';
+
+    // -------------------------------------------------------------------
+    // Construction
+    // -------------------------------------------------------------------
+
+    public function testGetNameReturnsRecaptchaOnV2(): void
+    {
+        $this->assertSame('recaptcha', $this->provider()->getName());
+    }
+
+    public function testGetNameIsVersionScopedOnV3(): void
+    {
+        // The name is what `challenge.audience` defaults to. A v3 pass is a
+        // weaker claim than a v2 one, so the two must not share an audience
+        // — otherwise a v3-earned token opens a v2-protected route.
+        $this->assertSame('recaptcha-v3', $this->provider(['version' => 'v3'])->getName());
+    }
+
+    public function testMissingSiteKeyFailsAtConstruction(): void
+    {
+        // A firewall that renders a keyless widget challenges every visitor
+        // with something none of them can pass, so this has to be loud.
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessageMatches('/site_key/');
+
+        new RecaptchaChallengeProvider(['secret_key' => self::SECRET_KEY]);
+    }
+
+    public function testMissingSecretKeyFailsAtConstruction(): void
+    {
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionMessageMatches('/secret_key/');
+
+        new RecaptchaChallengeProvider(['site_key' => self::SITE_KEY]);
+    }
+
+    public function testWhitespaceOnlyKeysAreTreatedAsMissing(): void
+    {
+        $this->expectException(ConfigurationException::class);
+
+        new RecaptchaChallengeProvider(['site_key' => '   ', 'secret_key' => self::SECRET_KEY]);
+    }
+
+    public function testNonScalarKeyIsTreatedAsMissing(): void
+    {
+        $this->expectException(ConfigurationException::class);
+
+        new RecaptchaChallengeProvider(['site_key' => ['nested'], 'secret_key' => self::SECRET_KEY]);
+    }
+
+    public function testUnknownVersionFallsBackToV2(): void
+    {
+        // v2 is the safe default: a visitor who fails can try again, which
+        // is not true of v3.
+        $this->assertSame('recaptcha', $this->provider(['version' => 'v9'])->getName());
+    }
+
+    public function testVersionIsCaseInsensitive(): void
+    {
+        $this->assertSame('recaptcha-v3', $this->provider(['version' => 'V3'])->getName());
+    }
+
+    // -------------------------------------------------------------------
+    // Endpoints and the payload field
+    // -------------------------------------------------------------------
+
+    public function testSiteverifyDefaultsToGoogle(): void
+    {
+        $this->assertSame(
+            RecaptchaChallengeProvider::GOOGLE_HOST . RecaptchaChallengeProvider::SITEVERIFY_PATH,
+            $this->provider()->getSiteverifyEndpoint()
+        );
+    }
+
+    public function testRecaptchaNetMovesBothTheWidgetAndSiteverify(): void
+    {
+        // Google's documented alternate domain, for networks where
+        // google.com is unreachable. Both halves have to move together — a
+        // widget the visitor can load is useless if this server cannot
+        // verify what it produces.
+        $provider = $this->provider(['use_recaptcha_net' => true]);
+
+        $this->assertStringStartsWith(
+            RecaptchaChallengeProvider::RECAPTCHA_NET_HOST,
+            $provider->getSiteverifyEndpoint()
+        );
+        $this->assertStringContainsString(
+            RecaptchaChallengeProvider::RECAPTCHA_NET_HOST . '/recaptcha/api.js',
+            $this->render($provider)
+        );
+    }
+
+    public function testRecaptchaNetOnlyAcceptsABooleanTrue(): void
+    {
+        // A truthy YAML string must not silently redirect verification to a
+        // different host.
+        $this->assertStringStartsWith(
+            RecaptchaChallengeProvider::GOOGLE_HOST,
+            $this->provider(['use_recaptcha_net' => 'yes'])->getSiteverifyEndpoint()
+        );
+    }
+
+    public function testPayloadFieldIsGooglesOnV2(): void
+    {
+        $this->assertSame(
+            RecaptchaChallengeProvider::PAYLOAD_FIELD,
+            $this->provider()->getPayloadField()
+        );
+    }
+
+    public function testPayloadFieldIsOurOwnOnV3(): void
+    {
+        // api.js injects hidden textareas named `g-recaptcha-response`. Two
+        // same-named fields make FormData carry both values, and which one
+        // wins is not something to stake a security check on.
+        $this->assertSame(
+            RecaptchaChallengeProvider::V3_PAYLOAD_FIELD,
+            $this->provider(['version' => 'v3'])->getPayloadField()
+        );
+        $this->assertNotSame(
+            RecaptchaChallengeProvider::PAYLOAD_FIELD,
+            RecaptchaChallengeProvider::V3_PAYLOAD_FIELD
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // Rendering — v2
+    // -------------------------------------------------------------------
+
+    public function testV2RenderProducesTheWidgetAndTheContractFields(): void
+    {
+        $html = $this->render($this->provider());
+
+        $this->assertStringContainsString('<form', $html);
+        $this->assertStringContainsString('action="/_firewall/challenge"', $html);
+        $this->assertStringContainsString('class="g-recaptcha"', $html);
+        $this->assertStringContainsString('data-sitekey="' . self::SITE_KEY . '"', $html);
+        $this->assertStringContainsString('/recaptcha/api.js', $html);
+        $this->assertStringContainsString(
+            'name="' . RecaptchaChallengeProvider::REDIRECT_FIELD . '"',
+            $html
+        );
+        $this->assertStringContainsString('name="' . RecaptchaChallengeProvider::TTL_FIELD . '"', $html);
+        $this->assertStringContainsString('value="/wanted-page"', $html);
+        $this->assertStringContainsString('value="900"', $html);
+    }
+
+    public function testV2RenderShipsTheSubmitButtonDisabled(): void
+    {
+        // Enabled only by the widget's success callback, so an empty token
+        // cannot be posted.
+        $this->assertMatchesRegularExpression(
+            '/<button[^>]*\sdisabled/',
+            $this->render($this->provider())
+        );
+    }
+
+    public function testV2CallbacksAreDeclaredBeforeTheWidgetBundleLoads(): void
+    {
+        // The bundle is async: it can finish and invoke the callback before
+        // a document-bottom script would have defined it, and a missing
+        // callback leaves the button disabled with no way forward.
+        $html = $this->render($this->provider());
+
+        $callback = strpos($html, 'window.fwRecaptchaVerified');
+        $bundle = strpos($html, '/recaptcha/api.js');
+
+        $this->assertIsInt($callback);
+        $this->assertIsInt($bundle);
+        $this->assertLessThan($bundle, $callback);
+    }
+
+    public function testV2WiresTheExpiryCallback(): void
+    {
+        // v2 tokens go stale about two minutes after the checkbox is
+        // ticked. Without this a visitor who reads the page first posts a
+        // token Google answers `timeout-or-duplicate` to.
+        $this->assertStringContainsString(
+            'data-expired-callback="fwRecaptchaReset"',
+            $this->render($this->provider())
+        );
+    }
+
+    public function testV2FailedSubmissionRecyclesTheWidget(): void
+    {
+        $this->assertStringContainsString(
+            'window.grecaptcha.reset()',
+            $this->render($this->provider())
+        );
+    }
+
+    public function testConfiguredThemeAndSizeAreRendered(): void
+    {
+        $html = $this->render($this->provider(['theme' => 'DARK', 'size' => 'Compact']));
+
+        $this->assertStringContainsString('data-theme="dark"', $html);
+        $this->assertStringContainsString('data-size="compact"', $html);
+    }
+
+    public function testUnknownThemeAndSizeFallBackToTheDefaults(): void
+    {
+        // reCAPTCHA has no `auto` theme, so an unknown value cannot be
+        // passed through and must resolve to something real.
+        $html = $this->render($this->provider(['theme' => 'auto', 'size' => 'invisible']));
+
+        $this->assertStringContainsString('data-theme="light"', $html);
+        $this->assertStringContainsString('data-size="normal"', $html);
+    }
+
+    public function testRenderEmitsNoIntegrityAttribute(): void
+    {
+        // Deliberate, and different from ALTCHA: api.js is unversioned and
+        // bootstraps further scripts, so a pinned digest would block the
+        // script the first time Google ships a change.
+        $this->assertStringNotContainsString('integrity=', $this->render($this->provider()));
+    }
+
+    public function testRenderEscapesTheSiteKeyIntoTheAttribute(): void
+    {
+        $provider = $this->provider(['site_key' => '6Le" onload="alert(1)']);
+
+        $html = $this->render($provider);
+
+        $this->assertStringNotContainsString('onload="alert(1)"', $html);
+        $this->assertStringContainsString('&quot;', $html);
+    }
+
+    public function testRenderEscapesContextValues(): void
+    {
+        $html = $this->render($this->provider(), '/"><script>alert(1)</script>');
+
+        $this->assertStringNotContainsString('<script>alert(1)</script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    // -------------------------------------------------------------------
+    // Rendering — v3
+    // -------------------------------------------------------------------
+
+    public function testV3RenderExecutesAndParksTheTokenInItsOwnField(): void
+    {
+        $html = $this->render($this->provider(['version' => 'v3']));
+
+        $this->assertStringContainsString(
+            'name="' . RecaptchaChallengeProvider::V3_PAYLOAD_FIELD . '"',
+            $html
+        );
+        $this->assertStringContainsString('window.grecaptcha.execute(', $html);
+        $this->assertStringNotContainsString('class="g-recaptcha"', $html);
+    }
+
+    public function testV3AppendsTheRenderParameterToTheBundle(): void
+    {
+        // grecaptcha.execute() only exists when api.js was loaded with
+        // render=<site key>.
+        $this->assertStringContainsString(
+            '/recaptcha/api.js?render=' . rawurlencode(self::SITE_KEY),
+            $this->render($this->provider(['version' => 'v3']))
+        );
+    }
+
+    public function testV3PollsForTheBundleRatherThanTrustingLoadOrder(): void
+    {
+        // api.js is async and bootstraps further scripts, and unlike v2
+        // there is no callback attribute to hang execution off.
+        $this->assertStringContainsString('window.setTimeout(fwRecaptchaExecute', $this->renderV3());
+    }
+
+    public function testV3RefreshesTheTokenBeforeItExpires(): void
+    {
+        // v3 tokens expire about two minutes after minting. A visitor who
+        // leaves the tab open would otherwise return to a token Google can
+        // only answer `timeout-or-duplicate` to.
+        $this->assertStringContainsString('window.setInterval(fwRecaptchaExecute, 90000)', $this->renderV3());
+    }
+
+    public function testV3EscapesTheSiteKeyForScriptContext(): void
+    {
+        // HTML entities are not decoded inside <script>, and a trailing
+        // backslash would escape the closing quote and kill the whole
+        // script — which on v3 is the only thing that enables the button.
+        $html = $this->render($this->provider([
+            'version' => 'v3',
+            'site_key' => 'key-with-a-trailing-backslash\\',
+        ]));
+
+        $this->assertStringContainsString('var fwSiteKey = "key-with-a-trailing-backslash\\\\"', $html);
+    }
+
+    public function testV3DisablesTheButtonBeforeMintingAReplacementToken(): void
+    {
+        // The refused attempt spent the token and minting is asynchronous,
+        // so leaving Continue live would let a second click re-post it.
+        $html = $this->renderV3();
+
+        $failure = strpos($html, 'submit.disabled = true;');
+        $refresh = strpos($html, 'window.fwRecaptchaRefresh();');
+
+        $this->assertIsInt($failure);
+        $this->assertIsInt($refresh);
+        $this->assertLessThan($refresh, $failure);
+    }
+
+    public function testV3RendersTheConfiguredAction(): void
+    {
+        $this->assertStringContainsString(
+            'var fwAction = "admin_area"',
+            $this->render($this->provider(['version' => 'v3', 'action' => 'admin_area']))
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // widget_src overrides
+    // -------------------------------------------------------------------
+
+    public function testCustomWidgetSrcIsHonouredOnV2(): void
+    {
+        $html = $this->render($this->provider(['widget_src' => '/assets/recaptcha.js']));
+
+        $this->assertStringContainsString('src="/assets/recaptcha.js"', $html);
+        $this->assertStringNotContainsString('www.google.com/recaptcha/api.js', $html);
+    }
+
+    /**
+     * Widget URLs and what the v3 render parameter should do to them.
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function widgetSrcProvider(): array
+    {
+        return [
+            'bare path gains a query string' => [
+                '/assets/recaptcha.js',
+                '/assets/recaptcha.js?render=' . self::SITE_KEY,
+            ],
+            'existing query string gains a parameter' => [
+                '/assets/recaptcha.js?v=2',
+                '/assets/recaptcha.js?v=2&amp;render=' . self::SITE_KEY,
+            ],
+            'an explicit render is left alone' => [
+                '/assets/recaptcha.js?render=someone-elses-key',
+                '/assets/recaptcha.js?render=someone-elses-key',
+            ],
+        ];
+    }
+
+    /**
+     * @param string $configured
+     *   The `widget_src` option as an operator would set it.
+     * @param string $expected
+     *   The src attribute the interstitial should carry, HTML-escaped.
+     */
+    #[DataProvider('widgetSrcProvider')]
+    public function testV3AddsTheRenderParameterToACustomWidgetSrc(
+        string $configured,
+        string $expected
+    ): void {
+        // Proxying the bundle should not require knowing that v3 needs the
+        // render parameter — but an operator who supplied one meant it.
+        $html = $this->render($this->provider([
+            'version' => 'v3',
+            'widget_src' => $configured,
+        ]));
+
+        $this->assertStringContainsString('src="' . $expected . '"', $html);
+    }
+
+    // -------------------------------------------------------------------
+    // Verification — shared
+    // -------------------------------------------------------------------
+
+    public function testMissingTokenIsRejectedWithoutAskingGoogle(): void
+    {
+        $provider = $this->scriptedProvider([]);
+
+        $this->assertFalse($provider->verifySolution($this->submission('')));
+        $this->assertSame(0, $provider->fetchCount, 'An absent token cannot be valid — do not spend a round trip.');
+    }
+
+    public function testOverlongTokenIsRejectedWithoutAskingGoogle(): void
+    {
+        $provider = $this->scriptedProvider([]);
+
+        $this->assertFalse($provider->verifySolution($this->submission(str_repeat('a', 8193))));
+        $this->assertSame(0, $provider->fetchCount);
+    }
+
+    public function testArrayTokenIsRejectedWithoutThrowing(): void
+    {
+        // `InputBag::get()` raises BadRequestException on a non-scalar, and
+        // verifySolution() is contractually forbidden from throwing, so
+        // `g-recaptcha-response[]=x` must be an ordinary rejection.
+        $provider = $this->scriptedProvider([]);
+
+        $request = Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [RecaptchaChallengeProvider::PAYLOAD_FIELD => ['nested']],
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.5']
+        );
+
+        $this->assertFalse($provider->verifySolution($request));
+        $this->assertSame(0, $provider->fetchCount);
+    }
+
+    public function testSuccessfulVerificationIsAccepted(): void
+    {
+        $provider = $this->scriptedProvider([self::verified()]);
+
+        $this->assertTrue($provider->verifySolution($this->submission('a-plausible-token')));
+        $this->assertSame(1, $provider->fetchCount);
+    }
+
+    public function testRejectedTokenIsRefused(): void
+    {
+        $provider = $this->scriptedProvider([self::refused(['invalid-input-response'])]);
+
+        $this->assertFalse($provider->verifySolution($this->submission('a-plausible-token')));
+    }
+
+    public function testReplayedTokenIsRefused(): void
+    {
+        // Replay protection lives at Google, which is why this provider
+        // needs no SingleUseSolutionInterface and touches no storage.
+        $provider = $this->scriptedProvider([self::refused(['timeout-or-duplicate'])]);
+
+        $this->assertFalse($provider->verifySolution($this->submission('a-replayed-token')));
+    }
+
+    public function testMisconfiguredSecretIsRefused(): void
+    {
+        $provider = $this->scriptedProvider([self::refused(['invalid-input-secret'])]);
+
+        $this->assertFalse($provider->verifySolution($this->submission('a-plausible-token')));
+    }
+
+    public function testUnreachableSiteverifyBlocksByDefault(): void
+    {
+        $provider = $this->scriptedProvider([self::unreachable()]);
+
+        $this->assertFalse(
+            $provider->verifySolution($this->submission('a-plausible-token')),
+            'Fail closed: a verdict that could not be obtained is not a pass.'
+        );
+    }
+
+    public function testUnreachableSiteverifyAllowsWhenExplicitlyConfigured(): void
+    {
+        $provider = $this->scriptedProvider([self::unreachable()], ['on_error' => 'allow']);
+
+        $this->assertTrue($provider->verifySolution($this->submission('a-plausible-token')));
+    }
+
+    public function testOnErrorOnlyAppliesToUnreachability(): void
+    {
+        // `allow` is about not locking visitors out during an outage. It
+        // must never turn a token Google actively rejected into a pass.
+        $provider = $this->scriptedProvider(
+            [self::refused(['invalid-input-response'])],
+            ['on_error' => 'allow']
+        );
+
+        $this->assertFalse($provider->verifySolution($this->submission('a-plausible-token')));
+    }
+
+    // -------------------------------------------------------------------
+    // Verification — v3 gates
+    // -------------------------------------------------------------------
+
+    public function testV3AcceptsAScoreAtOrAboveTheThreshold(): void
+    {
+        $provider = $this->scriptedProvider(
+            [self::scored(0.5, 'firewall')],
+            ['version' => 'v3']
+        );
+
+        $this->assertTrue($provider->verifySolution($this->v3Submission('a-plausible-token')));
+    }
+
+    public function testV3RefusesAScoreBelowTheThreshold(): void
+    {
+        $provider = $this->scriptedProvider(
+            [self::scored(0.4, 'firewall')],
+            ['version' => 'v3']
+        );
+
+        $this->assertFalse($provider->verifySolution($this->v3Submission('a-plausible-token')));
+    }
+
+    public function testV3HonoursACustomThreshold(): void
+    {
+        $provider = $this->scriptedProvider(
+            [self::scored(0.8, 'firewall')],
+            ['version' => 'v3', 'min_score' => 0.9]
+        );
+
+        $this->assertFalse($provider->verifySolution($this->v3Submission('a-plausible-token')));
+    }
+
+    public function testV3RefusesATokenMintedForAnotherAction(): void
+    {
+        // A v3 token is minted by the site key, not by a page. Without this
+        // check a token from any other reCAPTCHA call on the site — a
+        // newsletter box, a search field — would clear the firewall too.
+        $provider = $this->scriptedProvider(
+            [self::scored(0.9, 'newsletter_signup')],
+            ['version' => 'v3']
+        );
+
+        $this->assertFalse($provider->verifySolution($this->v3Submission('a-plausible-token')));
+    }
+
+    public function testV3RefusesAResponseCarryingNoScore(): void
+    {
+        // Means the configured keys are a v2 pair. Passing it would treat a
+        // "well-formed token" as "trustworthy visitor", which is the whole
+        // difference between the two versions.
+        $provider = $this->scriptedProvider([self::verified()], ['version' => 'v3']);
+
+        $this->assertFalse($provider->verifySolution($this->v3Submission('a-plausible-token')));
+    }
+
+    public function testV2IgnoresAScoreEntirely(): void
+    {
+        // A v2 yes is the whole answer; a stray score must not gate it.
+        $provider = $this->scriptedProvider([self::scored(0.0, 'something-else')]);
+
+        $this->assertTrue($provider->verifySolution($this->submission('a-plausible-token')));
+    }
+
+    public function testZeroScoreIsNotConfusedWithNoScore(): void
+    {
+        // 0.0 is the worst possible score and must not read as "absent".
+        $result = $this->provider(['version' => 'v3'])->exposedInterpret(200, (string) json_encode([
+            'success' => true,
+            'score' => 0.0,
+            'action' => 'firewall',
+        ]));
+
+        $this->assertSame(0.0, $result['score']);
+    }
+
+    // -------------------------------------------------------------------
+    // min_score and action normalisation
+    // -------------------------------------------------------------------
+
+    public function testMinScoreAboveOneIsClamped(): void
+    {
+        // `min_score: 50` is a plausible mistake from someone thinking in
+        // percentages, and an unclamped threshold above 1.0 would reject
+        // every visitor forever.
+        $provider = $this->scriptedProvider(
+            [self::scored(1.0, 'firewall')],
+            ['version' => 'v3', 'min_score' => 50]
+        );
+
+        $this->assertTrue($provider->verifySolution($this->v3Submission('a-plausible-token')));
+    }
+
+    public function testNegativeMinScoreIsClamped(): void
+    {
+        $provider = $this->scriptedProvider(
+            [self::scored(0.0, 'firewall')],
+            ['version' => 'v3', 'min_score' => -5]
+        );
+
+        $this->assertTrue($provider->verifySolution($this->v3Submission('a-plausible-token')));
+    }
+
+    public function testNonNumericMinScoreFallsBackToTheDefault(): void
+    {
+        $provider = $this->scriptedProvider(
+            [self::scored(0.4, 'firewall')],
+            ['version' => 'v3', 'min_score' => 'strict']
+        );
+
+        $this->assertFalse($provider->verifySolution($this->v3Submission('a-plausible-token')));
+    }
+
+    public function testActionIsFilteredToWhatGoogleWillEchoBack(): void
+    {
+        // Google drops anything outside alphanumerics, slashes and
+        // underscores server-side. Filtering here means the value compared
+        // against is the value that will come back — otherwise a stray
+        // character fails every verification as an action mismatch.
+        $provider = $this->scriptedProvider(
+            [self::scored(0.9, 'adminarea')],
+            ['version' => 'v3', 'action' => 'admin area!']
+        );
+
+        $this->assertTrue($provider->verifySolution($this->v3Submission('a-plausible-token')));
+    }
+
+    public function testActionThatFiltersToNothingFallsBackToTheDefault(): void
+    {
+        $provider = $this->scriptedProvider(
+            [self::scored(0.9, RecaptchaChallengeProvider::DEFAULT_ACTION)],
+            ['version' => 'v3', 'action' => '!!!']
+        );
+
+        $this->assertTrue($provider->verifySolution($this->v3Submission('a-plausible-token')));
+    }
+
+    public function testNonScalarActionFallsBackToTheDefault(): void
+    {
+        $provider = $this->scriptedProvider(
+            [self::scored(0.9, RecaptchaChallengeProvider::DEFAULT_ACTION)],
+            ['version' => 'v3', 'action' => ['nested']]
+        );
+
+        $this->assertTrue($provider->verifySolution($this->v3Submission('a-plausible-token')));
+    }
+
+    // -------------------------------------------------------------------
+    // The request body
+    // -------------------------------------------------------------------
+
+    public function testClientIpIsWithheldByDefault(): void
+    {
+        // Behind an unconfigured proxy `getClientIp()` returns whatever
+        // X-Forwarded-For claimed, so sending it can fail verification for
+        // legitimate visitors. Opt-in only.
+        $body = $this->provider()->exposedRequestBody('a-token', $this->submission('a-token'));
+
+        $this->assertStringContainsString('response=a-token', $body);
+        $this->assertStringNotContainsString('remoteip', $body);
+    }
+
+    public function testClientIpIsSentWhenOptedIn(): void
+    {
+        $body = $this->provider(['send_remoteip' => true])
+            ->exposedRequestBody('a-token', $this->submission('a-token'));
+
+        $this->assertStringContainsString('remoteip=10.0.0.5', $body);
+    }
+
+    public function testSendRemoteIpOnlyAcceptsABooleanTrue(): void
+    {
+        // A truthy YAML string must not silently enable it.
+        $body = $this->provider(['send_remoteip' => 'yes'])
+            ->exposedRequestBody('a-token', $this->submission('a-token'));
+
+        $this->assertStringNotContainsString('remoteip', $body);
+    }
+
+    public function testSecretKeyIsSentToGoogleButNeverRendered(): void
+    {
+        $provider = $this->provider();
+
+        $this->assertStringContainsString(
+            'secret=' . urlencode(self::SECRET_KEY),
+            $provider->exposedRequestBody('a-token', $this->submission('a-token'))
+        );
+        $this->assertStringNotContainsString(self::SECRET_KEY, $this->render($provider));
+    }
+
+    public function testSecretKeyIsNeverRenderedOnV3Either(): void
+    {
+        $provider = $this->provider(['version' => 'v3']);
+
+        $this->assertStringNotContainsString(self::SECRET_KEY, $this->render($provider));
+    }
+
+    // -------------------------------------------------------------------
+    // Response interpretation
+    // -------------------------------------------------------------------
+
+    public function testSuccessResponseIsInterpretedAsVerified(): void
+    {
+        $result = $this->provider()->exposedInterpret(200, (string) json_encode([
+            'success' => true,
+            'challenge_ts' => '2026-08-04T00:00:00Z',
+            'hostname' => 'example.com',
+        ]));
+
+        $this->assertTrue($result['verified']);
+        $this->assertNull($result['transport_error']);
+        $this->assertNull($result['score'], 'v2 responses carry no score.');
+        $this->assertNull($result['action']);
+    }
+
+    public function testScoreAndActionAreCarriedThrough(): void
+    {
+        $result = $this->provider(['version' => 'v3'])->exposedInterpret(200, (string) json_encode([
+            'success' => true,
+            'score' => 0.7,
+            'action' => 'firewall',
+        ]));
+
+        $this->assertSame(0.7, $result['score']);
+        $this->assertSame('firewall', $result['action']);
+    }
+
+    public function testMalformedScoreAndActionAreNotTrusted(): void
+    {
+        $result = $this->provider(['version' => 'v3'])->exposedInterpret(200, (string) json_encode([
+            'success' => true,
+            'score' => ['nested'],
+            'action' => 42,
+        ]));
+
+        $this->assertNull($result['score']);
+        $this->assertNull($result['action']);
+    }
+
+    public function testFailureResponseCarriesItsErrorCodes(): void
+    {
+        $result = $this->provider()->exposedInterpret(200, (string) json_encode([
+            'success' => false,
+            'error-codes' => ['invalid-input-response'],
+        ]));
+
+        $this->assertFalse($result['verified']);
+        $this->assertNull($result['transport_error'], 'A rejection is a verdict, not a transport failure.');
+        $this->assertSame(['invalid-input-response'], $result['error_codes']);
+    }
+
+    /**
+     * Responses that mean "no verdict available".
+     *
+     * @return array<string, array{0: int|null, 1: string|false}>
+     */
+    public static function noVerdictProvider(): array
+    {
+        return [
+            'server error' => [500, '{"success":true}'],
+            'gateway timeout' => [504, ''],
+            'unparseable status' => [null, '{"success":true}'],
+            'empty body' => [200, ''],
+            'read failure' => [200, false],
+            'not json' => [200, 'definitely not json'],
+            'json but not an object' => [200, '"a string"'],
+            'object without success' => [200, '{"error-codes":["bad-request"]}'],
+        ];
+    }
+
+    /**
+     * @param int|null $status
+     *   HTTP status to interpret.
+     * @param string|false $body
+     *   Body to interpret.
+     */
+    #[DataProvider('noVerdictProvider')]
+    public function testResponsesWithoutAVerdictAreTransportFailures(?int $status, string|false $body): void
+    {
+        $result = $this->provider()->exposedInterpret($status, $body);
+
+        $this->assertFalse($result['verified']);
+        $this->assertNotNull($result['transport_error']);
+    }
+
+    public function testSuccessOutsideAJsonBooleanIsNotAPass(): void
+    {
+        // A truthy-but-not-true value must not be read as verified.
+        $result = $this->provider()->exposedInterpret(200, '{"success":"true"}');
+
+        $this->assertFalse($result['verified']);
+        $this->assertNull($result['transport_error']);
+    }
+
+    public function testMalformedErrorCodesAreNormalisedRatherThanTrusted(): void
+    {
+        $result = $this->provider()->exposedInterpret(200, (string) json_encode([
+            'success' => false,
+            'error-codes' => ['invalid-input-response', 42, ['nested'], null],
+        ]));
+
+        $this->assertSame(['invalid-input-response'], $result['error_codes']);
+    }
+
+    public function testNonArrayErrorCodesAreIgnored(): void
+    {
+        $result = $this->provider()->exposedInterpret(200, '{"success":false,"error-codes":"oops"}');
+
+        $this->assertSame([], $result['error_codes']);
+    }
+
+    public function testStatusIsReadFromTheLastStatusLine(): void
+    {
+        // A redirect chain leaves several; the last one answered.
+        $this->assertSame(200, $this->provider()->exposedStatus([
+            'HTTP/1.1 301 Moved Permanently',
+            'Location: https://example.com/',
+            'HTTP/1.1 200 OK',
+        ]));
+    }
+
+    public function testStatusIsNullWhenNoStatusLineIsPresent(): void
+    {
+        $this->assertNull($this->provider()->exposedStatus(['Content-Type: application/json']));
+    }
+
+    // -------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------
+
+    /**
+     * A provider with the protected seams exposed for assertions.
+     *
+     * @param array<string, mixed> $options
+     *   Options merged over valid defaults.
+     */
+    private function provider(array $options = []): RecaptchaChallengeProvider
+    {
+        $options += ['site_key' => self::SITE_KEY, 'secret_key' => self::SECRET_KEY];
+
+        return new class ($options) extends RecaptchaChallengeProvider {
+            /**
+             * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null, score: float|null, action: string|null}
+             */
+            public function exposedInterpret(?int $status, string|false $body): array
+            {
+                return $this->interpretResponse($status, $body);
+            }
+
+            public function exposedRequestBody(string $token, Request $request): string
+            {
+                return $this->buildRequestBody($token, $request);
+            }
+
+            /**
+             * @param array<int, string> $headers
+             */
+            public function exposedStatus(array $headers): ?int
+            {
+                return $this->statusFromHeaders($headers);
+            }
+        };
+    }
+
+    /**
+     * A provider with the network replaced by scripted results.
+     *
+     * @param array<int, array{verified: bool, error_codes: array<int, string>, transport_error: string|null, score: float|null, action: string|null}> $results
+     *   Results to return from successive fetch() calls, in order.
+     * @param array<string, mixed> $options
+     *   Options merged over valid defaults.
+     */
+    private function scriptedProvider(array $results, array $options = []): RecaptchaChallengeProvider
+    {
+        $options += ['site_key' => self::SITE_KEY, 'secret_key' => self::SECRET_KEY];
+
+        return new class ($options, $results) extends RecaptchaChallengeProvider {
+            /**
+             * How many times siteverify would have been called.
+             */
+            public int $fetchCount = 0;
+
+            /**
+             * Remaining scripted results.
+             *
+             * @var array<int, array{verified: bool, error_codes: array<int, string>, transport_error: string|null, score: float|null, action: string|null}>
+             */
+            private array $scripted;
+
+            /**
+             * @param array<string, mixed> $options
+             *   Provider options.
+             * @param array<int, array{verified: bool, error_codes: array<int, string>, transport_error: string|null, score: float|null, action: string|null}> $scripted
+             *   Scripted fetch results.
+             */
+            public function __construct(array $options, array $scripted)
+            {
+                parent::__construct($options);
+                $this->scripted = $scripted;
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            protected function fetch(string $token, Request $request): array
+            {
+                $this->fetchCount++;
+
+                $next = array_shift($this->scripted);
+
+                return $next ?? [
+                    'verified' => false,
+                    'error_codes' => [],
+                    'transport_error' => 'the test scripted no further results',
+                    'score' => null,
+                    'action' => null,
+                ];
+            }
+        };
+    }
+
+    /**
+     * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null, score: float|null, action: string|null}
+     */
+    private static function verified(): array
+    {
+        return [
+            'verified' => true,
+            'error_codes' => [],
+            'transport_error' => null,
+            'score' => null,
+            'action' => null,
+        ];
+    }
+
+    /**
+     * A v3 response Google said yes to, carrying a score and an action.
+     *
+     * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null, score: float|null, action: string|null}
+     */
+    private static function scored(float $score, string $action): array
+    {
+        return [
+            'verified' => true,
+            'error_codes' => [],
+            'transport_error' => null,
+            'score' => $score,
+            'action' => $action,
+        ];
+    }
+
+    /**
+     * @param array<int, string> $codes
+     *   Error codes Google returned.
+     *
+     * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null, score: float|null, action: string|null}
+     */
+    private static function refused(array $codes): array
+    {
+        return [
+            'verified' => false,
+            'error_codes' => $codes,
+            'transport_error' => null,
+            'score' => null,
+            'action' => null,
+        ];
+    }
+
+    /**
+     * @return array{verified: bool, error_codes: array<int, string>, transport_error: string|null, score: float|null, action: string|null}
+     */
+    private static function unreachable(): array
+    {
+        return [
+            'verified' => false,
+            'error_codes' => [],
+            'transport_error' => 'could not reach the reCAPTCHA siteverify API',
+            'score' => null,
+            'action' => null,
+        ];
+    }
+
+    /**
+     * Render an interstitial with a stock context.
+     */
+    private function render(
+        RecaptchaChallengeProvider $provider,
+        string $redirectTo = '/wanted-page'
+    ): string {
+        return $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => $redirectTo,
+            'ttl' => '900',
+            'cookie_name' => 'fw_pass',
+            'header_name' => 'X-FW',
+        ]);
+    }
+
+    /**
+     * A stock v3 interstitial.
+     */
+    private function renderV3(): string
+    {
+        return $this->render($this->provider(['version' => 'v3']));
+    }
+
+    private function submission(string $token): Request
+    {
+        return $this->post(RecaptchaChallengeProvider::PAYLOAD_FIELD, $token);
+    }
+
+    private function v3Submission(string $token): Request
+    {
+        return $this->post(RecaptchaChallengeProvider::V3_PAYLOAD_FIELD, $token);
+    }
+
+    private function post(string $field, string $token): Request
+    {
+        return Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [$field => $token],
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.5']
+        );
+    }
+}

--- a/tests/Unit/Challenge/RecaptchaTransportTest.php
+++ b/tests/Unit/Challenge/RecaptchaTransportTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanopi\Firewall\Tests\Unit\Challenge;
+
+require_once __DIR__ . '/../../Traits/ChallengeNamespaceOverrides.php';
+
+use Kanopi\Firewall\Challenge\RecaptchaChallengeProvider;
+use Kanopi\Firewall\Logging\LoggingFactory;
+use Kanopi\Firewall\Tests\Logging\TestLogHandler;
+use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
+use Monolog\Level;
+use Monolog\Logger;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * The reCAPTCHA siteverify transport, with the stream wrapper shimmed.
+ *
+ * `RecaptchaChallengeProviderTest` and the integration suite both substitute
+ * `fetch()` so the provider's decision logic can be tested without a network.
+ * That is the right split, but it leaves the transport itself unexercised —
+ * the unreachable endpoint, and reading back a response whose headers carry
+ * no status line — and those are exactly the paths that decide whether a
+ * Google outage locks every challenged route or waves everyone through.
+ *
+ * Reaching them against the live endpoint would need a real secret key in CI
+ * and Google failing on demand, so the stream wrapper is shimmed instead.
+ * The shim is the one `TurnstileTransportTest` uses: it is scoped to the
+ * `Kanopi\Firewall\Challenge` namespace, so it intercepts both providers.
+ * See tests/Traits/ChallengeNamespaceOverrides.php.
+ */
+final class RecaptchaTransportTest extends AbstractTestCase
+{
+    private const SITE_KEY = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
+
+    private const SECRET_KEY = '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        // These are process-global. A leaked flag would feed a canned HTTP
+        // response to every later test in the run.
+        $GLOBALS['fake_challenge_http_response'] = null;
+        $GLOBALS['fake_challenge_http_handles'] = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * A genuine v2 token verified over the real transport.
+     */
+    public function testVerifiedTokenPassesThroughTheTransport(): void
+    {
+        $this->fakeResponse(200, (string) json_encode(['success' => true]));
+
+        $this->assertTrue($this->provider()->verifySolution($this->submission()));
+    }
+
+    /**
+     * A v3 score read back off the wire, not just out of a stub.
+     */
+    public function testScoreSurvivesTheTransportOnV3(): void
+    {
+        $this->fakeResponse(200, (string) json_encode([
+            'success' => true,
+            'score' => 0.9,
+            'action' => 'firewall',
+        ]));
+
+        $this->assertTrue(
+            $this->provider(['version' => 'v3'])->verifySolution($this->v3Submission())
+        );
+    }
+
+    /**
+     * A low score is refused after a completely successful round trip.
+     */
+    public function testLowScoreIsRefusedThroughTheTransport(): void
+    {
+        $this->fakeResponse(200, (string) json_encode([
+            'success' => true,
+            'score' => 0.1,
+            'action' => 'firewall',
+        ]));
+
+        $handler = $this->captureLogs();
+
+        $this->assertFalse(
+            $this->provider(['version' => 'v3'])->verifySolution($this->v3Submission())
+        );
+        $this->assertFalse(
+            $handler->hasErrorContaining('could not be completed'),
+            'Google answered — a score below the threshold is a decision, not an outage.',
+        );
+    }
+
+    /**
+     * Google's rejection is read back as a plain failure.
+     */
+    public function testRejectedTokenFailsThroughTheTransport(): void
+    {
+        $this->fakeResponse(200, (string) json_encode([
+            'success' => false,
+            'error-codes' => ['timeout-or-duplicate'],
+        ]));
+
+        $handler = $this->captureLogs();
+
+        $this->assertFalse($this->provider()->verifySolution($this->submission()));
+        $this->assertFalse(
+            $handler->hasErrorContaining('could not be completed'),
+            'A token Google answered about is a verdict, not a transport failure.',
+        );
+    }
+
+    /**
+     * An unreachable siteverify endpoint blocks by default.
+     *
+     * Fail-closed is the deliberate choice here: an attacker who can disrupt
+     * siteverify would otherwise get a bypass for every challenged route on
+     * demand.
+     */
+    public function testUnreachableEndpointBlocksByDefault(): void
+    {
+        $GLOBALS['fake_challenge_http_response'] = false;
+
+        $handler = $this->captureLogs();
+
+        $this->assertFalse($this->provider()->verifySolution($this->submission()));
+        $this->assertTrue(
+            $handler->hasErrorContaining('reCAPTCHA verification could not be completed'),
+            'Locking visitors out has to be stated in the log, not inferred from a failed solve.',
+        );
+    }
+
+    /**
+     * The same outage lets visitors through under `on_error: allow`.
+     */
+    public function testUnreachableEndpointAllowsWhenConfiguredTo(): void
+    {
+        $GLOBALS['fake_challenge_http_response'] = false;
+
+        $this->assertTrue(
+            $this->provider(['on_error' => 'allow'])->verifySolution($this->submission())
+        );
+    }
+
+    /**
+     * A response the wrapper reported no headers for is a transport failure.
+     *
+     * Without `wrapper_data` there is no status line to read, so the body
+     * cannot be trusted as a verdict however well-formed it looks — treating
+     * it as one would turn a broken proxy into a free pass.
+     */
+    public function testResponseWithoutWrapperHeadersIsATransportFailure(): void
+    {
+        $GLOBALS['fake_challenge_http_response'] = [
+            'body' => (string) json_encode(['success' => true]),
+        ];
+
+        $handler = $this->captureLogs();
+
+        $this->assertFalse($this->provider()->verifySolution($this->submission()));
+        $this->assertStringContainsString('unreadable status', $this->loggedTransportError($handler));
+    }
+
+    /**
+     * A non-200 from siteverify is an outage, not a failed visitor.
+     */
+    public function testServerErrorFromSiteverifyIsATransportFailure(): void
+    {
+        $this->fakeResponse(503, '');
+
+        $handler = $this->captureLogs();
+
+        $this->assertFalse($this->provider()->verifySolution($this->submission()));
+        $this->assertStringContainsString('returned HTTP 503', $this->loggedTransportError($handler));
+    }
+
+    /**
+     * With `send_remoteip` on, the client IP reaches the wire.
+     *
+     * `buildRequestBody()` is unit-tested directly, but only the transport
+     * proves the body it builds is what gets sent — an opt-in that never
+     * left the process would look identical from the outside.
+     */
+    public function testRemoteIpOptInReachesTheRequestBody(): void
+    {
+        $this->fakeResponse(200, (string) json_encode(['success' => true]));
+
+        $options = [
+            'site_key' => self::SITE_KEY,
+            'secret_key' => self::SECRET_KEY,
+            'send_remoteip' => true,
+        ];
+
+        $provider = new class ($options) extends RecaptchaChallengeProvider {
+            public string $sent = '';
+
+            /**
+             * {@inheritdoc}
+             */
+            protected function buildRequestBody(string $token, Request $request): string
+            {
+                return $this->sent = parent::buildRequestBody($token, $request);
+            }
+        };
+
+        $this->assertTrue($provider->verifySolution($this->submission()));
+        $this->assertStringContainsString('remoteip=203.0.113.45', $provider->sent);
+    }
+
+    /**
+     * Install a canned HTTP response with a conventional status line.
+     */
+    private function fakeResponse(int $status, string $body): void
+    {
+        $GLOBALS['fake_challenge_http_response'] = [
+            'headers' => ['HTTP/1.1 ' . $status . ' ' . ($status === 200 ? 'OK' : 'Error')],
+            'body' => $body,
+        ];
+    }
+
+    /**
+     * The reason recorded alongside a transport failure.
+     *
+     * `verifySolution()` logs one message for every unreachable verdict and
+     * puts the specific reason in the context, so asserting on the message
+     * alone cannot tell a 503 apart from a DNS failure — which is the whole
+     * point of recording it.
+     */
+    private function loggedTransportError(TestLogHandler $handler): string
+    {
+        foreach ($handler->records as $record) {
+            if (str_contains((string) $record->message, 'could not be completed')) {
+                return (string) ($record->context['error'] ?? '');
+            }
+        }
+
+        return '';
+    }
+
+    private function captureLogs(): TestLogHandler
+    {
+        $handler = new TestLogHandler(Level::Debug);
+        LoggingFactory::setLogger(new Logger('test', [$handler]));
+
+        return $handler;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *   Provider options; the keys are filled in.
+     */
+    private function provider(array $options = []): RecaptchaChallengeProvider
+    {
+        $options['site_key'] ??= self::SITE_KEY;
+        $options['secret_key'] ??= self::SECRET_KEY;
+
+        return new RecaptchaChallengeProvider($options);
+    }
+
+    /**
+     * A v2 POST carrying a plausible widget token.
+     */
+    private function submission(string $ip = '203.0.113.45'): Request
+    {
+        return $this->post(RecaptchaChallengeProvider::PAYLOAD_FIELD, $ip);
+    }
+
+    /**
+     * A v3 POST carrying a plausible executed token.
+     */
+    private function v3Submission(string $ip = '203.0.113.45'): Request
+    {
+        return $this->post(RecaptchaChallengeProvider::V3_PAYLOAD_FIELD, $ip);
+    }
+
+    private function post(string $field, string $ip): Request
+    {
+        return Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [$field => str_repeat('t', 64)],
+            [],
+            [],
+            ['REMOTE_ADDR' => $ip]
+        );
+    }
+}


### PR DESCRIPTION
## Description
- [x] Was AI used in this pull request?

`challenge.provider: recaptcha` now renders a reCAPTCHA widget and verifies its token against Google's siteverify API, joining `math`, `altcha` and `turnstile` as a built-in. Previously the docs pointed operators at `ChallengeProviderInterface` and left server-side verification, escaping, token expiry and CSP to each of them individually.

It shares its shape with `TurnstileChallengeProvider` — an opaque third-party token, one server-to-server round trip on the challenge POST, no local verification possible — and reuses the same stream-wrapper transport, so the dependency surface is unchanged. It differs in the two places reCAPTCHA genuinely differs: two incompatible versions, and one of them returns a score rather than a verdict.

## Related Issue

Fixes #134

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Changes Made

- `src/Challenge/RecaptchaChallengeProvider.php` — new provider, v2 checkbox (default) and v3 score modes.
- `ChallengeProviderFactory` — registers the `recaptcha` short name. The provider declines the `TokenManager` (it has no state of its own to sign), which the existing type-matched instantiation already supports.
- Docs: `docs/plugins/challenges.md` (options table, version guidance, CSP, audience caveat), `example/config.notes.yml`, `config/config.yml`, `docs/guides/demo.md`.
- Demo: `/secure-recaptcha` route + `example/demo/config.recaptcha.yml`, using Google's published v2 test keys. Also corrects `example/demo/README.md`, which still described two built-in providers.
- Tests: unit, transport (stream wrapper shimmed via the existing `ChallengeNamespaceOverrides`), factory, and integration.

## Decisions worth reviewing

**v2 is the default.** v3 never asks the visitor for anything, which sounds strictly better and is not: `success: true` on v3 only means the token was well-formed and unspent, and the accept/reject is the configured `min_score`. A human below the threshold has no puzzle to solve and no retry that helps. Documented as a lockout risk rather than presented as the upgrade.

**v3 binds the `action`.** A v3 token is minted by the site key, not by a page, so without this a token from any other reCAPTCHA v3 call on the site — a search box, a newsletter signup — would satisfy the firewall challenge. The configured value is filtered the way Google filters it, so the comparison is against what will actually come back.

**v3 reads its own form field**, not `g-recaptcha-response`. api.js injects hidden textareas under that name; two same-named fields make `FormData` carry both values, and which one `get()` returns is not something to stake a security check on.

**A scoreless v3 response is refused, not passed.** That is the signature of v2 keys configured as v3, and treating "well-formed token" as "trustworthy visitor" would erase the difference between the versions. Logged at `error` with a hint, since only an operator can fix it.

**Fail closed on an unreachable siteverify**, as Turnstile does; `on_error: allow` opts out. **`send_remoteip` defaults off**, for the same proxy-trust reason. **No retryable error code** — Google documents none, unlike Cloudflare's `internal-error`, so any well-formed `success: false` is a verdict. **No `SingleUseSolutionInterface`** — Google answers `timeout-or-duplicate` to a replayed or aged-out token, so solutions are single-use at the source.

**`use_recaptcha_net` is a boolean, not a free-form endpoint option.** Google documents the alternate domain for networks where google.com is blocked, and it has to move the widget and siteverify together — but an operator-supplied verification URL would be an inviting place to point a firewall at something that always says yes.

Token expiry (~2 minutes, both versions) is handled in the interstitial since the server never sees that window: v2 wires `data-expired-callback`; v3 re-executes on an interval and after a refused submission, disabling the button first so a second click cannot re-post the spent token.

## One limitation documented rather than fixed

`Firewall::createChallengePieces()` builds the `aud` claim from the `challenge.provider` config string — necessarily, since the `TokenManager` is constructed and handed to the factory before any provider exists. So v2 and v3 instances both configured as `recaptcha` share an audience and will honour each other's pass tokens, and a v3 pass is the weaker claim. Deployments running both against one `challenge.secret` need an explicit `challenge.audience`.

Two integration tests pin both halves: `testExplicitAudienceKeepsAV3PassOutOfAV2Route` and `testWithoutAnExplicitAudienceAV3PassOpensAV2Route`, so the sharp edge stays known rather than becoming a surprise.

Deriving the audience from `getName()` would fix this automatically, but it would change the claim for every FQCN-configured provider — a one-time re-challenge for existing deployments — so it felt like a separate decision rather than something to fold in here. Happy to do it in this PR if you'd rather.

`getName()` is version-scoped (`recaptcha` / `recaptcha-v3`) for the **logs only** — telling a score-threshold refusal apart from Google's own is most of diagnosing a challenge nobody can pass. Its docblock says explicitly that it does not scope tokens.

## Testing

### How to Test

1. `composer demo` and visit <http://localhost:8000/secure-recaptcha> — the v2 checkbox renders with Google's testing warning, and solving it mints a 60s pass cookie. Needs outbound network access.
2. `composer test` — 1349 tests green.
3. `composer check` — PHPCS, PHPStan (level max) and Rector all clean.
4. `composer test:gate` — `RecaptchaChallengeProvider.php` is at 100% line (217/217) and method (20/20) coverage. Repo-wide coverage is unchanged at 98.82%; the 49 uncovered lines are `RedisRateLimitStorage`, skipped locally without `ext-redis` and covered in CI.

The generated interstitial JavaScript for both versions was also syntax-checked with `node --check` — which is what caught v3 leaving the submit button live with a spent token during the async re-mint.

### Test Configuration

```yaml
challenge:
  provider: recaptcha
  secret: '%env(FIREWALL_CHALLENGE_SECRET)%'
  provider_options:
    # Google's published v2 test pair — always passes.
    site_key: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
    secret_key: '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe'

plugins:
  - plugin: "Kanopi\\Firewall\\Plugins\\Url"
    response: challenge
    weight: 0
    enable: true
    metadata:
      default_expiration_time: 60
    config:
      - "path@starts_with:/secure-recaptcha"
```

For v3 (needs a real v3 key pair — Google publishes no v3 test keys):

```yaml
challenge:
  provider: recaptcha
  secret: '%env(FIREWALL_CHALLENGE_SECRET)%'
  audience: recaptcha-v3        # see the limitation above
  provider_options:
    version: v3
    site_key: '%env(RECAPTCHA_V3_SITE_KEY)%'
    secret_key: '%env(RECAPTCHA_V3_SECRET_KEY)%'
    min_score: 0.5
```

## Checklist

### Code Quality

- [x] My code follows the project's code style (`composer cs` passes)
- [x] Static analysis passes (`composer stan` passes)
- [x] I have added appropriate code comments explaining complex logic
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)