### PR TITLE
Reject array-valued challenge fields instead of throwing (Fixes #130)

### DIFF
--- a/src/Challenge/AltchaChallengeProvider.php
+++ b/src/Challenge/AltchaChallengeProvider.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Kanopi\Firewall\Challenge;
 
+use Kanopi\Firewall\Traits\RequestFieldTrait;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -50,6 +51,8 @@ use Symfony\Component\HttpFoundation\Request;
  */
 final class AltchaChallengeProvider implements ChallengeProviderInterface, SingleUseSolutionInterface
 {
+    use RequestFieldTrait;
+
     /**
      * Form field that carries the base64-encoded solution payload posted
      * back from the widget. Name is fixed by the ALTCHA widget itself.
@@ -239,7 +242,9 @@ SCRIPT,
      */
     private function validate(Request $request): ?array
     {
-        $encoded = trim((string) $request->request->get(self::PAYLOAD_FIELD, ''));
+        // Read through the raw bag: an array-valued `altcha` field would make
+        // InputBag::get() throw, and neither caller may (#130).
+        $encoded = $this->postedString($request, self::PAYLOAD_FIELD);
         if ($encoded === '') {
             return null;
         }

--- a/src/Challenge/MathChallengeProvider.php
+++ b/src/Challenge/MathChallengeProvider.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Kanopi\Firewall\Challenge;
 
+use Kanopi\Firewall\Traits\RequestFieldTrait;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -38,6 +39,8 @@ use Symfony\Component\HttpFoundation\Request;
  */
 final class MathChallengeProvider implements ChallengeProviderInterface
 {
+    use RequestFieldTrait;
+
     /**
      * Form field that carries the signed `answer|exp.signature` payload
      * from render → verify.
@@ -125,8 +128,10 @@ FIELDS,
      */
     public function verifySolution(Request $request): bool
     {
-        $state = (string) $request->request->get(self::STATE_FIELD, '');
-        $answer = trim((string) $request->request->get(self::ANSWER_FIELD, ''));
+        // Read through the raw bag: an array-valued field would make
+        // InputBag::get() throw, and this method may not (#130).
+        $state = $this->postedString($request, self::STATE_FIELD, false);
+        $answer = $this->postedString($request, self::ANSWER_FIELD);
 
         if ($state === '' || $answer === '' || substr_count($state, '.') !== 1) {
             return false;

--- a/src/Challenge/RecaptchaChallengeProvider.php
+++ b/src/Challenge/RecaptchaChallengeProvider.php
@@ -13,6 +13,7 @@ namespace Kanopi\Firewall\Challenge;
 
 use Kanopi\Firewall\Exception\ConfigurationException;
 use Kanopi\Firewall\Logging\LoggingFactory;
+use Kanopi\Firewall\Traits\RequestFieldTrait;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -90,6 +91,8 @@ use Symfony\Component\HttpFoundation\Request;
  */
 final class RecaptchaChallengeProvider implements ChallengeProviderInterface
 {
+    use RequestFieldTrait;
+
     /**
      * Form field carrying a v2 widget's token.
      *
@@ -901,9 +904,7 @@ FAILURE,
      */
     private function postedToken(Request $request): string
     {
-        $raw = $request->request->all()[$this->getPayloadField()] ?? '';
-
-        return is_string($raw) ? trim($raw) : '';
+        return $this->postedString($request, $this->getPayloadField());
     }
 
     /**

--- a/src/Challenge/TurnstileChallengeProvider.php
+++ b/src/Challenge/TurnstileChallengeProvider.php
@@ -13,6 +13,7 @@ namespace Kanopi\Firewall\Challenge;
 
 use Kanopi\Firewall\Exception\ConfigurationException;
 use Kanopi\Firewall\Logging\LoggingFactory;
+use Kanopi\Firewall\Traits\RequestFieldTrait;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -61,6 +62,8 @@ use Symfony\Component\HttpFoundation\Request;
  */
 final class TurnstileChallengeProvider implements ChallengeProviderInterface
 {
+    use RequestFieldTrait;
+
     /**
      * Form field carrying the widget's token.
      *
@@ -498,9 +501,7 @@ FAILURE,
      */
     private function postedToken(Request $request): string
     {
-        $raw = $request->request->all()[self::PAYLOAD_FIELD] ?? '';
-
-        return is_string($raw) ? trim($raw) : '';
+        return $this->postedString($request, self::PAYLOAD_FIELD);
     }
 
     /**

--- a/src/Firewall.php
+++ b/src/Firewall.php
@@ -25,6 +25,7 @@ use Kanopi\Firewall\Plugins\PluginInterface;
 use Kanopi\Firewall\Plugins\PluginManager;
 use Kanopi\Firewall\Storage\StorageFactory;
 use Kanopi\Firewall\Storage\StorageInterface;
+use Kanopi\Firewall\Traits\RequestFieldTrait;
 use Kanopi\Firewall\Utility\Config;
 use Kanopi\Firewall\Utility\PluginConfigNormalizer;
 use Symfony\Component\HttpFoundation\Request;
@@ -35,6 +36,7 @@ use Symfony\Component\HttpFoundation\Request;
 final class Firewall
 {
     use LoggingTrait;
+    use RequestFieldTrait;
 
     /**
      * Firewall Mode.
@@ -725,11 +727,19 @@ final class Firewall
             // @codeCoverageIgnoreEnd
         }
 
-        $ttl = max(0, (int) $request->request->get(ChallengeProviderInterface::TTL_FIELD, 3600));
+        // Both fields ride in on the interstitial's POST, so both are
+        // attacker-chosen. Read them off the raw bag — InputBag::get() throws
+        // on an array value, and nothing above this frame catches it (#130).
+        // An absent or non-string ttl falls back to the default hour; an
+        // absent or non-string redirect falls back to the site root, which is
+        // what sanitizeRedirect() would have reduced a hostile one to anyway.
+        $rawTtl = $this->postedString($request, ChallengeProviderInterface::TTL_FIELD);
+        $ttl = $rawTtl === '' ? 3600 : max(0, (int) $rawTtl);
+
         $token = $this->tokenManager->mint($request, $ttl);
-        $redirect = $this->sanitizeRedirect(
-            (string) $request->request->get(ChallengeProviderInterface::REDIRECT_FIELD, '/')
-        );
+
+        $rawRedirect = $this->postedString($request, ChallengeProviderInterface::REDIRECT_FIELD, false);
+        $redirect = $this->sanitizeRedirect($rawRedirect === '' ? '/' : $rawRedirect);
 
         $this->getLogger()->info('Challenge solution accepted', $this->getContext($request, [
             'provider' => $this->challengeProvider->getName(),
@@ -1150,15 +1160,21 @@ final class Firewall
                 }
 
                 // 3. request.query.<param>
+                //
+                // Read off the raw bag rather than through InputBag::get(),
+                // which throws on an array value — `?q[]=1` against a template
+                // using this token would otherwise turn a block page into an
+                // uncaught exception (#130). $sanitize() already renders a
+                // non-scalar as '', so an array simply interpolates empty.
                 if (str_starts_with($key, 'request.query.')) {
                     $param = substr($key, 14);
-                    return $sanitize($request->query->get($param, ''));
+                    return $sanitize($request->query->all()[$param] ?? '');
                 }
 
-                // 4. request.post.<param>  (body fields)
+                // 4. request.post.<param>  (body fields), same treatment
                 if (str_starts_with($key, 'request.post.')) {
                     $param = substr($key, 13);
-                    return $sanitize($request->request->get($param, ''));
+                    return $sanitize($request->request->all()[$param] ?? '');
                 }
 
                 // 5. request.cookie.<name>

--- a/src/Traits/RequestFieldTrait.php
+++ b/src/Traits/RequestFieldTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Firewall package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Kanopi\Firewall\Traits;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Reads attacker-controlled request fields without ever throwing (#130).
+ *
+ * `InputBag::get()` raises `BadRequestException` when the posted value is an
+ * array, so reading `altcha[]=x` through it turns one crafted POST field into
+ * an uncaught exception and a 500. That matters most on the challenge flow:
+ * `ChallengeProviderInterface::verifySolution()` is contractually forbidden
+ * from throwing, and `Firewall::handleChallengeSubmission()` does not catch.
+ *
+ * The raw bag is inspected instead and anything that is not a string is
+ * treated as absent — an array-valued `challenge_answer` is not a wrong
+ * answer to be reported, it is simply not an answer.
+ */
+trait RequestFieldTrait
+{
+    /**
+     * Read a POST body field as a string, or the empty string.
+     *
+     * @param Request $request
+     *   The request carrying the submission.
+     * @param string $field
+     *   Body field name.
+     * @param bool $trim
+     *   Whether to trim surrounding whitespace from the value.
+     *
+     * @return string
+     *   The posted value, or '' when it is absent or not a string.
+     */
+    protected function postedString(Request $request, string $field, bool $trim = true): string
+    {
+        $raw = $request->request->all()[$field] ?? '';
+
+        if (!is_string($raw)) {
+            return '';
+        }
+
+        return $trim ? trim($raw) : $raw;
+    }
+}

--- a/tests/Integration/ChallengeFlowTest.php
+++ b/tests/Integration/ChallengeFlowTest.php
@@ -384,6 +384,73 @@ class ChallengeFlowTest extends TestCase
         $this->assertTrue($firewall->evaluate($request));
     }
 
+    /**
+     * A crafted array field is a rejected submission, not a 500 (#130).
+     *
+     * `InputBag::get()` throws BadRequestException on a non-scalar and
+     * nothing between here and the host application catches it, so before the
+     * fix one unauthenticated POST to any route serving `response: challenge`
+     * produced an uncaught exception and a stack trace — repeatable at
+     * whatever volume the caller cared to generate.
+     */
+    public function testArrayValuedSolutionFieldIsRejectedNotFatal(): void
+    {
+        $firewall = Firewall::create([$this->configWithChallenge()]);
+
+        $request = Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [
+                MathChallengeProvider::STATE_FIELD => ['x'],
+                MathChallengeProvider::ANSWER_FIELD => ['7'],
+                MathChallengeProvider::REDIRECT_FIELD => '/protected',
+                MathChallengeProvider::TTL_FIELD => '600',
+            ],
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.50']
+        );
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($request);
+    }
+
+    /**
+     * The firewall reads `ttl` and `redirect_to` itself, outside any provider,
+     * and they arrive on the same attacker-chosen POST (#130). Array values
+     * fall back to the defaults rather than throwing — and the fallback
+     * redirect is the site root, which is where sanitizeRedirect() sends
+     * anything off-site anyway.
+     */
+    public function testArrayValuedTtlAndRedirectFallBackToDefaults(): void
+    {
+        $firewall = Firewall::create([$this->configWithChallenge()]);
+
+        [$state, $answer] = $this->generateSolvedState($firewall, '10.0.0.50');
+
+        $request = Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [
+                MathChallengeProvider::STATE_FIELD => $state,
+                MathChallengeProvider::ANSWER_FIELD => $answer,
+                MathChallengeProvider::REDIRECT_FIELD => ['/protected'],
+                MathChallengeProvider::TTL_FIELD => ['600'],
+            ],
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.50']
+        );
+
+        try {
+            $firewall->evaluate($request);
+            $this->fail('Expected ChallengeSolvedException');
+        } catch (ChallengeSolvedException $e) {
+            $this->assertNotEmpty($e->getToken());
+            $this->assertSame('/', $e->getRedirect());
+        }
+    }
+
     public function testMissingSecretWithChallengePluginsThrowsAtStartup(): void
     {
         $configFile = $this->writeConfig([
@@ -631,6 +698,35 @@ class ChallengeFlowTest extends TestCase
                 $this->assertNotEmpty($e->getToken());
             }
         }
+    }
+
+    /**
+     * `altcha[]=x` is a rejected submission, not an uncaught exception (#130).
+     *
+     * Worth asserting through the firewall as well as at the provider: the
+     * ALTCHA payload is read twice per submission — once by
+     * `verifySolution()` and once by `getSolutionReceipt()` on the
+     * single-use path — and only the full flow exercises both.
+     */
+    public function testArrayValuedAltchaPayloadIsRejectedNotFatal(): void
+    {
+        $firewall = Firewall::create([$this->configWithAltchaChallenge()]);
+
+        $request = Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [
+                AltchaChallengeProvider::PAYLOAD_FIELD => ['x'],
+                AltchaChallengeProvider::REDIRECT_FIELD => '/protected',
+                AltchaChallengeProvider::TTL_FIELD => '600',
+            ],
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.50']
+        );
+
+        $this->expectException(ChallengeRequiredException::class);
+        $firewall->evaluate($request);
     }
 
     /**

--- a/tests/Unit/Challenge/AltchaChallengeProviderTest.php
+++ b/tests/Unit/Challenge/AltchaChallengeProviderTest.php
@@ -513,6 +513,32 @@ final class AltchaChallengeProviderTest extends AbstractTestCase
         ]));
     }
 
+    /**
+     * An array-valued payload is a rejection, not an exception (#130).
+     *
+     * `InputBag::get()` raises BadRequestException on a non-scalar, and both
+     * callers of validate() are forbidden from throwing — `verifySolution()`
+     * by the interface contract, `getSolutionReceipt()` because
+     * `Firewall::consumeSingleUseSolution()` does not catch either. One
+     * crafted `altcha[]=x` would otherwise be a 500.
+     */
+    public function testArrayValuedPayloadIsRejectedWithoutThrowing(): void
+    {
+        $provider = new AltchaChallengeProvider(new TokenManager(self::SECRET));
+
+        $request = Request::create(
+            '/_firewall/challenge',
+            'POST',
+            [AltchaChallengeProvider::PAYLOAD_FIELD => ['nested']],
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.5']
+        );
+
+        $this->assertFalse($provider->verifySolution($request));
+        $this->assertNull($provider->getSolutionReceipt($request));
+    }
+
     private function makeSubmissionRequest(string $payload): Request
     {
         return Request::create(

--- a/tests/Unit/Challenge/MathChallengeProviderTest.php
+++ b/tests/Unit/Challenge/MathChallengeProviderTest.php
@@ -183,6 +183,56 @@ final class MathChallengeProviderTest extends AbstractTestCase
         $this->assertFalse($provider->verifySolution($this->makeSubmissionRequest($state, '7')));
     }
 
+    /**
+     * Each hostile field on its own, so neither can mask the other.
+     *
+     * @return array<string, array{0: array<string, mixed>}>
+     */
+    public static function arrayValuedFieldProvider(): array
+    {
+        return [
+            'state is an array' => [[
+                MathChallengeProvider::STATE_FIELD => ['x'],
+                MathChallengeProvider::ANSWER_FIELD => '7',
+            ]],
+            'answer is an array' => [[
+                MathChallengeProvider::STATE_FIELD => '7|9999999999.sig',
+                MathChallengeProvider::ANSWER_FIELD => ['7'],
+            ]],
+            'both are arrays' => [[
+                MathChallengeProvider::STATE_FIELD => ['x'],
+                MathChallengeProvider::ANSWER_FIELD => ['7'],
+            ]],
+        ];
+    }
+
+    /**
+     * An array-valued field is a rejection, not an exception (#130).
+     *
+     * `InputBag::get()` raises BadRequestException on a non-scalar, and
+     * `verifySolution()` is contractually forbidden from throwing —
+     * `Firewall::handleChallengeSubmission()` does not catch, so a throw here
+     * reaches the host application as a 500 for one crafted POST field.
+     *
+     * @param array<string, mixed> $fields
+     */
+    #[DataProvider('arrayValuedFieldProvider')]
+    public function testArrayValuedFieldIsRejectedWithoutThrowing(array $fields): void
+    {
+        $provider = new MathChallengeProvider(new TokenManager(self::SECRET));
+
+        $request = Request::create(
+            '/_firewall/challenge',
+            'POST',
+            $fields,
+            [],
+            [],
+            ['REMOTE_ADDR' => '10.0.0.5']
+        );
+
+        $this->assertFalse($provider->verifySolution($request));
+    }
+
     private function makeSubmissionRequest(string $state, string $answer): Request
     {
         return Request::create(

--- a/tests/Unit/FirewallTest.php
+++ b/tests/Unit/FirewallTest.php
@@ -387,6 +387,31 @@ class FirewallTest extends AbstractTestCase
     }
 
     /**
+     * Array-valued query and body params interpolate empty, not fatally.
+     *
+     * Same defect as #130 one layer out: `InputBag::get()` throws on a
+     * non-scalar, and these tokens are read while building a *blocking*
+     * response, so `?q[]=1` against a config using `{{request.query.q}}`
+     * would have replaced the block page with an uncaught exception.
+     */
+    public function testInterpolateRendersArrayValuedParamsAsEmpty(): void
+    {
+        $request = Request::create('/', 'POST', ['name' => ['x']], [], [], [
+            'REMOTE_ADDR' => '8.8.8.8',
+        ], null);
+        $request->query->set('q', ['y']);
+
+        $ref = new \ReflectionClass(Firewall::class);
+        $firewall = $this->createFirewall();
+        $method = $ref->getMethod('interpolateTemplate');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($firewall, '[{{request.query.q}}][{{request.post.name}}]', $request);
+
+        $this->assertSame('[][]', $result);
+    }
+
+    /**
      * Attacker-controlled cookie values must be HTML-escaped.
      */
     public function testInterpolateEscapesHtmlInCookie(): void


### PR DESCRIPTION
## Description
- [x] Was AI used in this pull request?

`InputBag::get()` raises `BadRequestException` when the posted value is an array, so a single crafted field on the challenge POST — `altcha[]=x`, or an array-valued `challenge_state`, `challenge_answer`, `ttl`, or `redirect_to` — became an uncaught exception. `ChallengeProviderInterface` forbids `verifySolution()` from throwing and `Firewall::handleChallengeSubmission()` does not catch, so it surfaced as a 500 from the host application plus a stack trace, reachable by an unauthenticated caller in one request with no valid challenge state.

**Not a bypass.** No pass token is minted, nothing is allowed through, no secret is exposed. What it bought an attacker was a 500 from any route serving `response: challenge` and log/error-tracking noise at whatever volume they cared to generate — which on a paid error-tracking plan is the part that costs money.

Reproduced on `2.x` at `c04968a` before touching anything:

```
altcha           THREW BadRequestException: Input value "altcha" contains a non-scalar value.
altcha-receipt   THREW BadRequestException: Input value "altcha" contains a non-scalar value.
math             THREW BadRequestException: Input value "challenge_state" contains a non-scalar value.
ttl              THREW BadRequestException: Input value "ttl" contains a non-scalar value.
redirect_to      THREW BadRequestException: Input value "redirect_to" contains a non-scalar value.
```

## Related Issue

Fixes #130

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security fix

## Changes Made

New `src/Traits/RequestFieldTrait.php` — `postedString()` reads the raw bag and treats anything that is not a string as absent. An array-valued `challenge_answer` is not a wrong answer to be reported; it is simply not an answer.

| File | Change |
|---|---|
| `src/Challenge/MathChallengeProvider.php` | `challenge_state` (untrimmed, as before) and `challenge_answer` read via the trait |
| `src/Challenge/AltchaChallengeProvider.php` | `altcha` read via the trait inside `validate()` |
| `src/Challenge/TurnstileChallengeProvider.php` | `postedToken()` delegates to the trait |
| `src/Challenge/RecaptchaChallengeProvider.php` | `postedToken()` delegates to the trait |
| `src/Firewall.php` | `ttl` and `redirect_to` in `handleChallengeSubmission()`; both `interpolateTemplate()` reads |

Two details worth a reviewer's attention:

- **ALTCHA is read twice per submission.** `validate()` backs both `verifySolution()` and `getSolutionReceipt()`, and `consumeSingleUseSolution()` does not catch either, so fixing the one read closes both paths. The integration test goes through the full flow rather than the provider alone for exactly that reason.
- **Turnstile and reCAPTCHA already did this**, inline, since #126. Their `postedToken()` now delegates instead of the codebase carrying a fourth copy of the same four lines. Behaviour is identical.

**Fallbacks in `Firewall`:** a non-string `ttl` falls back to the default hour; a non-string `redirect_to` falls back to `/`, which is where `sanitizeRedirect()` already reduces anything off-site.

### One fix beyond the issue's scope

`interpolateTemplate()` had the same defect one layer out: `{{request.query.q}}` and `{{request.post.name}}` read through `get()`, so `?q[]=1` against a config using those tokens replaced a **block page** with an uncaught exception — the failure lands on the path whose whole job is to respond to hostile traffic. Same one-line shape, same file, so it is fixed here rather than left as a known throw two hundred lines from the ones being fixed.

Those two read the raw bag directly rather than through the trait: `$sanitize()` already renders a non-scalar as `''` and stringifies scalars, so routing them through a string-only helper would change how a numeric param renders. Say the word if you would rather see it split out.

## Testing

### How to Test

```bash
composer test              # both suites
composer phpunit:coverage  # coverage in one pass
composer check             # phpcs + phpstan (max) + rector
```

Every new test fails on `2.x` and passes here.

- `MathChallengeProviderTest::testArrayValuedFieldIsRejectedWithoutThrowing` — data provider covering state, answer, and both, so neither field can mask the other
- `AltchaChallengeProviderTest::testArrayValuedPayloadIsRejectedWithoutThrowing` — asserts `false` **and** a `null` receipt
- `ChallengeFlowTest::testArrayValuedSolutionFieldIsRejectedNotFatal` — through `Firewall::evaluate()` in `mode: exception`, asserting `ChallengeRequiredException` rather than `BadRequestException`
- `ChallengeFlowTest::testArrayValuedAltchaPayloadIsRejectedNotFatal` — same, exercising both reads of the payload
- `ChallengeFlowTest::testArrayValuedTtlAndRedirectFallBackToDefaults` — a *valid* solve carrying array `ttl`/`redirect_to`: the token still mints and the redirect falls back to `/`
- `FirewallTest::testInterpolateRendersArrayValuedParamsAsEmpty` — `[][]`

### Test Configuration

```yaml
global:
  mode: exception
challenge:
  provider: altcha
  secret: a-secret-of-sufficient-length
plugins:
  - plugin: Kanopi\Firewall\Plugins\IpAddress
    response: challenge
    enable: true
    config: ['10.0.0.50']
```

```
POST /_firewall/challenge   altcha[]=x&redirect_to=/protected&ttl=600
```

Before: `BadRequestException` escapes `evaluate()`. After: `ChallengeRequiredException`, i.e. the rejection the flow was designed to return.

## Checklist

### Code Quality

- [x] `composer cs` passes
- [x] `composer stan` passes (level max)
- [x] Comments explain why each hostile field bypasses `InputBag::get()`
- [x] No new warnings or errors

### Testing

- [x] Unit tests that prove the fix
- [x] Integration tests
- [x] `composer test` passes locally — 1284 + 73 tests, 2 deprecations and 12 skips, unchanged from `2.x`
- [x] 100% coverage of the new code
- [x] Edge cases and error conditions

Coverage reads 98.82% lines / 98.00% classes locally; the only file below 100% is `RedisRateLimitStorage`, which needs the `redis` extension and a server. Same local/CI gap #132 documented — CI has both.

### Security Considerations

- [x] Security implications considered
- [x] Input validation properly implemented
- [x] No sensitive information logged or exposed
- [x] Changes don't introduce new attack vectors

### Documentation

- [x] Inline documentation added — the trait's docblock explains the failure mode once, and each call site says why it is not using `get()`

## Breaking Changes

- [ ] This PR introduces breaking changes

## Performance Impact

- [ ] This change has performance implications

Reads move from `InputBag::get()` to an array lookup on the same bag.

## Reviewer Notes

**One thing deliberately not done.** #130 raises — without assuming — a `try`/`catch (\Throwable)` around the `verifySolution()` call in `handleChallengeSubmission()`, so that a misbehaving *third-party* provider becomes a rejected submission rather than a 500. Every field the shipped providers read is hardened here, but the "must never throw" contract remains unenforceable for custom providers. It is a real behavioural trade — it also swallows genuine bugs during development — so it is left as a decision rather than folded into a bug fix. Happy to add it in this PR, with the failure logged at `error`, if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
