### PR TITLE
Document %env() instead of ${VAR} for secrets in docs (Fixes #129)

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -6,6 +6,24 @@ You can reference OS environment variables inside YAML using Symfony‑style tok
 - When a token appears **inside a larger string**, it is interpolated as text.
 - Remember to **quote** tokens in YAML (e.g., `' %env(...)% '`) because `%` is a reserved indicator in YAML.
 
+## `${VAR}` Is Not Supported
+
+`%env(NAME)%` is the **only** substitution syntax this library implements. The shell-style form `${NAME}` is the more intuitive guess, but nothing resolves it — the value is loaded as the literal string `${NAME}`:
+
+```yaml
+# WRONG — loaded as the literal string "${FIREWALL_CHALLENGE_SECRET}"
+challenge:
+  secret: '${FIREWALL_CHALLENGE_SECRET}'
+
+# Correct
+challenge:
+  secret: '%env(FIREWALL_CHALLENGE_SECRET)%'
+```
+
+This matters most for secrets, because the failure is not always loud. A rejected API key surfaces quickly as an error from the remote service, but a signing key set to the literal `${FIREWALL_CHALLENGE_SECRET}` keeps working — using a value that is identical across every deployment that copy-pasted it, which anyone can then use to forge a valid token.
+
+If you see `${...}` in a config example, it is either a mistake or it belongs to a different tool. Docker Compose, shell scripts, and CI configuration substitute `${VAR}` themselves before this library ever sees the file; inside a firewall YAML config, it is always wrong.
+
 ## Variable Resolution with `$_SERVER` Fallback
 
 The firewall checks environment variables in the following order:

--- a/docs/configuration/logging.md
+++ b/docs/configuration/logging.md
@@ -104,7 +104,7 @@ logger:
   - class: Monolog\Handler\SendGridHandler
     args:
       - apikey                     # SendGrid API user (use "apikey" for API key auth)
-      - "${SENDGRID_API_KEY}"      # API key
+      - "%env(SENDGRID_API_KEY)%"  # API key
       - noreply@example.com        # from
       - security@example.com       # to (string or list)
       - "Firewall Alert"           # subject
@@ -119,7 +119,7 @@ Post directly to a Slack channel through an [Incoming Webhook](https://api.slack
 logger:
   - class: Monolog\Handler\SlackWebhookHandler
     args:
-      - "${SLACK_WEBHOOK_URL}"     # webhook URL
+      - "%env(SLACK_WEBHOOK_URL)%" # webhook URL
       - "#security-alerts"         # channel override (or null)
       - "Firewall"                 # bot username
       - true                       # useAttachment
@@ -135,7 +135,7 @@ If you prefer the Slack Web API (legacy token-based handler):
 logger:
   - class: Monolog\Handler\SlackHandler
     args:
-      - "${SLACK_BOT_TOKEN}"       # Slack bot token
+      - "%env(SLACK_BOT_TOKEN)%"   # Slack bot token
       - "#security-alerts"         # channel
       - "Firewall"                 # username
       - true                       # useAttachment
@@ -151,9 +151,9 @@ Send mobile push notifications via [Pushover](https://pushover.net/):
 logger:
   - class: Monolog\Handler\PushoverHandler
     args:
-      - "${PUSHOVER_APP_TOKEN}"    # application API token
-      - "${PUSHOVER_USER_KEY}"     # user/group key (string or list)
-      - "Firewall Alert"           # notification title
+      - "%env(PUSHOVER_APP_TOKEN)%"  # application API token
+      - "%env(PUSHOVER_USER_KEY)%"   # user/group key (string or list)
+      - "Firewall Alert"             # notification title
       - Monolog\Level::Critical
 ```
 
@@ -166,7 +166,7 @@ logger:
   - class: Monolog\Handler\IFTTTHandler
     args:
       - firewall_alert             # event name configured in the IFTTT applet
-      - "${IFTTT_MAKER_KEY}"       # Maker webhook key
+      - "%env(IFTTT_MAKER_KEY)%"   # Maker webhook key
       - Monolog\Level::Error
 ```
 
@@ -180,8 +180,8 @@ Send messages to a Telegram channel or chat via a bot token:
 logger:
   - class: Monolog\Handler\TelegramBotHandler
     args:
-      - "${TELEGRAM_BOT_TOKEN}"    # bot token from @BotFather
-      - "@my_security_channel"     # chat ID or @channel
+      - "%env(TELEGRAM_BOT_TOKEN)%"  # bot token from @BotFather
+      - "@my_security_channel"       # chat ID or @channel
       - Monolog\Level::Critical
 ```
 
@@ -229,7 +229,7 @@ logger:
   # Critical events ping the on-call channel
   - class: Monolog\Handler\SlackWebhookHandler
     args:
-      - "${SLACK_WEBHOOK_URL}"
+      - "%env(SLACK_WEBHOOK_URL)%"
       - "#security-oncall"
       - "Firewall"
       - true
@@ -241,8 +241,8 @@ logger:
   # And buzz a phone if no one acks
   - class: Monolog\Handler\PushoverHandler
     args:
-      - "${PUSHOVER_APP_TOKEN}"
-      - "${PUSHOVER_USER_KEY}"
+      - "%env(PUSHOVER_APP_TOKEN)%"
+      - "%env(PUSHOVER_USER_KEY)%"
       - "Firewall CRITICAL"
       - Monolog\Level::Critical
 ```


### PR DESCRIPTION
## Description
- [x] Was AI used in this pull request?

`docs/configuration/logging.md` documented nine handler credentials using shell-style `${VAR}`. That syntax is never substituted by this library — `TokenSubstitute` implements Symfony-style `%env(...)%` only, and there is no code path in `src/` that handles `${...}`. Anyone following those examples shipped the literal string `${SENDGRID_API_KEY}` as their API key.

Docs-only change. No source or behavior changes.

## Related Issue

Fixes #129

## Type of Change

- [x] Documentation update
- [x] Security fix

## Changes Made

- Replaced all nine `${VAR}` occurrences in `docs/configuration/logging.md` with `%env(VAR)%` (SendGrid, Slack webhook, Slack Web API, Pushover, IFTTT, Telegram, and the combined multi-handler example), keeping the inline comment alignment intact.
- Added a `${VAR}` Is Not Supported section to `docs/configuration/environment-variables.md` — it documented the correct syntax thoroughly but never ruled out the more intuitive wrong guess, so an operator had no way to discover the mistake except by noticing the credential never worked.
- Ran the repo-wide grep called for in the issue. No other affected YAML. The remaining `${...}` uses (`docker-compose.yml`, `example/demo/docker-compose.yml`, `tests/Performance/docker-compose.yml`, `.circleci/config.yml`) are interpolated by those tools before this library sees the file and are deliberately left alone.

Step 4 of the issue — having `ConfigLoader` warn on values matching `/^\$\{[A-Z_][A-Z0-9_]*\}$/` — is **not** included here. It is a behavior change with a false-positive risk for anyone legitimately storing such a string, and the issue itself flags it as worth discussing separately.

## Testing

### How to Test

1. Check out this branch and confirm `grep -rn '\${' docs/` returns only the two deliberate warnings (the new section in `environment-variables.md` and the pre-existing note in `docs/plugins/abuseipdb.md:40`).
2. Copy any handler example from `docs/configuration/logging.md` into a config file, export the matching env var, and load it through `ConfigLoader::load()`.
3. Confirm the value resolves rather than arriving as a literal.

### Test Configuration

```yaml
logger:
  - class: Monolog\Handler\SlackWebhookHandler
    args:
      - "%env(SLACK_WEBHOOK_URL)%"
      - "#security-alerts"
      - "Firewall"
```

Verified against the real loader:

```
$ SLACK_WEBHOOK_URL=https://hooks.example/T123 php -r '
require "vendor/autoload.php";
$c = \Kanopi\Firewall\Utility\ConfigLoader::load("envtest.yml");
var_export($c["logger"][0]["args"]);'

array (
  0 => 'https://hooks.example/T123',
  1 => '#security-alerts',
  2 => 'Firewall',
)
```

## Checklist

### Code Quality

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors

No source changes, so `composer cs` / `composer stan` / `composer test` are unaffected by this PR and were not run.

### Security Considerations

- [x] I have considered the security implications of my changes
- [x] No sensitive information is logged or exposed

For the handlers in this PR the original failure was loud and self-limiting — Slack or SendGrid rejects a nonsense credential and the operator investigates. The genuinely dangerous instance of the same mistake was `challenge.secret` in `example/config.notes.yml`, where a pass-token HMAC key set to the literal `${FIREWALL_CHALLENGE_SECRET}` still works while being published in this repository and identical across every deployment that copy-pasted it. That one was already corrected in #126; this PR clears the remainder and documents the rule so it does not recur.

### Documentation

- [x] I have added/updated configuration examples
- [x] I have updated inline documentation/comments

## Breaking Changes

- [ ] This PR introduces breaking changes

## Performance Impact

- [ ] This change has performance implications

## Reviewer Notes

Worth a look at the wording of the new `environment-variables.md` section — specifically whether the `challenge.secret` example is the right one to lead with, given that particular config is already fixed in the repo. It is used because it is the clearest illustration of a silent rather than loud failure.
