### PR TITLE
Drop the unused bc and xidel downloads from CI setup (Fixes #128)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,11 +99,9 @@ jobs:
       - run:
           name: Setup
           command: |
-            # Install BC Tool
+            # Database CLI clients
             sudo apt update
             sudo apt install mariadb-client postgresql-client
-            curl -o /tmp/bc.deb -fsSL http://archive.ubuntu.com/ubuntu/pool/main/b/bc/bc_1.07.1-3build1_amd64.deb
-            sudo dpkg -i /tmp/bc.deb 
             # Set Hostname
             echo "127.0.0.1 web" | sudo tee -a /etc/hosts
             # Install XDebug
@@ -112,9 +110,6 @@ jobs:
             printf "no\nno\n" | sudo pecl install redis
             sudo docker-php-ext-install pdo_mysql mysqli pdo_pgsql
             #sudo cp .circleci/config/*.ini /etc/php.d/
-            # Install Xidel
-            curl -fsSL https://github.com/benibela/xidel/releases/download/Xidel_0.9.8/xidel-0.9.8.linux64.tar.gz | tar xvz -C /tmp/
-            chmod +x /tmp/xidel && sudo mv /tmp/xidel /usr/sbin/
             cp .circleci/phpunit.env ./.env
       # Keyed per PHP version: composer.lock is not committed, so each PHP
       # version resolves a different Symfony line (8.1 -> 6.4, 8.2/8.3 -> 7.4,


### PR DESCRIPTION
## Description
- [x] Was AI used in this pull request?

The `phpunit` job's `Setup` step fetches two binaries from third-party hosts on every run of all five PHP versions — a version-pinned `bc` `.deb` over **plain HTTP** from `archive.ubuntu.com`, and the `xidel` release tarball from GitHub. Neither is used by anything anymore.

Their only consumer was the coverage gate: `xidel` for one XPath query against `reports/xml/index.xml`, `bc` for one arithmetic comparison. #132 replaced both with `simplexml_load_file` and a PHP comparison. Since that merged, the pipeline has been downloading two binaries that nothing calls.

The `bc` fetch is not hypothetical flakiness — it failed `ci/circleci: phpunit 8.2` on #126 in `Setup`, before PHPUnit ran:

```
curl: (56) Recv failure: Connection reset by peer
Exited with code exit status 56
```

The same commit passed on 8.1, 8.3, 8.4 and 8.5, and a rerun went green with no code change.

## Related Issue

Fixes #128

## Type of Change

- [x] Refactoring (no functional changes)

## Changes Made

- Removed the `bc` `.deb` download and `dpkg -i` from the `Setup` step.
- Removed the `xidel` tarball download, `chmod` and `mv` from the `Setup` step.
- Corrected the `# Install BC Tool` comment, which sat above the apt line and described a tool that is no longer installed there, to `# Database CLI clients`.

Five lines removed, one comment corrected. Net effect across five parallel jobs per build: two fewer external network dependencies including the only plain-HTTP fetch in the pipeline, and one fewer version-pinned URL to rot (`bc_1.07.1-3build1_amd64.deb` is pinned to a version that will eventually leave the archive).

## Deliberately NOT changed

**`mariadb-client` and `postgresql-client` stay.** The original issue proposed removing these too, on the grounds that nothing invokes `mysql` or `psql`. That grep result still holds, but they are left in place here — see Reviewer Notes for the reason and the follow-up.

**`rsync` stays** — used by `.circleci/scripts/build.sh:18` with `--exclude-from` to assemble the release zip, per the issue's own out-of-scope note.

**The PECL and extension installs stay** — `xdebug` (coverage), `redis` (`RedisRateLimitStorage` tests), and `pdo_mysql mysqli pdo_pgsql` (`DatabaseStorage` tests) are all load-bearing.

## Testing

### How to Test

1. Confirm `grep -n 'bc\.deb\|xidel\|archive\.ubuntu' .circleci/config.yml` returns only the explanatory comment inside the coverage gate — which is written in the past tense and is now fully accurate.
2. Confirm the config still parses: `php -r 'require "vendor/autoload.php"; Symfony\Component\Yaml\Yaml::parseFile(".circleci/config.yml", Symfony\Component\Yaml\Yaml::PARSE_CUSTOM_TAGS);'` — verified locally, parses clean.
3. Watch the `phpunit` matrix on this PR. All five PHP versions should complete `Setup` and the `Check Coverage` gate should report the same percentage as on `2.x`.

The gate itself is untouched, so any change in reported coverage would indicate a problem rather than an expected result.

## Checklist

### Code Quality

- [x] My changes generate no new warnings or errors

CI-only change. No source or test files touched, so `composer cs` / `stan` / `test` are unaffected and were not run — this PR's own matrix run is the real verification.

### Security Considerations

- [x] I have considered the security implications of my changes

Removes the pipeline's only plain-HTTP dependency fetch. A `.deb` retrieved over unauthenticated HTTP and installed with `dpkg -i` is an unnecessary trust relationship in a build that has repository write credentials in scope.

## Breaking Changes

- [ ] This PR introduces breaking changes

## Performance Impact

- [ ] This change has performance implications

Marginally faster setup — two fewer network round-trips per job, five jobs per build — but not the motivation.

## Reviewer Notes

**Why the database clients were kept.** The integration tests connect through Doctrine DBAL, not a shell:

```php
// tests/Integration/Storage/StorageIntegrationTest.php:205
$connectionParams = (new DsnParser())->parse($dsn);
$connection = DriverManager::getConnection($connectionParams);
```

with `DB_MYSQL_DSN="mysqli://root:password@mysql:3306/firewall_test?serverVersion=10.6"` — the `mysqli://` scheme routes to the PHP extension, not `/usr/bin/mysql`. So the original "nothing uses them" finding is technically correct.

But there is a gap those packages are the right tool for, which is worth resolving before removing them. There is no readiness gate before PHPUnit runs. CircleCI starts service containers in parallel with the primary, and these tests **skip** rather than fail when they cannot connect:

```php
// tests/Integration/Storage/StorageIntegrationTest.php:207
} catch (\Exception $e) {
    $this->markTestSkipped('Could not connect to MySQL: ' . $e->getMessage());
}
```

Today the only thing preventing a silent skip of the entire database suite is that `composer install` happens to take long enough for MariaDB and Postgres to come up. That is timing, not design. `mysqladmin ping` and `pg_isready` — from exactly these two packages — are the standard fix.

Suggest a follow-up issue covering both halves: add the readiness gate, and decide whether a connection failure should skip or hard-fail under CI. If the gate is written in PHP instead, for consistency with what #132 did to the coverage check, the client packages can be dropped at that point.
