### PR TITLE
Parse-check every interstitial script, on CI too (Fixes #139)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,12 @@ jobs:
             # Database CLI clients
             sudo apt update
             sudo apt install mariadb-client postgresql-client
+            # InterstitialRendererTest parse-checks the generated inline
+            # scripts with `node --check`, and fails rather than skips when
+            # CI is set. Conditional because the cimg images may already
+            # ship node -- installing over an existing one is the only way
+            # this could conflict.
+            command -v node >/dev/null || sudo apt install -y nodejs
             # Set Hostname
             echo "127.0.0.1 web" | sudo tee -a /etc/hosts
             # Install XDebug

--- a/tests/Unit/Challenge/InterstitialRendererTest.php
+++ b/tests/Unit/Challenge/InterstitialRendererTest.php
@@ -7,6 +7,7 @@ namespace Kanopi\Firewall\Tests\Unit\Challenge;
 use Kanopi\Firewall\Challenge\AltchaChallengeProvider;
 use Kanopi\Firewall\Challenge\InterstitialRenderer;
 use Kanopi\Firewall\Challenge\MathChallengeProvider;
+use Kanopi\Firewall\Challenge\RecaptchaChallengeProvider;
 use Kanopi\Firewall\Challenge\TokenManager;
 use Kanopi\Firewall\Challenge\TurnstileChallengeProvider;
 use Kanopi\Firewall\Tests\Unit\AbstractTestCase;
@@ -15,14 +16,19 @@ use PHPUnit\Framework\Attributes\DataProvider;
 /**
  * Escaping rules for the shared interstitial document.
  *
- * The regression these guard is a real lockout: the ALTCHA submit button
- * renders disabled and is only enabled by the inline script, so a value
- * that breaks that script's syntax leaves the visitor with no way to
- * complete the challenge.
+ * The regression these guard is a real lockout: the ALTCHA, Turnstile and
+ * reCAPTCHA submit buttons all render disabled and are only enabled by the
+ * inline script, so a value that breaks that script's syntax leaves the
+ * visitor with no way to complete the challenge.
  */
 final class InterstitialRendererTest extends AbstractTestCase
 {
     private const SECRET = 'interstitial-test-secret';
+
+    /** Google's published test keys -- never reach the network here. */
+    private const RECAPTCHA_SITE_KEY = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
+
+    private const RECAPTCHA_SECRET_KEY = '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe';
 
     /**
      * Values that broke, or could break, the inline script when they were
@@ -90,6 +96,45 @@ final class InterstitialRendererTest extends AbstractTestCase
     }
 
     #[DataProvider('hostileRedirectProvider')]
+    public function testRecaptchaV2InterstitialStaysSyntacticallyValid(string $redirect): void
+    {
+        $provider = new RecaptchaChallengeProvider([
+            'site_key' => self::RECAPTCHA_SITE_KEY,
+            'secret_key' => self::RECAPTCHA_SECRET_KEY,
+        ]);
+        $html = $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => $redirect,
+            'ttl' => '60',
+            'header_name' => 'X-FW',
+        ]);
+
+        $this->assertInlineScriptParses($html);
+    }
+
+    /**
+     * v3 renders a different interstitial to v2 -- no checkbox widget, a
+     * `grecaptcha.execute()` call instead -- so it needs its own case.
+     */
+    #[DataProvider('hostileRedirectProvider')]
+    public function testRecaptchaV3InterstitialStaysSyntacticallyValid(string $redirect): void
+    {
+        $provider = new RecaptchaChallengeProvider([
+            'version' => 'v3',
+            'site_key' => self::RECAPTCHA_SITE_KEY,
+            'secret_key' => self::RECAPTCHA_SECRET_KEY,
+        ]);
+        $html = $provider->renderInterstitial($this->getRequest('10.0.0.5'), [
+            'submit_url' => '/_firewall/challenge',
+            'redirect_to' => $redirect,
+            'ttl' => '60',
+            'header_name' => 'X-FW',
+        ]);
+
+        $this->assertInlineScriptParses($html);
+    }
+
+    #[DataProvider('hostileRedirectProvider')]
     public function testHeaderNameIsAlsoJsEncoded(string $headerName): void
     {
         $provider = new MathChallengeProvider(new TokenManager(self::SECRET));
@@ -145,37 +190,61 @@ final class InterstitialRendererTest extends AbstractTestCase
     /**
      * Assert every inline (non-module) script in the document parses.
      *
-     * Uses node when available so this is a real parse rather than a
-     * regex approximation; skips rather than silently passing when node
-     * is absent.
+     * Matches `<script>` with no attributes, so external bundles
+     * (`<script src=... async defer>`) and module scripts are excluded --
+     * only the markup this library generates is checked.
+     *
+     * Every block is checked, not just the first. Turnstile and reCAPTCHA v2
+     * emit two: the document-bottom `(function ...)` block, and a second one
+     * in `extra_head` declaring the widget callbacks. That second block is
+     * what re-enables the submit button, so skipping it would leave the
+     * lockout path this test exists to guard entirely unchecked.
+     *
+     * Uses node so this is a real parse rather than a regex approximation.
      */
     private function assertInlineScriptParses(string $html): void
     {
+        $found = preg_match_all('#<script>(.*?)</script>#s', $html, $matches);
+        $this->assertGreaterThan(0, $found, 'no inline script block found');
+
+        // A value that broke out of the element would close one <script>
+        // early and open another, so the tags stop balancing. Counted over
+        // the whole document because that is where the imbalance shows up:
+        // the captured blocks cannot contain `</script>` by construction,
+        // the non-greedy match having stopped at the first one.
         $this->assertSame(
-            1,
-            preg_match('#<script>\s*(\(function.*?)</script>#s', $html, $matches),
-            'inline script block not found'
+            preg_match_all('#<script[\s>]#', $html),
+            preg_match_all('#</script>#', $html),
+            'unbalanced <script> tags -- a rendered value escaped the element'
         );
-
-        $script = $matches[1];
-
-        // A bare `</script>` anywhere in the block would have ended the
-        // element early in a real browser, regardless of JS validity.
-        $this->assertStringNotContainsString('</script>', $script);
 
         $node = trim((string) shell_exec('command -v node 2>/dev/null'));
         if ($node === '') {
+            // Skipping is right locally, where node is optional. On CI it is
+            // how this guard silently stopped running for 32 cases, so fail
+            // instead: a future image change surfaces immediately rather
+            // than quietly reverting to a green build that checks nothing.
+            if (getenv('CI') !== false) {
+                $this->fail('node is required to parse-check inline scripts on CI, and was not found');
+            }
+
             $this->markTestSkipped('node is not available to parse-check the inline script');
         }
 
-        $file = tempnam(sys_get_temp_dir(), 'fw-inline-') . '.js';
-        file_put_contents($file, $script);
+        foreach ($matches[1] as $index => $script) {
+            $file = tempnam(sys_get_temp_dir(), 'fw-inline-') . '.js';
+            file_put_contents($file, $script);
 
-        $output = [];
-        $status = 0;
-        exec(escapeshellarg($node) . ' --check ' . escapeshellarg($file) . ' 2>&1', $output, $status);
-        unlink($file);
+            $output = [];
+            $status = 0;
+            exec(escapeshellarg($node) . ' --check ' . escapeshellarg($file) . ' 2>&1', $output, $status);
+            unlink($file);
 
-        $this->assertSame(0, $status, "inline script failed to parse:\n" . implode("\n", $output));
+            $this->assertSame(
+                0,
+                $status,
+                "inline script block {$index} failed to parse:\n" . implode("\n", $output)
+            );
+        }
     }
 }


### PR DESCRIPTION
## Description
- [x] Was AI used in this pull request?

`InterstitialRendererTest` guards a hard lockout. The ALTCHA, Turnstile and reCAPTCHA submit buttons all render `disabled` and are only re-enabled by an inline script, so a value that breaks that script's syntax leaves the visitor with no way to complete the challenge and no fallback. Three separate defects stopped it from actually guarding that.

No production defect is known — the escaping in all four providers appears correct. This is about the guard being load-bearing for two providers new in this release while not meaningfully running.

## Related Issue

Fixes #139

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

### 1. Only one of two script blocks was being checked

The helper anchored on `(function` and used `preg_match`, which stops at the first hit:

```php
preg_match('#<script>\s*(\(function.*?)</script>#s', $html, $matches)
```

Turnstile and reCAPTCHA v2 each emit a second inline block via `extra_head`, opening with `window.fwTurnstileVerified = function () {`. It never matched. Measured against the real rendered output:

```
Math          inline blocks: 1   helper matched: 1   unchecked: 0
Altcha        inline blocks: 1   helper matched: 1   unchecked: 0
Turnstile     inline blocks: 2   helper matched: 1   unchecked: 1
Recaptcha v2  inline blocks: 2   helper matched: 1   unchecked: 1
Recaptcha v3  inline blocks: 1   helper matched: 1   unchecked: 0
```

The unchecked block is the one holding `b.disabled = false` — the exact line whose failure strands a visitor. Both providers carry a comment explaining those callbacks must live in `extra_head` to avoid a race with the async bundle, and that "a missing callback leaves the button disabled for good."

Now every attribute-less `<script>` block is parsed. External bundles (`<script src=... async defer>`) and module scripts still fall outside the pattern, so only generated markup is checked.

### 2. reCAPTCHA had no case at all

It landed in #135, after #132's coverage work, and never picked one up. Added for **v2 and v3 separately** — v3 renders a different document (no checkbox widget, a `grecaptcha.execute()` call) and emits one inline block rather than two, so a single case would not have covered both paths.

### 3. Every case skipped on CI

`node` is not on the image, so the guard hit `markTestSkipped` for all 32 cases while passing locally. The setup step now installs it **only when absent**, since the `cimg` images may already ship it and installing over an existing node is the one way this could conflict:

```bash
command -v node >/dev/null || sudo apt install -y nodejs
```

And the helper now **fails rather than skips when `CI` is set**. Without that, a future image change silently reverts this to a green build that checks nothing — which is exactly how it went unnoticed in the first place.

### 4. Replaced an assertion that could never fail

```php
$this->assertStringNotContainsString('</script>', $script);
```

Structurally always true: the non-greedy match stops at the first `</script>`, so the captured block never contains one. Same class of defect as the three no-op tests #132 documented. Replaced with a tag-balance count across the whole document, which catches what it was aiming at.

## Testing

### How to Test

Each new assertion was verified to fail when it should, rather than assumed to work.

**1. The second script block is genuinely checked.** Break only `extra_head`, leaving the document-bottom block valid:

```
old helper:  OK (8 tests, 24 assertions)          <- passed a broken lockout script
new helper:  FAILURES! Tests: 8, Failures: 8      <- "inline script block 0 failed to parse"
```

**2. The balance assertion catches the original regression.** Drop `JSON_HEX_TAG` from `InterstitialRenderer::escapeJs()`, reproducing the bug this file was written for:

```
1) testMathInterstitialStaysSyntacticallyValid with data set "script close tag"
unbalanced <script> tags -- a rendered value escaped the element
```

The old assertion could not detect this.

**3. CI-fails / locally-skips.** Running with `node` off `PATH`:

```
CI=true   -> FAILURES! Tests: 8, Failures: 8
             "node is required to parse-check inline scripts on CI, and was not found"
CI unset  -> SSSSSSSS  Skipped: 8
```

### Test Configuration

```yaml
challenge:
  provider: recaptcha
  version: v3          # and v2 — both now covered
  site_key: '%env(RECAPTCHA_SITE_KEY)%'
  secret_key: '%env(RECAPTCHA_SECRET_KEY)%'
```

Google's published test keys are used in the test, so nothing reaches the network.

## Checklist

### Code Quality

- [x] `composer cs` passes (exit 0)
- [x] `composer stan` passes (level max, no errors)
- [x] Comments explain the non-obvious parts — why every block is checked, why CI fails rather than skips, why the balance count is document-wide
- [x] No new warnings or errors

### Testing

- [x] New and existing tests pass locally — 1300 unit / 73 integration, 2 pre-existing deprecations
- [x] Edge cases and error conditions
- [x] Coverage cannot regress: tests added, no source touched

`InterstitialRendererTest` goes from 36 to 52 cases.

### Security Considerations

- [x] I have considered the security implications of my changes
- [x] No sensitive information is logged or exposed

The values in `hostileRedirectProvider` are injection attempts — `</script><script>alert(1)</script>`, quote-breakouts, invalid UTF-8 — and `redirect_to` arrives on the interstitial's POST, so an attacker chooses it. This restores real verification that they cannot break out of the script element or its enclosing document.

## Breaking Changes

- [ ] This PR introduces breaking changes

One change for contributors: with `CI` set and no `node`, these tests now fail instead of skipping. That is the intent.

## Performance Impact

- [ ] This change has performance implications

The suite shells out to `node --check` once per inline block rather than once per document, and 16 more cases run. Adds roughly ten seconds locally.

## Reviewer Notes

1. **The `nodejs` install is the part I am least able to verify from here.** If the `cimg/php` images already ship node, the `command -v` guard makes it a no-op and the line could be dropped later. This PR's own matrix run is what settles it — worth a glance at the `Setup` step output on any of the five jobs.
2. **Ubuntu's `nodejs` package may be old.** Irrelevant for `--check`, which is a parse and has existed since forever, but noting it rather than leaving it implicit.
3. **The balance assertion is document-wide, not per-block**, which reads oddly next to a per-block loop. It has to be: a captured block cannot contain `</script>` by construction, so the imbalance is only visible at document level. The comment says so.
